### PR TITLE
Fixing overlay geometry.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ By default, LiTr uses Android MediaCodec stack for hardware accelerated decoding
 Simply grab via Gradle:
 
 ```groovy
- implementation 'com.linkedin.android.litr:litr:1.0.1'
+ implementation 'com.linkedin.android.litr:litr:1.1.0'
 ``` 
 ...or Maven:
 
@@ -22,7 +22,7 @@ Simply grab via Gradle:
 <dependency>
   <groupId>com.linkedin.android.litr</groupId>
   <artifactId>litr</artifactId>
-  <version>1.0.1</version>
+  <version>1.1.0</version>
 </dependency>
 
 ```
@@ -116,10 +116,10 @@ When using your own component implementations, make sure that output of a compon
 
 ## Using Filters
 
-You can use custom filters to modify video frames. Write your own in OpenGL as an implementtion of `GlFilter` interface, or use existing one from "filter pack" library, which is available via Gradle:
+You can use custom filters to modify video frames. Write your own in OpenGL as an implementation of `GlFilter` interface, or use existing one from "filter pack" library, which is available via Gradle:
 
 ```groovy
- implementation 'com.linkedin.android.litr:litr-filters:1.0.1'
+ implementation 'com.linkedin.android.litr:litr-filters:1.1.0'
 ``` 
 ...or Maven:
 
@@ -127,7 +127,7 @@ You can use custom filters to modify video frames. Write your own in OpenGL as a
 <dependency>
   <groupId>com.linkedin.android.litr</groupId>
   <artifactId>litr-filters</artifactId>
-  <version>1.0.1</version>
+  <version>1.1.0</version>
 </dependency>
 
 ```

--- a/litr-demo/src/main/java/com/linkedin/android/litr/demo/MainActivity.java
+++ b/litr-demo/src/main/java/com/linkedin/android/litr/demo/MainActivity.java
@@ -282,7 +282,7 @@ public class MainActivity extends AppCompatActivity {
                             Bitmap overlayBitmap = BitmapFactory.decodeStream(getContentResolver().openInputStream(overlayUri));
                             float overlayWidth = (float) overlayBitmap.getWidth() / width;
                             float overlayHeight = (float) overlayBitmap.getHeight() / height;
-                            PointF position = new PointF(0.3f, 0.1f);
+                            PointF position = new PointF(0.6f, 0.4f);
                             PointF size = new PointF(overlayWidth, overlayHeight);
                             float rotation = 30;
 

--- a/litr-demo/src/main/java/com/linkedin/android/litr/demo/MainActivity.java
+++ b/litr-demo/src/main/java/com/linkedin/android/litr/demo/MainActivity.java
@@ -279,9 +279,12 @@ public class MainActivity extends AppCompatActivity {
                     try {
                         Bitmap bitmap = BitmapFactory.decodeStream(getContentResolver().openInputStream(overlayUri));
                         if (bitmap != null) {
+                            Bitmap overlayBitmap = BitmapFactory.decodeStream(getContentResolver().openInputStream(overlayUri));
+                            float overlayWidth = (float) overlayBitmap.getWidth() / width;
+                            float overlayHeight = (float) overlayBitmap.getHeight() / height;
                             PointF position = new PointF(0.3f, 0.1f);
-                            PointF size = new PointF(0.5f, 0.9f);
-                            float rotation = 45;
+                            PointF size = new PointF(overlayWidth, overlayHeight);
+                            float rotation = 30;
 
                             if (TextUtils.equals(getContentResolver().getType(overlayUri), "image/gif")) {
                                 ContentResolver contentResolver = getApplicationContext().getContentResolver();

--- a/litr-filters/build.gradle
+++ b/litr-filters/build.gradle
@@ -9,8 +9,8 @@ android {
     defaultConfig {
         minSdkVersion 18
         targetSdkVersion 28
-        versionCode 3
-        versionName '1.0.2'
+        versionCode 4
+        versionName '1.1.0'
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles 'consumer-rules.pro'

--- a/litr-filters/src/main/java/com/linkedin/android/litr/filter/video/gl/BaseOverlayGlFilter.java
+++ b/litr-filters/src/main/java/com/linkedin/android/litr/filter/video/gl/BaseOverlayGlFilter.java
@@ -56,10 +56,11 @@ abstract class BaseOverlayGlFilter implements GlFilter {
     BaseOverlayGlFilter(@Nullable RectF bitmapRect) {
         if (bitmapRect == null) {
             size = new PointF(1, 1);
-            position = new PointF(0, 0);
+            position = new PointF(0.5f, 0.5f);
         } else {
             size = new PointF(bitmapRect.right - bitmapRect.left, bitmapRect.bottom - bitmapRect.top);
-            position = new PointF(bitmapRect.left, bitmapRect.top);
+            position = new PointF((bitmapRect.left + bitmapRect.right) / 2,
+                                  (bitmapRect.top + bitmapRect.bottom) / 2);
         }
         rotation = 0;
     }
@@ -104,19 +105,15 @@ abstract class BaseOverlayGlFilter implements GlFilter {
         }
 
         // Position values are in relative (0, 1) range, which means they have to be mapped from (-1, 1) range
-        // and adjusted for aspect ratio. Furthermore, they are given for top left corner of bitmap's bounding box
-        // (not its center as in OpenGL), so we have to adjust for that, too.
-        double rotationRads = Math.abs(Math.toRadians(rotation));
-        float boundingBoxWidth = (float) (scaleX * Math.cos(rotationRads) + scaleY * Math.sin(rotationRads));
-        float boundingBoxHeight = (float) (scaleX * Math.sin(rotationRads) + scaleY * Math.cos(rotationRads));
+        // and adjusted for aspect ratio.
         float translateX;
         float translateY;
         if (isPortraitVideo) {
-            translateX = position.x * 2 - 1 + boundingBoxWidth;
-            translateY = (1 - position.y * 2) * videoAspectRatio - boundingBoxHeight;
+            translateX = position.x * 2 - 1;
+            translateY = (1 - position.y * 2) * videoAspectRatio;
         } else {
-            translateX = (position.x * 2 - 1) * videoAspectRatio + boundingBoxWidth;
-            translateY = 1 - position.y * 2 - boundingBoxHeight;
+            translateX = (position.x * 2 - 1) * videoAspectRatio;
+            translateY = 1 - position.y * 2;
         }
 
         // Matrix operations in OpenGL are done in reverse. So here we scale (and flip vertically) first, then rotate

--- a/litr-filters/src/main/java/com/linkedin/android/litr/filter/video/gl/BitmapOverlayFilter.java
+++ b/litr-filters/src/main/java/com/linkedin/android/litr/filter/video/gl/BitmapOverlayFilter.java
@@ -53,7 +53,7 @@ public class BitmapOverlayFilter extends BaseOverlayGlFilter {
      * @param context context for accessing bitmap
      * @param bitmapUri bitmap {@link Uri}
      * @param size size in X and Y direction, relative to video frame
-     * @param position position of top left corner, in relative coordinate in 0 - 1 range
+     * @param position position of bitmap center, in relative coordinate in 0 - 1 range
      *      *          in fourth quadrant (0,0 is top left corner)
      * @param rotation counter-clockwise rotation, in degrees
      */
@@ -67,7 +67,7 @@ public class BitmapOverlayFilter extends BaseOverlayGlFilter {
      * Create filter with client managed {@link Bitmap}, then scale, then position and then rotate the bitmap around its center as specified.
      * @param bitmap client managed bitmap
      * @param size size in X and Y direction, relative to video frame
-     * @param position position of top left corner, in relative coordinate in 0 - 1 range
+     * @param position position of bitmap center, in relative coordinate in 0 - 1 range
      *                 in fourth quadrant (0,0 is top left corner)
      * @param rotation counter-clockwise rotation, in degrees
      */

--- a/litr/build.gradle
+++ b/litr/build.gradle
@@ -9,8 +9,8 @@ android {
     defaultConfig {
         minSdkVersion 18
         targetSdkVersion 28
-        versionCode 1
-        versionName '1.0.1'
+        versionCode 3
+        versionName '1.1.0'
     }
 
     testOptions {

--- a/litr/src/main/java/com/linkedin/android/litr/filter/GlFilter.java
+++ b/litr/src/main/java/com/linkedin/android/litr/filter/GlFilter.java
@@ -17,15 +17,15 @@ public interface GlFilter {
 
     /**
      * Initialize filter. This will be called during renderer initialization.
-     * Before calling this, renderer will configure its MVP matrix and pass copies of it to filters, so they can use it to
-     * configure their own MVP matrices. Model matrix in renderer's MVP matrix is usually an identity matrix. View matrix
-     * is configured to have its camera angle match video's. Using renderer's MVP matrix ensures that filters don't have to
-     * worry about handling video rotation and can just do model transformations.
+     * Before calling this, renderer will configure its VP matrix and pass copies of it to filters, so they can use it to
+     * configure their own MVP matrices. Model matrix not present. View matrix is configured to have its camera angle match video's.
+     * Projection matrix is configured to orthogonal projection to account for video frame's aspect ratio: (-aspectRatio, aspectRatio, -1, 1, -1, 1)
+     * Filters can set up their model matrix and then multiply it by renderer's VP matrix to match their geometry to video frame's.
      *
-     * @param mvpMatrix MVP matrix configured by the renderer, usually
-     * @param mvpMatrixOffset offset into MVP matrix
+     * @param vpMatrix VP (projection * view) matrix configured by the renderer, usually
+     * @param vpMatrixOffset offset into VP matrix
      */
-    void init(@NonNull float[] mvpMatrix, int mvpMatrixOffset);
+    void init(@NonNull float[] vpMatrix, int vpMatrixOffset);
 
     /**
      * Apply GL rendering to a frame

--- a/litr/src/main/java/com/linkedin/android/litr/render/VideoRenderer.java
+++ b/litr/src/main/java/com/linkedin/android/litr/render/VideoRenderer.java
@@ -20,8 +20,9 @@ public interface VideoRenderer {
      * Initialize the renderer. Called during track transformer initialization.
      * @param outputSurface {@link Surface} to render onto, null for non OpenGL renderer
      * @param rotation source frame rotation
+     * @param aspectRatio source video frame aspect ratio
      */
-    void init(@Nullable Surface outputSurface, int rotation);
+    void init(@Nullable Surface outputSurface, int rotation, float aspectRatio);
 
     /**
      * Get renderer's input surface. Renderer creates it internally.

--- a/litr/src/main/java/com/linkedin/android/litr/transcoder/VideoTrackTranscoder.java
+++ b/litr/src/main/java/com/linkedin/android/litr/transcoder/VideoTrackTranscoder.java
@@ -82,8 +82,8 @@ public class VideoTrackTranscoder extends TrackTranscoder {
             rotation = sourceVideoFormat.getInteger(KEY_ROTATION);
         }
         float aspectRatio = 1;
-        if (sourceVideoFormat.containsKey(MediaFormat.KEY_WIDTH) && sourceVideoFormat.containsKey(MediaFormat.KEY_HEIGHT)) {
-            aspectRatio = (float) sourceVideoFormat.getInteger(MediaFormat.KEY_WIDTH) / sourceVideoFormat.getInteger(MediaFormat.KEY_HEIGHT);
+        if (targetVideoFormat.containsKey(MediaFormat.KEY_WIDTH) && targetVideoFormat.containsKey(MediaFormat.KEY_HEIGHT)) {
+            aspectRatio = (float) targetVideoFormat.getInteger(MediaFormat.KEY_WIDTH) / targetVideoFormat.getInteger(MediaFormat.KEY_HEIGHT);
         }
 
         encoder.init(targetFormat);

--- a/litr/src/main/java/com/linkedin/android/litr/transcoder/VideoTrackTranscoder.java
+++ b/litr/src/main/java/com/linkedin/android/litr/transcoder/VideoTrackTranscoder.java
@@ -81,9 +81,13 @@ public class VideoTrackTranscoder extends TrackTranscoder {
         if (sourceVideoFormat.containsKey(KEY_ROTATION)) {
             rotation = sourceVideoFormat.getInteger(KEY_ROTATION);
         }
+        float aspectRatio = 1;
+        if (sourceVideoFormat.containsKey(MediaFormat.KEY_WIDTH) && sourceVideoFormat.containsKey(MediaFormat.KEY_HEIGHT)) {
+            aspectRatio = (float) sourceVideoFormat.getInteger(MediaFormat.KEY_WIDTH) / sourceVideoFormat.getInteger(MediaFormat.KEY_HEIGHT);
+        }
 
         encoder.init(targetFormat);
-        renderer.init(encoder.createInputSurface(), rotation);
+        renderer.init(encoder.createInputSurface(), rotation, aspectRatio);
         decoder.init(sourceVideoFormat, renderer.getInputSurface());
     }
 

--- a/litr/src/test/java/com/linkedin/android/litr/transcoder/VideoTrackTranscoderShould.java
+++ b/litr/src/test/java/com/linkedin/android/litr/transcoder/VideoTrackTranscoderShould.java
@@ -40,6 +40,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class VideoTrackTranscoderShould {
     private static final int VIDEO_TRACK = 0;
@@ -48,6 +49,12 @@ public class VideoTrackTranscoderShould {
     private static final float DURATION = 84f;
     private static final long CURRENT_PRESENTATION_TIME = 42L;
     private static final float CURRENT_PROGRESS = 0.5f;
+
+    private static final String TARGET_MIME_TYPE = "video/avc";
+    private static final int TARGET_WIDTH = 1280;
+    private static final int TARGET_HEIGHT = 720;
+    private static final int TARGET_BITRATE = 4000000;
+    private static final int TARGET_KEY_FRAME_INTERVAL = 3;
 
     @Mock private MediaSource mediaSource;
     @Mock private MediaTarget mediaTarget;
@@ -59,7 +66,8 @@ public class VideoTrackTranscoderShould {
     @Mock private Decoder decoder;
     @Mock private GlVideoRenderer renderer;
 
-    private MediaFormat targetVideoFormat;
+    @Mock private MediaFormat targetVideoFormat;
+
     private VideoTrackTranscoder videoTrackTranscoder;
 
     private ByteBuffer[] sampleByteBuffers;
@@ -79,12 +87,16 @@ public class VideoTrackTranscoderShould {
         doReturn(true).when(decoder).isRunning();
         doReturn(true).when(encoder).isRunning();
 
-        targetVideoFormat = new MediaFormat();
-        targetVideoFormat.setString(MediaFormat.KEY_MIME, "video/avc");
-        targetVideoFormat.setInteger(MediaFormat.KEY_WIDTH, 1280);
-        targetVideoFormat.setInteger(MediaFormat.KEY_HEIGHT, 720);
-        targetVideoFormat.setInteger(MediaFormat.KEY_BIT_RATE, 4000000);
-        targetVideoFormat.setInteger(MediaFormat.KEY_I_FRAME_INTERVAL, 3);
+        when(targetVideoFormat.containsKey(MediaFormat.KEY_MIME)).thenReturn(true);
+        when(targetVideoFormat.getString(MediaFormat.KEY_MIME)).thenReturn(TARGET_MIME_TYPE);
+        when(targetVideoFormat.containsKey(MediaFormat.KEY_WIDTH)).thenReturn(true);
+        when(targetVideoFormat.getInteger(MediaFormat.KEY_WIDTH)).thenReturn(TARGET_WIDTH);
+        when(targetVideoFormat.containsKey(MediaFormat.KEY_HEIGHT)).thenReturn(true);
+        when(targetVideoFormat.getInteger(MediaFormat.KEY_HEIGHT)).thenReturn(TARGET_HEIGHT);
+        when(targetVideoFormat.containsKey(MediaFormat.KEY_BIT_RATE)).thenReturn(true);
+        when(targetVideoFormat.getInteger(MediaFormat.KEY_BIT_RATE)).thenReturn(TARGET_BITRATE);
+        when(targetVideoFormat.containsKey(MediaFormat.KEY_I_FRAME_INTERVAL)).thenReturn(true);
+        when(targetVideoFormat.getInteger(MediaFormat.KEY_I_FRAME_INTERVAL)).thenReturn(TARGET_KEY_FRAME_INTERVAL);
 
         // setting up and starting test target, which will be used for frame processing testing below
         videoTrackTranscoder = spy(new VideoTrackTranscoder(mediaSource,
@@ -153,7 +165,7 @@ public class VideoTrackTranscoderShould {
         verify(decoder, never()).stop();
         verify(encoder).start();
         verify(decoder).start();
-        verify(renderer).init(surface, 0);
+        verify(renderer).init(surface, 0, (float) TARGET_WIDTH / TARGET_HEIGHT);
     }
 
     @Test


### PR DESCRIPTION
Reworking some OpenGL rendering logic to fix bitmap overlays becoming distorted when rotated:
 - Introducing projection matrix in GlVideoRenderer. Using projection matrix is essential for correct scaling in non-square canvas. 
- Passing in video frame aspect ratio to renderer. Breaking change in interface, so bumping a minor version. 
- Renderer now sets up projection in addition to view matrix and passes it to filters. 
- Bitmap overlay filters extract video frame aspect ratio and orientation to apply correct transformations to bitmaps.