### PR TITLE
Animated GIF overlay filter

### DIFF
--- a/litr-demo/build.gradle
+++ b/litr-demo/build.gradle
@@ -19,7 +19,11 @@ android {
 }
 
 dependencies {
-    implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation project(':litr')
     implementation project(':litr-filters')
+
+    implementation 'androidx.appcompat:appcompat:1.1.0'
+    implementation 'com.github.bumptech.glide:glide:4.10.0'
+
+    annotationProcessor 'com.github.bumptech.glide:compiler:4.10.0'
 }

--- a/litr-demo/src/main/java/com/linkedin/android/litr/demo/MainActivity.java
+++ b/litr-demo/src/main/java/com/linkedin/android/litr/demo/MainActivity.java
@@ -23,6 +23,7 @@ import android.os.Bundle;
 import android.os.Environment;
 import android.os.SystemClock;
 import android.provider.MediaStore;
+import android.text.TextUtils;
 import android.util.Log;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -46,6 +47,7 @@ import com.linkedin.android.litr.MediaTransformer;
 import com.linkedin.android.litr.TransformationListener;
 import com.linkedin.android.litr.analytics.TrackTransformationInfo;
 import com.linkedin.android.litr.filter.GlFilter;
+import com.linkedin.android.litr.filter.video.gl.AnimatedGifOverlayFilter;
 import com.linkedin.android.litr.filter.video.gl.BitmapOverlayFilter;
 import com.linkedin.android.litr.utils.TrackMetadataUtil;
 
@@ -271,8 +273,13 @@ public class MainActivity extends AppCompatActivity {
                             float bitmapWidth = 0.5f;
                             float bitmapHeight = bitmapWidth * bitmap.getHeight() / bitmap.getWidth() * width / height;
                             RectF bitmapRect = new RectF(bitmapLeft, bitmapTop, bitmapLeft + bitmapWidth, bitmapTop + bitmapHeight);
-                            GlFilter bitmapOverlayFilter = new BitmapOverlayFilter(MainActivity.this, overlayUri, bitmapRect);
-                            glFilters = Collections.singletonList(bitmapOverlayFilter);
+                            if (TextUtils.equals(getContentResolver().getType(overlayUri), "image/gif")) {
+                                GlFilter animatedGifOverlayFilter = new AnimatedGifOverlayFilter(getApplicationContext(), overlayUri, bitmapRect);
+                                glFilters = Collections.singletonList(animatedGifOverlayFilter);
+                            } else {
+                                GlFilter bitmapOverlayFilter = new BitmapOverlayFilter(getApplicationContext(), overlayUri, bitmapRect);
+                                glFilters = Collections.singletonList(bitmapOverlayFilter);
+                            }
                             bitmap.recycle();
                         }
                     } catch (IOException ex) {

--- a/litr-demo/src/main/java/com/linkedin/android/litr/demo/MainActivity.java
+++ b/litr-demo/src/main/java/com/linkedin/android/litr/demo/MainActivity.java
@@ -8,8 +8,10 @@
 package com.linkedin.android.litr.demo;
 
 import android.Manifest;
+import android.content.ContentResolver;
 import android.content.Intent;
 import android.content.pm.PackageManager;
+import android.content.res.AssetFileDescriptor;
 import android.database.Cursor;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
@@ -43,19 +45,28 @@ import androidx.appcompat.app.AppCompatActivity;
 import androidx.core.app.ActivityCompat;
 import androidx.core.content.ContextCompat;
 import androidx.core.content.FileProvider;
+import com.bumptech.glide.gifdecoder.GifDecoder;
+import com.bumptech.glide.gifdecoder.StandardGifDecoder;
+import com.bumptech.glide.load.engine.bitmap_recycle.BitmapPool;
+import com.bumptech.glide.load.engine.bitmap_recycle.LruBitmapPool;
+import com.bumptech.glide.load.resource.gif.GifBitmapProvider;
 import com.linkedin.android.litr.MediaTransformer;
 import com.linkedin.android.litr.TransformationListener;
 import com.linkedin.android.litr.analytics.TrackTransformationInfo;
 import com.linkedin.android.litr.filter.GlFilter;
 import com.linkedin.android.litr.filter.video.gl.AnimatedGifOverlayFilter;
+import com.linkedin.android.litr.filter.video.gl.AnimationFrameProvider;
 import com.linkedin.android.litr.filter.video.gl.BitmapOverlayFilter;
 import com.linkedin.android.litr.utils.TrackMetadataUtil;
 
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 
 public class MainActivity extends AppCompatActivity {
     private static final String TAG = MainActivity.class.getSimpleName();
@@ -274,7 +285,37 @@ public class MainActivity extends AppCompatActivity {
                             float bitmapHeight = bitmapWidth * bitmap.getHeight() / bitmap.getWidth() * width / height;
                             RectF bitmapRect = new RectF(bitmapLeft, bitmapTop, bitmapLeft + bitmapWidth, bitmapTop + bitmapHeight);
                             if (TextUtils.equals(getContentResolver().getType(overlayUri), "image/gif")) {
-                                GlFilter animatedGifOverlayFilter = new AnimatedGifOverlayFilter(getApplicationContext(), overlayUri, bitmapRect);
+                                ContentResolver contentResolver = getApplicationContext().getContentResolver();
+                                InputStream inputStream = contentResolver.openInputStream(overlayUri);
+                                BitmapPool bitmapPool = new LruBitmapPool(10);
+                                GifBitmapProvider gifBitmapProvider = new GifBitmapProvider(bitmapPool);
+                                final GifDecoder gifDecoder = new StandardGifDecoder(gifBitmapProvider);
+                                gifDecoder.read(inputStream, (int) getGifSize(overlayUri));
+
+                                AnimationFrameProvider animationFrameProvider = new AnimationFrameProvider() {
+                                    @Override
+                                    public int getFrameCount() {
+                                        return gifDecoder.getFrameCount();
+                                    }
+
+                                    @Nullable
+                                    @Override
+                                    public Bitmap getNextFrame() {
+                                        return gifDecoder.getNextFrame();
+                                    }
+
+                                    @Override
+                                    public long getNextFrameDurationNs() {
+                                        return TimeUnit.MILLISECONDS.toNanos(gifDecoder.getNextDelay());
+                                    }
+
+                                    @Override
+                                    public void advance() {
+                                        gifDecoder.advance();
+                                    }
+                                };
+
+                                GlFilter animatedGifOverlayFilter = new AnimatedGifOverlayFilter(animationFrameProvider, bitmapRect);
                                 glFilters = Collections.singletonList(animatedGifOverlayFilter);
                             } else {
                                 GlFilter bitmapOverlayFilter = new BitmapOverlayFilter(getApplicationContext(), overlayUri, bitmapRect);
@@ -525,4 +566,30 @@ public class MainActivity extends AppCompatActivity {
         });
     }
 
+    private long getGifSize(@NonNull Uri uri) {
+        if (ContentResolver.SCHEME_CONTENT.equals(uri.getScheme())) {
+            AssetFileDescriptor fileDescriptor = null;
+            try {
+                fileDescriptor = getApplicationContext().getContentResolver().openAssetFileDescriptor(uri, "r");
+                long size = fileDescriptor != null ? fileDescriptor.getParcelFileDescriptor().getStatSize() : 0;
+                return size < 0 ? 0 : size;
+            } catch (FileNotFoundException | IllegalStateException e) {
+                Log.e(TAG, "Unable to extract length from uri: " + uri, e);
+                return 0;
+            } finally {
+                if (fileDescriptor != null) {
+                    try {
+                        fileDescriptor.close();
+                    } catch (IOException e) {
+                        Log.e(TAG, "Unable to close file descriptor from uri: " + uri, e);
+                    }
+                }
+            }
+        } else if (ContentResolver.SCHEME_FILE.equals(uri.getScheme()) && uri.getPath() != null) {
+            File file = new File(uri.getPath());
+            return file.length();
+        } else {
+            return 0;
+        }
+    }
 }

--- a/litr-demo/src/main/java/com/linkedin/android/litr/demo/MainActivity.java
+++ b/litr-demo/src/main/java/com/linkedin/android/litr/demo/MainActivity.java
@@ -54,7 +54,7 @@ import com.linkedin.android.litr.MediaTransformer;
 import com.linkedin.android.litr.TransformationListener;
 import com.linkedin.android.litr.analytics.TrackTransformationInfo;
 import com.linkedin.android.litr.filter.GlFilter;
-import com.linkedin.android.litr.filter.video.gl.AnimatedGifOverlayFilter;
+import com.linkedin.android.litr.filter.video.gl.FrameSequenceAnimationOverlayFilter;
 import com.linkedin.android.litr.filter.video.gl.AnimationFrameProvider;
 import com.linkedin.android.litr.filter.video.gl.BitmapOverlayFilter;
 import com.linkedin.android.litr.utils.TrackMetadataUtil;
@@ -315,7 +315,7 @@ public class MainActivity extends AppCompatActivity {
                                     }
                                 };
 
-                                GlFilter animatedGifOverlayFilter = new AnimatedGifOverlayFilter(animationFrameProvider, bitmapRect);
+                                GlFilter animatedGifOverlayFilter = new FrameSequenceAnimationOverlayFilter(animationFrameProvider, bitmapRect);
                                 glFilters = Collections.singletonList(animatedGifOverlayFilter);
                             } else {
                                 GlFilter bitmapOverlayFilter = new BitmapOverlayFilter(getApplicationContext(), overlayUri, bitmapRect);

--- a/litr-filters/build.gradle
+++ b/litr-filters/build.gradle
@@ -29,9 +29,6 @@ dependencies {
     implementation project(':litr')
 
     implementation 'androidx.annotation:annotation:1.1.0'
-    implementation 'com.github.bumptech.glide:glide:4.10.0'
-
-    annotationProcessor 'com.github.bumptech.glide:compiler:4.10.0'
 }
 
 publish {

--- a/litr-filters/build.gradle
+++ b/litr-filters/build.gradle
@@ -9,8 +9,8 @@ android {
     defaultConfig {
         minSdkVersion 18
         targetSdkVersion 28
-        versionCode 1
-        versionName "1.0.0"
+        versionCode 2
+        versionName "1.0.1"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles 'consumer-rules.pro'
@@ -26,14 +26,18 @@ android {
 }
 
 dependencies {
-    implementation 'androidx.annotation:annotation:1.1.0'
     implementation project(':litr')
+
+    implementation 'androidx.annotation:annotation:1.1.0'
+    implementation 'com.github.bumptech.glide:glide:4.10.0'
+
+    annotationProcessor 'com.github.bumptech.glide:compiler:4.10.0'
 }
 
 publish {
     def groupProjectID = 'com.linkedin.android.litr'
     def artifactProjectID = 'litr-filters'
-    def publishVersionID = '1.0.0'
+    def publishVersionID = '1.0.1'
 
     userOrg = 'linkedin'
     repoName = 'maven'

--- a/litr-filters/src/main/java/com/linkedin/android/litr/filter/video/gl/AnimatedGifOverlayFilter.java
+++ b/litr-filters/src/main/java/com/linkedin/android/litr/filter/video/gl/AnimatedGifOverlayFilter.java
@@ -7,27 +7,12 @@
  */
 package com.linkedin.android.litr.filter.video.gl;
 
-import android.content.ContentResolver;
-import android.content.Context;
-import android.content.res.AssetFileDescriptor;
 import android.graphics.Bitmap;
 import android.graphics.RectF;
-import android.net.Uri;
 import android.util.Log;
 import androidx.annotation.IntRange;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import com.bumptech.glide.gifdecoder.GifDecoder;
-import com.bumptech.glide.gifdecoder.StandardGifDecoder;
-import com.bumptech.glide.load.engine.bitmap_recycle.BitmapPool;
-import com.bumptech.glide.load.engine.bitmap_recycle.LruBitmapPool;
-import com.bumptech.glide.load.resource.gif.GifBitmapProvider;
-
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.concurrent.TimeUnit;
 
 /**
  * An OpenGL filter that overlays an animated GIF on top of all video frames.
@@ -36,64 +21,55 @@ public class AnimatedGifOverlayFilter extends BaseOverlayGlFilter {
 
     private static final String TAG = AnimatedGifOverlayFilter.class.getSimpleName();
 
+    private final AnimationFrameProvider animationFrameProvider;
+
     private Frame currentFrame;
     private long nextFramePresentationTime;
 
     /**
      * Create filter with certain configuration.
-     * @param context context for accessing bitmap
-     * @param bitmapUri bitmap {@link Uri}
+     * @param animationFrameProvider {@link AnimationFrameProvider} which provides animation frames and their durations
      * @param bitmapRect Rectangle of bitmap's target position on a video frame, in relative coordinate in 0 - 1 range
      *                   in fourth quadrant (0,0 is top left corner)
      */
-    public AnimatedGifOverlayFilter(@NonNull Context context, @NonNull Uri bitmapUri, @Nullable RectF bitmapRect) {
-        super(context, bitmapUri, bitmapRect);
+    public AnimatedGifOverlayFilter(@NonNull AnimationFrameProvider animationFrameProvider, @Nullable RectF bitmapRect) {
+        super(bitmapRect);
+
+        this.animationFrameProvider = animationFrameProvider;
     }
 
     @Override
     public void init(@NonNull float[] mvpMatrix, int mvpMatrixOffset) {
         super.init(mvpMatrix, mvpMatrixOffset);
 
-        try {
-            ContentResolver contentResolver = context.getContentResolver();
-            InputStream inputStream = contentResolver.openInputStream(bitmapUri);
-            BitmapPool bitmapPool = new LruBitmapPool(10);
-            GifBitmapProvider gifBitmapProvider = new GifBitmapProvider(bitmapPool);
-            GifDecoder gifDecoder = new StandardGifDecoder(gifBitmapProvider);
-            gifDecoder.read(inputStream, (int) getGifSize(bitmapUri));
-
-            int frameCount = gifDecoder.getFrameCount();
-            Frame firstFrame = null;
-            Frame prevFrame = null;
-            Frame frame = null;
-            Bitmap frameBitmap;
-            for (int frameIdx = 0; frameIdx < frameCount; frameIdx++) {
-                gifDecoder.advance();
-                frameBitmap = gifDecoder.getNextFrame();
-                if (frameBitmap == null) {
-                    Log.e(TAG, "Error loading GIF frame " + frameIdx);
-                    continue;
-                }
-                int textureId = createOverlayTexture(frameBitmap);
-                frame = new Frame(textureId, gifDecoder.getNextDelay());
-                if (frameIdx == 0) {
-                    firstFrame = frame;
-                }
-                if (prevFrame != null) {
-                    prevFrame.next = frame;
-                }
-                prevFrame = frame;
-                frameBitmap.recycle();
+        Frame firstFrame = null;
+        Frame prevFrame = null;
+        Frame frame = null;
+        Bitmap frameBitmap;
+        for (int frameIdx = 0; frameIdx < animationFrameProvider.getFrameCount(); frameIdx++) {
+            animationFrameProvider.advance();
+            frameBitmap = animationFrameProvider.getNextFrame();
+            if (frameBitmap == null) {
+                Log.e(TAG, "Error loading GIF frame " + frameIdx);
+                continue;
             }
-            if (frame != null) {
-                frame.next = firstFrame;
+            int textureId = createOverlayTexture(frameBitmap);
+            frame = new Frame(textureId, animationFrameProvider.getNextFrameDurationNs());
+            if (frameIdx == 0) {
+                firstFrame = frame;
             }
-            if (firstFrame != null) {
-                currentFrame = firstFrame;
-                nextFramePresentationTime = TimeUnit.MILLISECONDS.toNanos(currentFrame.delay);
+            if (prevFrame != null) {
+                prevFrame.next = frame;
             }
-        } catch (IOException ex) {
-            Log.e(TAG, "Error loading animated gif", ex);
+            prevFrame = frame;
+            frameBitmap.recycle();
+        }
+        if (frame != null) {
+            frame.next = firstFrame;
+        }
+        if (firstFrame != null) {
+            currentFrame = firstFrame;
+            nextFramePresentationTime = currentFrame.duration;
         }
     }
 
@@ -105,47 +81,20 @@ public class AnimatedGifOverlayFilter extends BaseOverlayGlFilter {
 
         if (presentationTimeNs > nextFramePresentationTime) {
             currentFrame = currentFrame.next;
-            nextFramePresentationTime += TimeUnit.MILLISECONDS.toNanos(currentFrame.delay);
+            nextFramePresentationTime += currentFrame.duration;
         }
 
         renderOverlayTexture(currentFrame.textureId);
     }
 
-    private long getGifSize(@NonNull Uri uri) {
-        if (ContentResolver.SCHEME_CONTENT.equals(uri.getScheme())) {
-            AssetFileDescriptor fileDescriptor = null;
-            try {
-                fileDescriptor = context.getContentResolver().openAssetFileDescriptor(uri, "r");
-                long size = fileDescriptor != null ? fileDescriptor.getParcelFileDescriptor().getStatSize() : 0;
-                return size < 0 ? 0 : size;
-            } catch (FileNotFoundException | IllegalStateException e) {
-                Log.e(TAG, "Unable to extract length from uri: " + uri, e);
-                return 0;
-            } finally {
-                if (fileDescriptor != null) {
-                    try {
-                        fileDescriptor.close();
-                    } catch (IOException e) {
-                        Log.e(TAG, "Unable to close file descriptor from uri: " + uri, e);
-                    }
-                }
-            }
-        } else if (ContentResolver.SCHEME_FILE.equals(uri.getScheme()) && uri.getPath() != null) {
-            File file = new File(uri.getPath());
-            return file.length();
-        } else {
-            return 0;
-        }
-    }
-
     private static class Frame {
         private int textureId;
-        private int delay;
+        private long duration;
         private Frame next;
 
-        private Frame(@IntRange(from = 0) int textureId, @IntRange(from = 0) int delay) {
+        private Frame(@IntRange(from = 0) int textureId, @IntRange(from = 0) long duration) {
             this.textureId = textureId;
-            this.delay = delay;
+            this.duration = duration;
         }
     }
 }

--- a/litr-filters/src/main/java/com/linkedin/android/litr/filter/video/gl/AnimatedGifOverlayFilter.java
+++ b/litr-filters/src/main/java/com/linkedin/android/litr/filter/video/gl/AnimatedGifOverlayFilter.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2019 LinkedIn Corporation
+ * All Rights Reserved.
+ *
+ * Licensed under the BSD 2-Clause License (the "License").  See License in the project root for
+ * license information.
+ */
+package com.linkedin.android.litr.filter.video.gl;
+
+import android.content.ContentResolver;
+import android.content.Context;
+import android.content.res.AssetFileDescriptor;
+import android.graphics.Bitmap;
+import android.graphics.RectF;
+import android.net.Uri;
+import android.util.Log;
+import androidx.annotation.IntRange;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import com.bumptech.glide.gifdecoder.GifDecoder;
+import com.bumptech.glide.gifdecoder.StandardGifDecoder;
+import com.bumptech.glide.load.engine.bitmap_recycle.BitmapPool;
+import com.bumptech.glide.load.engine.bitmap_recycle.LruBitmapPool;
+import com.bumptech.glide.load.resource.gif.GifBitmapProvider;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * An OpenGL filter that overlays an animated GIF on top of all video frames.
+ */
+public class AnimatedGifOverlayFilter extends BaseOverlayGlFilter {
+
+    private static final String TAG = AnimatedGifOverlayFilter.class.getSimpleName();
+
+    private Frame currentFrame;
+    private long nextFramePresentationTime;
+
+    /**
+     * Create filter with certain configuration.
+     * @param context context for accessing bitmap
+     * @param bitmapUri bitmap {@link Uri}
+     * @param bitmapRect Rectangle of bitmap's target position on a video frame, in relative coordinate in 0 - 1 range
+     *                   in fourth quadrant (0,0 is top left corner)
+     */
+    public AnimatedGifOverlayFilter(@NonNull Context context, @NonNull Uri bitmapUri, @Nullable RectF bitmapRect) {
+        super(context, bitmapUri, bitmapRect);
+    }
+
+    @Override
+    public void init(@NonNull float[] mvpMatrix, int mvpMatrixOffset) {
+        super.init(mvpMatrix, mvpMatrixOffset);
+
+        try {
+            ContentResolver contentResolver = context.getContentResolver();
+            InputStream inputStream = contentResolver.openInputStream(bitmapUri);
+            BitmapPool bitmapPool = new LruBitmapPool(10);
+            GifBitmapProvider gifBitmapProvider = new GifBitmapProvider(bitmapPool);
+            GifDecoder gifDecoder = new StandardGifDecoder(gifBitmapProvider);
+            gifDecoder.read(inputStream, (int) getGifSize(bitmapUri));
+
+            int frameCount = gifDecoder.getFrameCount();
+            Frame firstFrame = null;
+            Frame prevFrame = null;
+            Frame frame = null;
+            Bitmap frameBitmap;
+            for (int frameIdx = 0; frameIdx < frameCount; frameIdx++) {
+                gifDecoder.advance();
+                frameBitmap = gifDecoder.getNextFrame();
+                if (frameBitmap == null) {
+                    Log.e(TAG, "Error loading GIF frame " + frameIdx);
+                    continue;
+                }
+                int textureId = createOverlayTexture(frameBitmap);
+                frame = new Frame(textureId, gifDecoder.getNextDelay());
+                if (frameIdx == 0) {
+                    firstFrame = frame;
+                }
+                if (prevFrame != null) {
+                    prevFrame.next = frame;
+                }
+                prevFrame = frame;
+                frameBitmap.recycle();
+            }
+            if (frame != null) {
+                frame.next = firstFrame;
+            }
+            if (firstFrame != null) {
+                currentFrame = firstFrame;
+                nextFramePresentationTime = TimeUnit.MILLISECONDS.toNanos(currentFrame.delay);
+            }
+        } catch (IOException ex) {
+            Log.e(TAG, "Error loading animated gif", ex);
+        }
+    }
+
+    @Override
+    public void apply(long presentationTimeNs) {
+        if (currentFrame == null) {
+            return;
+        }
+
+        if (presentationTimeNs > nextFramePresentationTime) {
+            currentFrame = currentFrame.next;
+            nextFramePresentationTime += TimeUnit.MILLISECONDS.toNanos(currentFrame.delay);
+        }
+
+        renderOverlayTexture(currentFrame.textureId);
+    }
+
+    private long getGifSize(@NonNull Uri uri) {
+        if (ContentResolver.SCHEME_CONTENT.equals(uri.getScheme())) {
+            AssetFileDescriptor fileDescriptor = null;
+            try {
+                fileDescriptor = context.getContentResolver().openAssetFileDescriptor(uri, "r");
+                long size = fileDescriptor != null ? fileDescriptor.getParcelFileDescriptor().getStatSize() : 0;
+                return size < 0 ? 0 : size;
+            } catch (FileNotFoundException | IllegalStateException e) {
+                Log.e(TAG, "Unable to extract length from uri: " + uri, e);
+                return 0;
+            } finally {
+                if (fileDescriptor != null) {
+                    try {
+                        fileDescriptor.close();
+                    } catch (IOException e) {
+                        Log.e(TAG, "Unable to close file descriptor from uri: " + uri, e);
+                    }
+                }
+            }
+        } else if (ContentResolver.SCHEME_FILE.equals(uri.getScheme()) && uri.getPath() != null) {
+            File file = new File(uri.getPath());
+            return file.length();
+        } else {
+            return 0;
+        }
+    }
+
+    private static class Frame {
+        private int textureId;
+        private int delay;
+        private Frame next;
+
+        private Frame(@IntRange(from = 0) int textureId, @IntRange(from = 0) int delay) {
+            this.textureId = textureId;
+            this.delay = delay;
+        }
+    }
+}

--- a/litr-filters/src/main/java/com/linkedin/android/litr/filter/video/gl/AnimationFrameProvider.java
+++ b/litr-filters/src/main/java/com/linkedin/android/litr/filter/video/gl/AnimationFrameProvider.java
@@ -1,0 +1,34 @@
+package com.linkedin.android.litr.filter.video.gl;
+
+import android.graphics.Bitmap;
+import androidx.annotation.Nullable;
+
+/**
+ * Interface that provides animation frames to be overlaid onto video frames.
+ */
+public interface AnimationFrameProvider {
+
+    /**
+     * Get total number of frames in animation
+     * @return total frame count
+     */
+    int getFrameCount();
+
+    /**
+     * Get next frame content
+     * @return frame bitmap, null if not available
+     */
+    @Nullable
+    Bitmap getNextFrame();
+
+    /**
+     * Get next frame delay, AKA duration frame is visible before replaced by next one
+     * @return frame delay in nanoseconds
+     */
+    long getNextFrameDurationNs();
+
+    /**
+     * Advance animation to next frame
+     */
+    void advance();
+}

--- a/litr-filters/src/main/java/com/linkedin/android/litr/filter/video/gl/BaseOverlayGlFilter.java
+++ b/litr-filters/src/main/java/com/linkedin/android/litr/filter/video/gl/BaseOverlayGlFilter.java
@@ -7,10 +7,8 @@
  */
 package com.linkedin.android.litr.filter.video.gl;
 
-import android.content.Context;
 import android.graphics.Bitmap;
 import android.graphics.RectF;
-import android.net.Uri;
 import android.opengl.GLES20;
 import android.opengl.GLUtils;
 import android.opengl.Matrix;
@@ -41,9 +39,7 @@ abstract class BaseOverlayGlFilter implements GlFilter {
             "  gl_FragColor = texture2D(uTexture, vTextureCoord);\n" +
             "}\n";
 
-    final Context context;
-    final Uri bitmapUri;
-    final RectF bitmapRect;
+    private final RectF bitmapRect;
 
     private int glOverlayProgram;
     private int overlayMvpMatrixHandle;
@@ -54,9 +50,7 @@ abstract class BaseOverlayGlFilter implements GlFilter {
 
     private float[] stMatrix = new float[16];
 
-    BaseOverlayGlFilter(@NonNull Context context, @NonNull Uri bitmapUri, @Nullable RectF bitmapRect) {
-        this.context = context;
-        this.bitmapUri = bitmapUri;
+    BaseOverlayGlFilter(@Nullable RectF bitmapRect) {
         this.bitmapRect = bitmapRect;
     }
 

--- a/litr-filters/src/main/java/com/linkedin/android/litr/filter/video/gl/BaseOverlayGlFilter.java
+++ b/litr-filters/src/main/java/com/linkedin/android/litr/filter/video/gl/BaseOverlayGlFilter.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2019 LinkedIn Corporation
+ * All Rights Reserved.
+ *
+ * Licensed under the BSD 2-Clause License (the "License").  See License in the project root for
+ * license information.
+ */
+package com.linkedin.android.litr.filter.video.gl;
+
+import android.content.Context;
+import android.graphics.Bitmap;
+import android.graphics.RectF;
+import android.net.Uri;
+import android.opengl.GLES20;
+import android.opengl.GLUtils;
+import android.opengl.Matrix;
+import androidx.annotation.CallSuper;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import com.linkedin.android.litr.filter.GlFilter;
+import com.linkedin.android.litr.render.GlRenderUtils;
+
+abstract class BaseOverlayGlFilter implements GlFilter {
+
+    private static final String VERTEX_SHADER =
+        "uniform mat4 uMVPMatrix;\n" +
+            "uniform mat4 uSTMatrix;\n" +
+            "attribute vec4 aPosition;\n" +
+            "attribute vec4 aTextureCoord;\n" +
+            "varying vec2 vTextureCoord;\n" +
+            "void main() {\n" +
+            "  gl_Position = uMVPMatrix * aPosition;\n" +
+            "  vTextureCoord = (uSTMatrix * aTextureCoord).xy;\n" +
+            "}\n";
+
+    private static final String FRAGMENT_OVERLAY_SHADER =
+        "precision mediump float;\n" +
+            "uniform sampler2D uTexture;\n" +
+            "varying vec2 vTextureCoord;\n" +
+            "void main() {\n" +
+            "  gl_FragColor = texture2D(uTexture, vTextureCoord);\n" +
+            "}\n";
+
+    final Context context;
+    final Uri bitmapUri;
+    final RectF bitmapRect;
+
+    private int glOverlayProgram;
+    private int overlayMvpMatrixHandle;
+    private int overlayUstMatrixHandle;
+
+    private float[] mvpMatrix;
+    private int mvpMatrixOffset;
+
+    private float[] stMatrix = new float[16];
+
+    BaseOverlayGlFilter(@NonNull Context context, @NonNull Uri bitmapUri, @Nullable RectF bitmapRect) {
+        this.context = context;
+        this.bitmapUri = bitmapUri;
+        this.bitmapRect = bitmapRect;
+    }
+
+    @Override
+    @CallSuper
+    public void init(@NonNull float[] mvpMatrix, int mvpMatrixOffset) {
+        Matrix.setIdentityM(stMatrix, 0);
+        // flip the bitmap vertically
+        Matrix.scaleM(stMatrix, 0, 1, -1, 1);
+
+        this.mvpMatrix = mvpMatrix;
+        this.mvpMatrixOffset = mvpMatrixOffset;
+
+        // initializing bitmap matrix
+        if (bitmapRect == null) {
+            // just apply video frame's MVP matrix, which will fit the bitmap to entire video frame
+            return;
+        }
+
+        float scaleX = bitmapRect.right - bitmapRect.left;
+        float scaleY = bitmapRect.bottom - bitmapRect.top;
+        float translateX = (bitmapRect.left * 2 + scaleX - 1) / scaleX;
+        float translateY = (1 - bitmapRect.top * 2 - scaleY) / scaleY;
+        Matrix.scaleM(mvpMatrix, mvpMatrixOffset, scaleX, scaleY, 1);
+        Matrix.translateM(mvpMatrix, mvpMatrixOffset, translateX, translateY, 0);
+    }
+
+    void renderOverlayTexture(int textureId) {
+        // Switch to overlay texture
+        GLES20.glUseProgram(glOverlayProgram);
+        GLES20.glActiveTexture(GLES20.GL_TEXTURE0);
+        GLES20.glBindTexture(GLES20.GL_TEXTURE_2D, textureId);
+
+        GLES20.glUniformMatrix4fv(overlayMvpMatrixHandle, 1, false, mvpMatrix, mvpMatrixOffset);
+        GLES20.glUniformMatrix4fv(overlayUstMatrixHandle, 1, false, stMatrix, 0);
+
+        // Enable blending
+        GLES20.glEnable(GLES20.GL_BLEND);
+        GLES20.glBlendFunc(GLES20.GL_SRC_ALPHA, GLES20.GL_ONE_MINUS_SRC_ALPHA);
+
+        // Call OpenGL to draw
+        GLES20.glDrawArrays(GLES20.GL_TRIANGLE_STRIP, 0, 4);
+        GlRenderUtils.checkGlError("glDrawArrays");
+
+        GLES20.glDisable(GLES20.GL_BLEND);
+    }
+
+    /**
+     * Create a texture and load the overlay bitmap into this texture.
+     */
+    int createOverlayTexture(@NonNull Bitmap overlayBitmap) {
+        int overlayTextureID;
+
+        // Create program
+        glOverlayProgram = GlRenderUtils.createProgram(VERTEX_SHADER, FRAGMENT_OVERLAY_SHADER);
+        if (glOverlayProgram == 0) {
+            throw new RuntimeException("failed creating glOverlayProgram");
+        }
+
+        // Get the location of our uniforms
+        overlayMvpMatrixHandle = GLES20.glGetUniformLocation(glOverlayProgram, "uMVPMatrix");
+        GlRenderUtils.checkGlError("glGetUniformLocation uMVPMatrix");
+        if (overlayMvpMatrixHandle == -1) {
+            throw new RuntimeException("Could not get attrib location for uMVPMatrix");
+        }
+        overlayUstMatrixHandle = GLES20.glGetUniformLocation(glOverlayProgram, "uSTMatrix");
+        GlRenderUtils.checkGlError("glGetUniformLocation uSTMatrix");
+        if (overlayUstMatrixHandle == -1) {
+            throw new RuntimeException("Could not get attrib location for uSTMatrix");
+        }
+
+        // Generate one texture for overlay
+        int[] textures = new int[1];
+        GLES20.glGenTextures(1, textures, 0);
+        overlayTextureID = textures[0];
+
+        // Tell OpenGL to bind this texture
+        GLES20.glBindTexture(GLES20.GL_TEXTURE_2D, overlayTextureID);
+        GlRenderUtils.checkGlError("glBindTexture overlayTextureID");
+
+        // Set default texture filtering parameters
+        GLES20.glTexParameteri(GLES20.GL_TEXTURE_2D, GLES20.GL_TEXTURE_MIN_FILTER, GLES20.GL_LINEAR);
+        GLES20.glTexParameteri(GLES20.GL_TEXTURE_2D, GLES20.GL_TEXTURE_MAG_FILTER, GLES20.GL_LINEAR);
+        GlRenderUtils.checkGlError("glTexParameter");
+
+        // Load the bitmap and copy it over into the texture
+        GLUtils.texImage2D(GLES20.GL_TEXTURE_2D, 0, overlayBitmap, 0);
+
+        return overlayTextureID;
+    }
+}

--- a/litr-filters/src/main/java/com/linkedin/android/litr/filter/video/gl/BitmapOverlayFilter.java
+++ b/litr-filters/src/main/java/com/linkedin/android/litr/filter/video/gl/BitmapOverlayFilter.java
@@ -13,14 +13,9 @@ import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.graphics.RectF;
 import android.net.Uri;
-import android.opengl.GLES20;
-import android.opengl.GLUtils;
-import android.opengl.Matrix;
 import android.util.Log;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import com.linkedin.android.litr.filter.GlFilter;
-import com.linkedin.android.litr.render.GlRenderUtils;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -29,43 +24,11 @@ import java.io.InputStream;
 /**
  * An OpenGL filter that overlays a static bitmap on top of all video frames.
  */
-public class BitmapOverlayFilter implements GlFilter {
+public class BitmapOverlayFilter extends BaseOverlayGlFilter {
 
     private static final String TAG = BitmapOverlayFilter.class.getSimpleName();
 
-    private static final String VERTEX_SHADER =
-        "uniform mat4 uMVPMatrix;\n" +
-            "uniform mat4 uSTMatrix;\n" +
-            "attribute vec4 aPosition;\n" +
-            "attribute vec4 aTextureCoord;\n" +
-            "varying vec2 vTextureCoord;\n" +
-            "void main() {\n" +
-            "  gl_Position = uMVPMatrix * aPosition;\n" +
-            "  vTextureCoord = (uSTMatrix * aTextureCoord).xy;\n" +
-            "}\n";
-
-    private static final String FRAGMENT_OVERLAY_SHADER =
-        "precision mediump float;\n" +
-            "uniform sampler2D uTexture;\n" +
-            "varying vec2 vTextureCoord;\n" +
-            "void main() {\n" +
-            "  gl_FragColor = texture2D(uTexture, vTextureCoord);\n" +
-            "}\n";
-
-    private final Context context;
-    private final Uri bitmapUri;
-    private final RectF bitmapRect;
-
-    private int glOverlayProgram;
     private int overlayTextureID = -12346;
-    private int overlayMvpMatrixHandle;
-    private int overlayUstMatrixHandle;
-
-    private float[] mvpMatrix;
-    private int mvpMatrixOffset;
-
-    private float[] stMatrix = new float[16];
-
     /**
      * Create filter with certain configuration.
      * @param context context for accessing bitmap
@@ -74,98 +37,32 @@ public class BitmapOverlayFilter implements GlFilter {
      *                   in fourth quadrant (0,0 is top left corner)
      */
     public BitmapOverlayFilter(@NonNull Context context, @NonNull Uri bitmapUri, @Nullable RectF bitmapRect) {
-        this.context = context;
-        this.bitmapUri = bitmapUri;
-        this.bitmapRect = bitmapRect;
+        super(context, bitmapUri, bitmapRect);
     }
 
     @Override
     public void init(@NonNull float[] mvpMatrix, int mvpMatrixOffset) {
-        Matrix.setIdentityM(stMatrix, 0);
-        // flip the bitmap vertically
-        Matrix.scaleM(stMatrix, 0, 1, -1, 1);
-
-        this.mvpMatrix = mvpMatrix;
-        this.mvpMatrixOffset = mvpMatrixOffset;
-        initBitmapMatrix();
+        super.init(mvpMatrix, mvpMatrixOffset);
 
         Bitmap bitmap = decodeBitmap(bitmapUri);
         if (bitmap != null) {
-            createOverlayTexture(bitmap);
+            overlayTextureID = createOverlayTexture(bitmap);
             bitmap.recycle();
         }
     }
 
     @Override
     public void apply(long presentationTimeNs) {
-        if (overlayTextureID < 0) {
-            return;
+        if (overlayTextureID >= 0) {
+            renderOverlayTexture(overlayTextureID);
         }
-
-        // Switch to overlay texture
-        GLES20.glUseProgram(glOverlayProgram);
-        GLES20.glActiveTexture(GLES20.GL_TEXTURE0);
-        GLES20.glBindTexture(GLES20.GL_TEXTURE_2D, overlayTextureID);
-
-        GLES20.glUniformMatrix4fv(overlayMvpMatrixHandle, 1, false, mvpMatrix, mvpMatrixOffset);
-        GLES20.glUniformMatrix4fv(overlayUstMatrixHandle, 1, false, stMatrix, 0);
-
-        // Enable blending
-        GLES20.glEnable(GLES20.GL_BLEND);
-        GLES20.glBlendFunc(GLES20.GL_SRC_ALPHA, GLES20.GL_ONE_MINUS_SRC_ALPHA);
-
-        // Call OpenGL to draw
-        GLES20.glDrawArrays(GLES20.GL_TRIANGLE_STRIP, 0, 4);
-        GlRenderUtils.checkGlError("glDrawArrays");
-
-        GLES20.glDisable(GLES20.GL_BLEND);
-    }
-
-    /**
-     * Create a texture and load the overlay bitmap into this texture.
-     */
-    private void createOverlayTexture(@NonNull Bitmap overlayBitmap) {
-        // Create program
-        glOverlayProgram = GlRenderUtils.createProgram(VERTEX_SHADER, FRAGMENT_OVERLAY_SHADER);
-        if (glOverlayProgram == 0) {
-            throw new RuntimeException("failed creating glOverlayProgram");
-        }
-
-        // Get the location of our uniforms
-        overlayMvpMatrixHandle = GLES20.glGetUniformLocation(glOverlayProgram, "uMVPMatrix");
-        GlRenderUtils.checkGlError("glGetUniformLocation uMVPMatrix");
-        if (overlayMvpMatrixHandle == -1) {
-            throw new RuntimeException("Could not get attrib location for uMVPMatrix");
-        }
-        overlayUstMatrixHandle = GLES20.glGetUniformLocation(glOverlayProgram, "uSTMatrix");
-        GlRenderUtils.checkGlError("glGetUniformLocation uSTMatrix");
-        if (overlayUstMatrixHandle == -1) {
-            throw new RuntimeException("Could not get attrib location for uSTMatrix");
-        }
-
-        // Generate one texture for overlay
-        int[] textures = new int[1];
-        GLES20.glGenTextures(1, textures, 0);
-        overlayTextureID = textures[0];
-
-        // Tell OpenGL to bind this texture
-        GLES20.glBindTexture(GLES20.GL_TEXTURE_2D, overlayTextureID);
-        GlRenderUtils.checkGlError("glBindTexture overlayTextureID");
-
-        // Set default texture filtering parameters
-        GLES20.glTexParameteri(GLES20.GL_TEXTURE_2D, GLES20.GL_TEXTURE_MIN_FILTER, GLES20.GL_LINEAR);
-        GLES20.glTexParameteri(GLES20.GL_TEXTURE_2D, GLES20.GL_TEXTURE_MAG_FILTER, GLES20.GL_LINEAR);
-        GlRenderUtils.checkGlError("glTexParameter");
-
-        // Load the bitmap and copy it over into the texture
-        GLUtils.texImage2D(GLES20.GL_TEXTURE_2D, 0, overlayBitmap, 0);
     }
 
     @Nullable
     private Bitmap decodeBitmap(@NonNull Uri imageUri) {
         Bitmap bitmap = null;
 
-        if (ContentResolver.SCHEME_FILE.equals(imageUri.getScheme())) {
+        if (ContentResolver.SCHEME_FILE.equals(imageUri.getScheme()) && imageUri.getPath() != null) {
             File file = new File(imageUri.getPath());
             bitmap = BitmapFactory.decodeFile(file.getPath());
 
@@ -187,17 +84,4 @@ public class BitmapOverlayFilter implements GlFilter {
         return bitmap;
     }
 
-    private void initBitmapMatrix() {
-        if (bitmapRect == null) {
-            // just apply video frame's MVP matrix, which will fit the bitmap to entire video frame
-            return;
-        }
-
-        float scaleX = bitmapRect.right - bitmapRect.left;
-        float scaleY = bitmapRect.bottom - bitmapRect.top;
-        float translateX = (bitmapRect.left * 2 + scaleX - 1) / scaleX;
-        float translateY = (1 - bitmapRect.top * 2 - scaleY) / scaleY;
-        Matrix.scaleM(mvpMatrix, mvpMatrixOffset, scaleX, scaleY, 1);
-        Matrix.translateM(mvpMatrix, mvpMatrixOffset, translateX, translateY, 0);
-    }
 }

--- a/litr-filters/src/main/java/com/linkedin/android/litr/filter/video/gl/BitmapOverlayFilter.java
+++ b/litr-filters/src/main/java/com/linkedin/android/litr/filter/video/gl/BitmapOverlayFilter.java
@@ -28,6 +28,9 @@ public class BitmapOverlayFilter extends BaseOverlayGlFilter {
 
     private static final String TAG = BitmapOverlayFilter.class.getSimpleName();
 
+    private final Context context;
+    private final Uri bitmapUri;
+
     private int overlayTextureID = -12346;
     /**
      * Create filter with certain configuration.
@@ -37,7 +40,9 @@ public class BitmapOverlayFilter extends BaseOverlayGlFilter {
      *                   in fourth quadrant (0,0 is top left corner)
      */
     public BitmapOverlayFilter(@NonNull Context context, @NonNull Uri bitmapUri, @Nullable RectF bitmapRect) {
-        super(context, bitmapUri, bitmapRect);
+        super(bitmapRect);
+        this.context = context;
+        this.bitmapUri = bitmapUri;
     }
 
     @Override

--- a/litr-filters/src/main/java/com/linkedin/android/litr/filter/video/gl/FrameSequenceAnimationOverlayFilter.java
+++ b/litr-filters/src/main/java/com/linkedin/android/litr/filter/video/gl/FrameSequenceAnimationOverlayFilter.java
@@ -15,11 +15,11 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 /**
- * An OpenGL filter that overlays an animated GIF on top of all video frames.
+ * An OpenGL filter that overlays a sprite animation (such as animated GIF) on top of all video frames.
  */
-public class AnimatedGifOverlayFilter extends BaseOverlayGlFilter {
+public class FrameSequenceAnimationOverlayFilter extends BaseOverlayGlFilter {
 
-    private static final String TAG = AnimatedGifOverlayFilter.class.getSimpleName();
+    private static final String TAG = FrameSequenceAnimationOverlayFilter.class.getSimpleName();
 
     private final AnimationFrameProvider animationFrameProvider;
 
@@ -32,7 +32,7 @@ public class AnimatedGifOverlayFilter extends BaseOverlayGlFilter {
      * @param bitmapRect Rectangle of bitmap's target position on a video frame, in relative coordinate in 0 - 1 range
      *                   in fourth quadrant (0,0 is top left corner)
      */
-    public AnimatedGifOverlayFilter(@NonNull AnimationFrameProvider animationFrameProvider, @Nullable RectF bitmapRect) {
+    public FrameSequenceAnimationOverlayFilter(@NonNull AnimationFrameProvider animationFrameProvider, @Nullable RectF bitmapRect) {
         super(bitmapRect);
 
         this.animationFrameProvider = animationFrameProvider;


### PR DESCRIPTION
Implementation of new filter, which overlays animated GIFs on top of a video.
 - Static bitmap and animated GIF filters share a lot of common logic, which is now abstracted into base class. Difference between classes is now how they load a texture from file and which texture ID is rendered onto video frame at a given presentation time. 
 - Using Glide to load animated GIF
 - Animated GIF frames are loaded into a circular buffer, along with their delays (duration of each frame)