### PR TITLE
Applying overlays when target video format is null

### DIFF
--- a/litr-demo/src/main/java/com/linkedin/android/litr/demo/BaseTransformationFragment.java
+++ b/litr-demo/src/main/java/com/linkedin/android/litr/demo/BaseTransformationFragment.java
@@ -20,7 +20,7 @@ import com.linkedin.android.litr.demo.data.AudioTrackFormat;
 import com.linkedin.android.litr.demo.data.GenericTrackFormat;
 import com.linkedin.android.litr.demo.data.SourceMedia;
 import com.linkedin.android.litr.demo.data.VideoTrackFormat;
-import com.linkedin.android.litr.utils.TransformationUtil;
+import com.linkedin.android.litr.utils.TranscoderUtils;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -59,7 +59,7 @@ public class BaseTransformationFragment extends Fragment {
     @NonNull
     protected void updateSourceMedia(@NonNull SourceMedia sourceMedia, @NonNull Uri uri) {
         sourceMedia.uri = uri;
-        sourceMedia.size = TransformationUtil.getSize(getContext(), uri);
+        sourceMedia.size = TranscoderUtils.getSize(getContext(), uri);
 
         try {
             MediaExtractor mediaExtractor = new MediaExtractor();

--- a/litr-demo/src/main/java/com/linkedin/android/litr/utils/TransformationUtil.java
+++ b/litr-demo/src/main/java/com/linkedin/android/litr/utils/TransformationUtil.java
@@ -9,7 +9,6 @@ package com.linkedin.android.litr.utils;
 
 import android.content.ContentResolver;
 import android.content.Context;
-import android.content.res.AssetFileDescriptor;
 import android.database.Cursor;
 import android.graphics.Bitmap;
 import android.graphics.PointF;
@@ -32,7 +31,6 @@ import com.linkedin.android.litr.filter.video.gl.BitmapOverlayFilter;
 import com.linkedin.android.litr.filter.video.gl.FrameSequenceAnimationOverlayFilter;
 
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.concurrent.TimeUnit;
@@ -58,7 +56,7 @@ public class TransformationUtil {
                 BitmapPool bitmapPool = new LruBitmapPool(10);
                 GifBitmapProvider gifBitmapProvider = new GifBitmapProvider(bitmapPool);
                 final GifDecoder gifDecoder = new StandardGifDecoder(gifBitmapProvider);
-                gifDecoder.read(inputStream, (int) getSize(context, overlayUri));
+                gifDecoder.read(inputStream, (int) TranscoderUtils.getSize(context, overlayUri));
 
                 AnimationFrameProvider animationFrameProvider = new AnimationFrameProvider() {
                     @Override
@@ -91,33 +89,6 @@ public class TransformationUtil {
         }
 
         return filter;
-    }
-
-    public static long getSize(@NonNull Context context, @NonNull Uri uri) {
-        if (ContentResolver.SCHEME_CONTENT.equals(uri.getScheme())) {
-            AssetFileDescriptor fileDescriptor = null;
-            try {
-                fileDescriptor = context.getContentResolver().openAssetFileDescriptor(uri, "r");
-                long size = fileDescriptor != null ? fileDescriptor.getParcelFileDescriptor().getStatSize() : 0;
-                return size < 0 ? 0 : size;
-            } catch (FileNotFoundException | IllegalStateException e) {
-                Log.e(TAG, "Unable to extract length from targetFile: " + uri, e);
-                return 0;
-            } finally {
-                if (fileDescriptor != null) {
-                    try {
-                        fileDescriptor.close();
-                    } catch (IOException e) {
-                        Log.e(TAG, "Unable to close file descriptor from targetFile: " + uri, e);
-                    }
-                }
-            }
-        } else if (ContentResolver.SCHEME_FILE.equals(uri.getScheme()) && uri.getPath() != null) {
-            File file = new File(uri.getPath());
-            return file.length();
-        } else {
-            return 0;
-        }
     }
 
     @NonNull

--- a/litr/src/main/java/com/linkedin/android/litr/MediaTransformer.java
+++ b/litr/src/main/java/com/linkedin/android/litr/MediaTransformer.java
@@ -301,10 +301,11 @@ public class MediaTransformer {
                 targetMediaFormat = MediaFormat.createVideoFormat(mimeType,
                                                                   sourceMediaFormat.getInteger(MediaFormat.KEY_WIDTH),
                                                                   sourceMediaFormat.getInteger(MediaFormat.KEY_HEIGHT));
-                int targetBitrate = TranscoderUtils.estimateVideoTrackBitrate(mediaSource,
-                                                                              sourceTrackIndex);
+                int targetBitrate;
                 if (sourceMediaFormat.containsKey(MediaFormat.KEY_BIT_RATE)) {
                     targetBitrate = sourceMediaFormat.getInteger(MediaFormat.KEY_BIT_RATE);
+                } else {
+                    targetBitrate = TranscoderUtils.estimateVideoTrackBitrate(mediaSource, sourceTrackIndex);
                 }
                 targetMediaFormat.setInteger(MediaFormat.KEY_BIT_RATE, targetBitrate);
 

--- a/litr/src/main/java/com/linkedin/android/litr/MediaTransformer.java
+++ b/litr/src/main/java/com/linkedin/android/litr/MediaTransformer.java
@@ -220,6 +220,8 @@ public class MediaTransformer {
             if (trackTransform.getTargetFormat() == null
                 && trackTransform.getRenderer() != null
                 && trackTransform.getRenderer().hasFilters()) {
+                // target format is null, but track has overlays, which means that we cannot use passthrough transcoder
+                // so we transcode the track using source parameters (resolution, bitrate) as a target
                 MediaFormat targetFormat = createTargetMediaFormat(trackTransform.getMediaSource(),
                                                                    trackTransform.getSourceTrack());
                 TrackTransform updatedTrackTransform = new TrackTransform.Builder(trackTransform.getMediaSource(),
@@ -232,8 +234,7 @@ public class MediaTransformer {
                     .setTargetFormat(targetFormat)
                     .build();
 
-                trackTransforms.remove(trackIndex);
-                trackTransforms.add(trackIndex, updatedTrackTransform);
+                trackTransforms.set(trackIndex, updatedTrackTransform);
             }
         }
 

--- a/litr/src/main/java/com/linkedin/android/litr/MediaTransformer.java
+++ b/litr/src/main/java/com/linkedin/android/litr/MediaTransformer.java
@@ -301,12 +301,7 @@ public class MediaTransformer {
                 targetMediaFormat = MediaFormat.createVideoFormat(mimeType,
                                                                   sourceMediaFormat.getInteger(MediaFormat.KEY_WIDTH),
                                                                   sourceMediaFormat.getInteger(MediaFormat.KEY_HEIGHT));
-                int targetBitrate;
-                if (sourceMediaFormat.containsKey(MediaFormat.KEY_BIT_RATE)) {
-                    targetBitrate = sourceMediaFormat.getInteger(MediaFormat.KEY_BIT_RATE);
-                } else {
-                    targetBitrate = TranscoderUtils.estimateVideoTrackBitrate(mediaSource, sourceTrackIndex);
-                }
+                int targetBitrate = TranscoderUtils.estimateVideoTrackBitrate(mediaSource, sourceTrackIndex);
                 targetMediaFormat.setInteger(MediaFormat.KEY_BIT_RATE, targetBitrate);
 
                 int targetKeyFrameInterval = DEFAULT_KEY_FRAME_INTERVAL;

--- a/litr/src/main/java/com/linkedin/android/litr/io/MediaExtractorMediaSource.java
+++ b/litr/src/main/java/com/linkedin/android/litr/io/MediaExtractorMediaSource.java
@@ -14,6 +14,7 @@ import android.media.MediaMetadataRetriever;
 import android.net.Uri;
 import androidx.annotation.NonNull;
 import com.linkedin.android.litr.exception.MediaSourceException;
+import com.linkedin.android.litr.utils.TranscoderUtils;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -28,6 +29,7 @@ public class MediaExtractorMediaSource implements MediaSource {
     private MediaExtractor mediaExtractor;
 
     private int orientationHint;
+    private long size;
 
     public MediaExtractorMediaSource(@NonNull Context context, @NonNull Uri uri) throws MediaSourceException {
         mediaExtractor = new MediaExtractor();
@@ -42,6 +44,7 @@ public class MediaExtractorMediaSource implements MediaSource {
         if (rotation != null) {
             orientationHint = Integer.parseInt(rotation);
         }
+        size = TranscoderUtils.getSize(context, uri);
     }
 
     @Override
@@ -98,5 +101,10 @@ public class MediaExtractorMediaSource implements MediaSource {
     @Override
     public void release() {
         mediaExtractor.release();
+    }
+
+    @Override
+    public long getSize() {
+        return size;
     }
 }

--- a/litr/src/main/java/com/linkedin/android/litr/io/MediaSource.java
+++ b/litr/src/main/java/com/linkedin/android/litr/io/MediaSource.java
@@ -85,4 +85,10 @@ public interface MediaSource {
      * Free up all resources. Make sure to call this when MediaSource is no longer needed.
      */
     void release();
+
+    /**
+     * Get total size of media source
+     * @return size in bytes, -1 if unknown
+     */
+    long getSize();
 }

--- a/litr/src/main/java/com/linkedin/android/litr/render/GlVideoRenderer.java
+++ b/litr/src/main/java/com/linkedin/android/litr/render/GlVideoRenderer.java
@@ -149,6 +149,11 @@ public class GlVideoRenderer implements VideoRenderer {
         outputSurface.release();
     }
 
+    @Override
+    public boolean hasFilters() {
+        return filters != null && !filters.isEmpty();
+    }
+
     /**
      * Initializes GL state.  Call this after the EGL surface has been created and made current.
      */

--- a/litr/src/main/java/com/linkedin/android/litr/render/VideoRenderer.java
+++ b/litr/src/main/java/com/linkedin/android/litr/render/VideoRenderer.java
@@ -42,4 +42,10 @@ public interface VideoRenderer {
      * Release the renderer and all it resources.
      */
     void release();
+
+    /**
+     * Check if renderer has filters
+     * @return true if has, false otherwise
+     */
+    boolean hasFilters();
 }

--- a/litr/src/main/java/com/linkedin/android/litr/utils/TranscoderUtils.java
+++ b/litr/src/main/java/com/linkedin/android/litr/utils/TranscoderUtils.java
@@ -135,7 +135,7 @@ public final class TranscoderUtils {
                 if (trackFormat.containsKey(MediaFormat.KEY_BIT_RATE) && trackFormat.containsKey(MediaFormat.KEY_DURATION)) {
                     int bitrate = trackFormat.getInteger(MediaFormat.KEY_BIT_RATE);
                     long duration = trackFormat.getLong(MediaFormat.KEY_DURATION);
-                    unallocatedSize -= bitrate * TimeUnit.MICROSECONDS.toSeconds(duration);
+                    unallocatedSize -= bitrate * TimeUnit.MICROSECONDS.toSeconds(duration) / 8;
                 } else {
                     String mimeType = trackFormat.getString(MediaFormat.KEY_MIME);
                     if (mimeType.startsWith("video")) {

--- a/litr/src/main/java/com/linkedin/android/litr/utils/TranscoderUtils.java
+++ b/litr/src/main/java/com/linkedin/android/litr/utils/TranscoderUtils.java
@@ -126,6 +126,11 @@ public final class TranscoderUtils {
      * @return estimated bitrate in bits per second
      */
     public static int estimateVideoTrackBitrate(@NonNull MediaSource mediaSource, int trackIndex) {
+        MediaFormat videoTrackFormat = mediaSource.getTrackFormat(trackIndex);
+        if (videoTrackFormat.containsKey(MediaFormat.KEY_BIT_RATE)) {
+            return videoTrackFormat.getInteger(MediaFormat.KEY_BIT_RATE);
+        }
+
         long unallocatedSize = mediaSource.getSize();
         long totalPixels = 0;
         int trackCount = mediaSource.getTrackCount();
@@ -147,7 +152,6 @@ public final class TranscoderUtils {
             }
         }
 
-        MediaFormat videoTrackFormat = mediaSource.getTrackFormat(trackIndex);
         long trackPixels = videoTrackFormat.getInteger(MediaFormat.KEY_WIDTH)
             * videoTrackFormat.getInteger(MediaFormat.KEY_HEIGHT)
             * TimeUnit.MICROSECONDS.toSeconds(videoTrackFormat.getLong(MediaFormat.KEY_DURATION));

--- a/litr/src/main/java/com/linkedin/android/litr/utils/TranscoderUtils.java
+++ b/litr/src/main/java/com/linkedin/android/litr/utils/TranscoderUtils.java
@@ -120,7 +120,8 @@ public final class TranscoderUtils {
      * Estimates video track bitrate. On many devices bitrate value is not specified in {@link MediaFormat} for video track.
      * Since not all data required for accurate estimation is available, this method makes several assumptions:
      *  - if multiple video tracks are present, average per-pixel bitrate is assumed to be the same for all tracks
-     *  - if both bitrate and duration are not specified for a track, its size is not accounted for
+     *  - if either bitrate or duration are not specified for a track, its size is not accounted for
+     *
      * @param mediaSource {@link MediaSource} which contains the video track
      * @param trackIndex index of video track
      * @return estimated bitrate in bits per second

--- a/litr/src/main/java/com/linkedin/android/litr/utils/TranscoderUtils.java
+++ b/litr/src/main/java/com/linkedin/android/litr/utils/TranscoderUtils.java
@@ -7,7 +7,11 @@
  */
 package com.linkedin.android.litr.utils;
 
+import android.content.ContentResolver;
+import android.content.Context;
+import android.content.res.AssetFileDescriptor;
 import android.media.MediaFormat;
+import android.net.Uri;
 import android.util.Log;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -15,6 +19,9 @@ import androidx.annotation.VisibleForTesting;
 import com.linkedin.android.litr.TrackTransform;
 import com.linkedin.android.litr.io.MediaSource;
 
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -107,6 +114,80 @@ public final class TranscoderUtils {
         }
 
         return getEstimatedTargetFileSize(trackTransforms);
+    }
+
+    /**
+     * Estimates video track bitrate. On many devices bitrate value is not specified in {@link MediaFormat} for video track.
+     * Since not all data required for accurate estimation is available, this method makes several assumptions:
+     *  - if multiple video tracks are present, average per-pixel bitrate is assumed to be the same for all tracks
+     *  - if both bitrate and duration are not specified for a track, its size is not accounted for
+     * @param mediaSource {@link MediaSource} which contains the video track
+     * @param trackIndex index of video track
+     * @return estimated bitrate in bits per second
+     */
+    public static int estimateVideoTrackBitrate(@NonNull MediaSource mediaSource, int trackIndex) {
+        long unallocatedSize = mediaSource.getSize();
+        long totalPixels = 0;
+        int trackCount = mediaSource.getTrackCount();
+        for (int track = 0; track < trackCount; track++) {
+            MediaFormat trackFormat = mediaSource.getTrackFormat(track);
+            if (trackFormat.containsKey(MediaFormat.KEY_MIME)) {
+                if (trackFormat.containsKey(MediaFormat.KEY_BIT_RATE) && trackFormat.containsKey(MediaFormat.KEY_DURATION)) {
+                    int bitrate = trackFormat.getInteger(MediaFormat.KEY_BIT_RATE);
+                    long duration = trackFormat.getLong(MediaFormat.KEY_DURATION);
+                    unallocatedSize -= bitrate * TimeUnit.MICROSECONDS.toSeconds(duration);
+                } else {
+                    String mimeType = trackFormat.getString(MediaFormat.KEY_MIME);
+                    if (mimeType.startsWith("video")) {
+                        totalPixels += trackFormat.getInteger(MediaFormat.KEY_WIDTH)
+                            * trackFormat.getInteger(MediaFormat.KEY_HEIGHT)
+                            * TimeUnit.MICROSECONDS.toSeconds(trackFormat.getLong(MediaFormat.KEY_DURATION));
+                    }
+                }
+            }
+        }
+
+        MediaFormat videoTrackFormat = mediaSource.getTrackFormat(trackIndex);
+        long trackPixels = videoTrackFormat.getInteger(MediaFormat.KEY_WIDTH)
+            * videoTrackFormat.getInteger(MediaFormat.KEY_HEIGHT)
+            * TimeUnit.MICROSECONDS.toSeconds(videoTrackFormat.getLong(MediaFormat.KEY_DURATION));
+
+        long trackSize = unallocatedSize * trackPixels / totalPixels;
+
+        return (int) (trackSize * 8 / TimeUnit.MICROSECONDS.toSeconds(videoTrackFormat.getLong(MediaFormat.KEY_DURATION)));
+    }
+
+    /**
+     * Get size of data abstracted by uri
+     * @param context context to access uri
+     * @param uri uri
+     * @return size in bytes, -1 if unknown
+     */
+    public static long getSize(@NonNull Context context, @NonNull Uri uri) {
+        if (ContentResolver.SCHEME_CONTENT.equals(uri.getScheme())) {
+            AssetFileDescriptor fileDescriptor = null;
+            try {
+                fileDescriptor = context.getContentResolver().openAssetFileDescriptor(uri, "r");
+                long size = fileDescriptor != null ? fileDescriptor.getParcelFileDescriptor().getStatSize() : 0;
+                return size < 0 ? -1 : size;
+            } catch (FileNotFoundException | IllegalStateException e) {
+                Log.e(TAG, "Unable to extract length from targetFile: " + uri, e);
+                return -1;
+            } finally {
+                if (fileDescriptor != null) {
+                    try {
+                        fileDescriptor.close();
+                    } catch (IOException e) {
+                        Log.e(TAG, "Unable to close file descriptor from targetFile: " + uri, e);
+                    }
+                }
+            }
+        } else if (ContentResolver.SCHEME_FILE.equals(uri.getScheme()) && uri.getPath() != null) {
+            File file = new File(uri.getPath());
+            return file.length();
+        } else {
+            return -1;
+        }
     }
 
     @Nullable

--- a/litr/src/test/java/com/linkedin/android/litr/utils/TranscoderUtilsShould.java
+++ b/litr/src/test/java/com/linkedin/android/litr/utils/TranscoderUtilsShould.java
@@ -155,6 +155,17 @@ public class TranscoderUtilsShould {
     }
 
     @Test
+    public void useVideoTrackBitrateAsEstimationWhenPresent() {
+        when(mediaSource.getSize()).thenReturn(VIDEO_BIT_RATE * DURATION_S / 8);
+        when(mediaSource.getTrackCount()).thenReturn(1);
+        when(mediaSource.getTrackFormat(0)).thenReturn(videoMediaFormat);
+
+        int estimatedBitrate = TranscoderUtils.estimateVideoTrackBitrate(mediaSource, 0);
+
+        assertThat(estimatedBitrate, is(VIDEO_BIT_RATE));
+    }
+
+    @Test
     public void estimateVideoTrackBitrateWhenSingleVideoTrack() {
         when(mediaSource.getSize()).thenReturn(VIDEO_BIT_RATE * DURATION_S / 8);
         when(mediaSource.getTrackCount()).thenReturn(1);

--- a/litr/src/test/java/com/linkedin/android/litr/utils/TranscoderUtilsShould.java
+++ b/litr/src/test/java/com/linkedin/android/litr/utils/TranscoderUtilsShould.java
@@ -16,6 +16,8 @@ import org.mockito.MockitoAnnotations;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class TranscoderUtilsShould {
@@ -24,8 +26,12 @@ public class TranscoderUtilsShould {
     private static final long MISC_DURATION_S = 25;
     private static final long MISC_DURATION_US = MISC_DURATION_S * 1000 * 1000;
 
+    private static final int VIDEO_BIT_RATE = 19 * 1000 * 1000;
     private static final int AUDIO_BIT_RATE = 96 * 1000;
     private static final int MISC_BIT_RATE = 5 * 1000;
+
+    private static final int VIDEO_WIDTH = 1920;
+    private static final int VIDEO_HEIGHT = 1080;
 
     @Mock private MediaSource mediaSource;
     @Mock private MediaFormat targetVideoFormat;
@@ -47,9 +53,11 @@ public class TranscoderUtilsShould {
         when(videoMediaFormat.containsKey(MediaFormat.KEY_MIME)).thenReturn(true);
         when(videoMediaFormat.getString(MediaFormat.KEY_MIME)).thenReturn("video/avc");
         when(videoMediaFormat.containsKey(MediaFormat.KEY_BIT_RATE)).thenReturn(true);
-        when(videoMediaFormat.getInteger(MediaFormat.KEY_BIT_RATE)).thenReturn(12 * 1000 * 1000);
+        when(videoMediaFormat.getInteger(MediaFormat.KEY_BIT_RATE)).thenReturn(VIDEO_BIT_RATE);
         when(videoMediaFormat.containsKey(MediaFormat.KEY_DURATION)).thenReturn(true);
         when(videoMediaFormat.getLong(MediaFormat.KEY_DURATION)).thenReturn(DURATION_US);
+        when(videoMediaFormat.getInteger(MediaFormat.KEY_WIDTH)).thenReturn(VIDEO_WIDTH);
+        when(videoMediaFormat.getInteger(MediaFormat.KEY_HEIGHT)).thenReturn(VIDEO_HEIGHT);
 
         when(audioMediaFormat.containsKey(MediaFormat.KEY_MIME)).thenReturn(true);
         when(audioMediaFormat.getString(MediaFormat.KEY_MIME)).thenReturn("audio/mp4a-latm");
@@ -144,5 +152,83 @@ public class TranscoderUtilsShould {
         long estimatedSize = TranscoderUtils.getEstimatedTargetVideoFileSize(mediaSource, targetVideoFormat, null);
 
         assertThat(estimatedSize, is(referenceSize));
+    }
+
+    @Test
+    public void estimateVideoTrackBitrateWhenSingleVideoTrack() {
+        when(mediaSource.getSize()).thenReturn(VIDEO_BIT_RATE * DURATION_S / 8);
+        when(mediaSource.getTrackCount()).thenReturn(1);
+        when(mediaSource.getTrackFormat(0)).thenReturn(videoMediaFormat);
+        when(videoMediaFormat.containsKey(MediaFormat.KEY_BIT_RATE)).thenReturn(false);
+
+        int estimatedBitrate = TranscoderUtils.estimateVideoTrackBitrate(mediaSource, 0);
+
+        assertThat(estimatedBitrate, is(VIDEO_BIT_RATE));
+    }
+
+    @Test
+    public void estimateVideoTrackBitrateWhenSingleVideoAndSingleAudioTracks() {
+        long size = (VIDEO_BIT_RATE * DURATION_S + AUDIO_BIT_RATE * DURATION_S) / 8;
+        when(mediaSource.getSize()).thenReturn(size);
+        when(mediaSource.getTrackCount()).thenReturn(2);
+        when(mediaSource.getTrackFormat(0)).thenReturn(videoMediaFormat);
+        when(mediaSource.getTrackFormat(1)).thenReturn(audioMediaFormat);
+        when(videoMediaFormat.containsKey(MediaFormat.KEY_BIT_RATE)).thenReturn(false);
+        when(audioMediaFormat.containsKey(MediaFormat.KEY_BIT_RATE)).thenReturn(true);
+        when(audioMediaFormat.getInteger(MediaFormat.KEY_BIT_RATE)).thenReturn(AUDIO_BIT_RATE);
+
+        int estimatedBitrate = TranscoderUtils.estimateVideoTrackBitrate(mediaSource, 0);
+
+        assertThat(estimatedBitrate, is(VIDEO_BIT_RATE));
+    }
+
+    @Test
+    public void estimateVideoTrackBitrateWhenSingleVideoAndSingleAudioAndSingleMiscTracks() {
+        long size = (VIDEO_BIT_RATE * DURATION_S + AUDIO_BIT_RATE * DURATION_S + MISC_BIT_RATE * DURATION_S) / 8;
+        when(mediaSource.getSize()).thenReturn(size);
+        when(mediaSource.getTrackCount()).thenReturn(3);
+        when(mediaSource.getTrackFormat(0)).thenReturn(videoMediaFormat);
+        when(mediaSource.getTrackFormat(1)).thenReturn(audioMediaFormat);
+        when(mediaSource.getTrackFormat(2)).thenReturn(miscMediaFormat);
+        when(videoMediaFormat.containsKey(MediaFormat.KEY_BIT_RATE)).thenReturn(false);
+        when(audioMediaFormat.containsKey(MediaFormat.KEY_BIT_RATE)).thenReturn(true);
+        when(audioMediaFormat.getInteger(MediaFormat.KEY_BIT_RATE)).thenReturn(AUDIO_BIT_RATE);
+        when(miscMediaFormat.containsKey(MediaFormat.KEY_BIT_RATE)).thenReturn(false);
+
+        int estimatedBitrate = TranscoderUtils.estimateVideoTrackBitrate(mediaSource, 0);
+
+        assertThat(estimatedBitrate, is(VIDEO_BIT_RATE + MISC_BIT_RATE));
+    }
+
+    @Test
+    public void estimateVideoTrackBitrateWhenMultipleVideoTracks() {
+        int videoWidth2 = 1280;
+        int videoHeight2 = 720;
+        int videoDuration2 = 25;
+        long videoDurationUs2 = videoDuration2 * 1000 * 1000;
+
+        long videoBitrate2 = ((long) videoWidth2 * videoHeight2 * VIDEO_BIT_RATE) / (VIDEO_WIDTH * VIDEO_HEIGHT);
+
+        MediaFormat videoMediaFormat2 = mock(MediaFormat.class);
+        when(videoMediaFormat2.containsKey(MediaFormat.KEY_MIME)).thenReturn(true);
+        when(videoMediaFormat2.getString(MediaFormat.KEY_MIME)).thenReturn("video/avc");
+        when(videoMediaFormat2.containsKey(MediaFormat.KEY_DURATION)).thenReturn(true);
+        when(videoMediaFormat2.getLong(MediaFormat.KEY_DURATION)).thenReturn(videoDurationUs2);
+        when(videoMediaFormat2.getInteger(MediaFormat.KEY_WIDTH)).thenReturn(videoWidth2);
+        when(videoMediaFormat2.getInteger(MediaFormat.KEY_HEIGHT)).thenReturn(videoHeight2);
+        when(videoMediaFormat2.containsKey(MediaFormat.KEY_BIT_RATE)).thenReturn(false);
+
+        when(videoMediaFormat.containsKey(MediaFormat.KEY_DURATION)).thenReturn(false);
+
+        long size = (VIDEO_BIT_RATE * DURATION_S + videoBitrate2 * videoDuration2) / 8;
+        when(mediaSource.getSize()).thenReturn(size);
+        when(mediaSource.getTrackCount()).thenReturn(2);
+        when(mediaSource.getTrackFormat(0)).thenReturn(videoMediaFormat);
+        when(mediaSource.getTrackFormat(1)).thenReturn(videoMediaFormat2);
+
+        int estimatedBitrate = TranscoderUtils.estimateVideoTrackBitrate(mediaSource, 0);
+
+        // estimation is affected by integer division, so let's account for that
+        assertEquals(estimatedBitrate, VIDEO_BIT_RATE, 1);
     }
 }


### PR DESCRIPTION
In current implementation LiTr doesn't apply overlays if target video format is null. Which may be inconvenient for clients who want to modify video frames without changing resolution or bitrate. 

Now LiTr will make sure overlays are always applied. The catch is that on many devices bitrate is not provided for video tracks, for which we implement a utility method to estimate it.