### PR TITLE
Making VideoRenderer interface more general purpose Renderer interface.

### DIFF
--- a/litr/src/main/java/com/linkedin/android/litr/MediaTransformer.java
+++ b/litr/src/main/java/com/linkedin/android/litr/MediaTransformer.java
@@ -32,7 +32,7 @@ import com.linkedin.android.litr.io.MediaMuxerMediaTarget;
 import com.linkedin.android.litr.io.MediaSource;
 import com.linkedin.android.litr.io.MediaTarget;
 import com.linkedin.android.litr.render.GlVideoRenderer;
-import com.linkedin.android.litr.render.VideoRenderer;
+import com.linkedin.android.litr.render.Renderer;
 import com.linkedin.android.litr.utils.TranscoderUtils;
 
 import java.util.ArrayList;
@@ -109,7 +109,7 @@ public class MediaTransformer {
                                                                 mediaSource.getTrackCount(),
                                                                 mediaSource.getOrientationHint(),
                                                                 MediaMuxer.OutputFormat.MUXER_OUTPUT_MPEG_4);
-            VideoRenderer renderer = new GlVideoRenderer(filters);
+            Renderer renderer = new GlVideoRenderer(filters);
             Decoder decoder = new MediaCodecDecoder();
             Encoder encoder = new MediaCodecEncoder();
             transform(requestId,
@@ -137,7 +137,7 @@ public class MediaTransformer {
      * @param requestId client defined unique id for a transformation request. If not unique, {@link IllegalArgumentException} will be thrown.
      * @param mediaSource {@link MediaSource} to provide input frames
      * @param decoder {@link Decoder} to decode input frames
-     * @param videoRenderer {@link VideoRenderer} to draw (with optional filters) decoder's output frame onto encoder's input frame
+     * @param videoRenderer {@link Renderer} to draw (with optional filters) decoder's output frame onto encoder's input frame
      * @param encoder {@link Encoder} to encode output frames into target format
      * @param mediaTarget {@link MediaTarget} to write/mux output frames
      * @param targetVideoFormat target format parameters for video track(s), null to keep them as is
@@ -149,7 +149,7 @@ public class MediaTransformer {
     public void transform(@NonNull String requestId,
                           @NonNull MediaSource mediaSource,
                           @NonNull Decoder decoder,
-                          @NonNull VideoRenderer videoRenderer,
+                          @NonNull Renderer videoRenderer,
                           @NonNull Encoder encoder,
                           @NonNull MediaTarget mediaTarget,
                           @Nullable MediaFormat targetVideoFormat,

--- a/litr/src/main/java/com/linkedin/android/litr/TrackTransform.java
+++ b/litr/src/main/java/com/linkedin/android/litr/TrackTransform.java
@@ -14,7 +14,7 @@ import com.linkedin.android.litr.codec.Decoder;
 import com.linkedin.android.litr.codec.Encoder;
 import com.linkedin.android.litr.io.MediaSource;
 import com.linkedin.android.litr.io.MediaTarget;
-import com.linkedin.android.litr.render.VideoRenderer;
+import com.linkedin.android.litr.render.Renderer;
 
 /**
  * Transformation instruction for a specific track. Must be constructed using a {@link Builder}.
@@ -22,7 +22,7 @@ import com.linkedin.android.litr.render.VideoRenderer;
 public class TrackTransform {
     private final MediaSource mediaSource;
     private final Decoder decoder;
-    private final VideoRenderer renderer;
+    private final Renderer renderer;
     private final Encoder encoder;
     private final MediaTarget mediaTarget;
 
@@ -32,7 +32,7 @@ public class TrackTransform {
 
     private TrackTransform(@NonNull MediaSource mediaSource,
                            @Nullable Decoder decoder,
-                           @Nullable VideoRenderer renderer,
+                           @Nullable Renderer renderer,
                            @Nullable Encoder encoder,
                            @NonNull MediaTarget mediaTarget,
                            @Nullable MediaFormat targetFormat,
@@ -67,11 +67,11 @@ public class TrackTransform {
     }
 
     /**
-     * Get {@link VideoRenderer} for a track
-     * @return {@link VideoRenderer} for a track, null if none
+     * Get {@link Renderer} for a track
+     * @return {@link Renderer} for a track, null if none
      */
     @Nullable
-    public VideoRenderer getRenderer() {
+    public Renderer getRenderer() {
         return renderer;
     }
 
@@ -125,7 +125,7 @@ public class TrackTransform {
         private final MediaTarget mediaTarget;
 
         private Decoder decoder;
-        private VideoRenderer renderer;
+        private Renderer renderer;
         private Encoder encoder;
         private MediaFormat targetFormat;
         private int targetTrack;
@@ -148,7 +148,7 @@ public class TrackTransform {
         }
 
         @NonNull
-        public Builder setRenderer(@Nullable VideoRenderer renderer) {
+        public Builder setRenderer(@Nullable Renderer renderer) {
             this.renderer = renderer;
             return this;
         }

--- a/litr/src/main/java/com/linkedin/android/litr/render/GlVideoRenderer.java
+++ b/litr/src/main/java/com/linkedin/android/litr/render/GlVideoRenderer.java
@@ -119,7 +119,7 @@ public class GlVideoRenderer implements Renderer {
 
         // clear the rotation flag, we don't want any auto-rotation issues
         int rotation = 0;
-        if (sourceMediaFormat.containsKey(KEY_ROTATION)) {
+        if (sourceMediaFormat != null && sourceMediaFormat.containsKey(KEY_ROTATION)) {
             rotation = sourceMediaFormat.getInteger(KEY_ROTATION);
         }
         float aspectRatio = 1;

--- a/litr/src/main/java/com/linkedin/android/litr/render/Renderer.java
+++ b/litr/src/main/java/com/linkedin/android/litr/render/Renderer.java
@@ -7,22 +7,23 @@
  */
 package com.linkedin.android.litr.render;
 
+import android.media.MediaFormat;
 import android.view.Surface;
 import androidx.annotation.Nullable;
 import com.linkedin.android.litr.codec.Frame;
 
 /**
- * Common interface for video frame renderer
+ * Common interface for renderer
  */
-public interface VideoRenderer {
+public interface Renderer {
 
     /**
      * Initialize the renderer. Called during track transformer initialization.
      * @param outputSurface {@link Surface} to render onto, null for non OpenGL renderer
-     * @param rotation source frame rotation
-     * @param aspectRatio source video frame aspect ratio
+     * @param sourceMediaFormat source {@link MediaFormat}
+     * @param targetMediaFormat target {@link MediaFormat}
      */
-    void init(@Nullable Surface outputSurface, int rotation, float aspectRatio);
+    void init(@Nullable Surface outputSurface, @Nullable MediaFormat sourceMediaFormat, @Nullable MediaFormat targetMediaFormat);
 
     /**
      * Get renderer's input surface. Renderer creates it internally.

--- a/litr/src/main/java/com/linkedin/android/litr/transcoder/TrackTranscoder.java
+++ b/litr/src/main/java/com/linkedin/android/litr/transcoder/TrackTranscoder.java
@@ -8,7 +8,6 @@
 package com.linkedin.android.litr.transcoder;
 
 import android.media.MediaFormat;
-import android.os.Build;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.RestrictTo;
@@ -28,10 +27,6 @@ public abstract class TrackTranscoder {
     public static final int RESULT_OUTPUT_MEDIA_FORMAT_CHANGED = 1;
     public static final int RESULT_FRAME_PROCESSED = 2;
     public static final int RESULT_EOS_REACHED = 3;
-
-    protected static final String KEY_ROTATION = Build.VERSION.SDK_INT >= Build.VERSION_CODES.M
-                                               ? MediaFormat.KEY_ROTATION
-                                               : "rotation-degrees";
 
     @NonNull protected final MediaSource mediaSource;
     @NonNull protected final MediaTarget mediaMuxer;

--- a/litr/src/main/java/com/linkedin/android/litr/transcoder/TrackTranscoderFactory.java
+++ b/litr/src/main/java/com/linkedin/android/litr/transcoder/TrackTranscoderFactory.java
@@ -20,7 +20,7 @@ import com.linkedin.android.litr.codec.MediaCodecEncoder;
 import com.linkedin.android.litr.exception.TrackTranscoderException;
 import com.linkedin.android.litr.io.MediaSource;
 import com.linkedin.android.litr.io.MediaTarget;
-import com.linkedin.android.litr.render.VideoRenderer;
+import com.linkedin.android.litr.render.Renderer;
 
 @RestrictTo(RestrictTo.Scope.LIBRARY)
 public class TrackTranscoderFactory {
@@ -40,7 +40,7 @@ public class TrackTranscoderFactory {
                                   int targetTrack,
                                   @NonNull MediaSource mediaSource,
                                   @Nullable Decoder decoder,
-                                  @Nullable VideoRenderer renderer,
+                                  @Nullable Renderer renderer,
                                   @Nullable Encoder encoder,
                                   @NonNull MediaTarget mediaTarget,
                                   @Nullable MediaFormat targetFormat) throws TrackTranscoderException {

--- a/litr/src/main/java/com/linkedin/android/litr/transcoder/VideoTrackTranscoder.java
+++ b/litr/src/main/java/com/linkedin/android/litr/transcoder/VideoTrackTranscoder.java
@@ -20,7 +20,7 @@ import com.linkedin.android.litr.exception.TrackTranscoderException;
 import com.linkedin.android.litr.io.MediaSource;
 import com.linkedin.android.litr.io.MediaTarget;
 import com.linkedin.android.litr.render.GlVideoRenderer;
-import com.linkedin.android.litr.render.VideoRenderer;
+import com.linkedin.android.litr.render.Renderer;
 
 /**
  * Transcoder that processes video tracks.
@@ -45,7 +45,7 @@ public class VideoTrackTranscoder extends TrackTranscoder {
                          @NonNull MediaTarget mediaTarget,
                          int targetTrack,
                          @NonNull MediaFormat targetFormat,
-                         @NonNull VideoRenderer renderer,
+                         @NonNull Renderer renderer,
                          @NonNull Decoder decoder,
                          @NonNull Encoder encoder) throws TrackTranscoderException {
         super(mediaSource, sourceTrack, mediaTarget, targetTrack, targetFormat, decoder, encoder);
@@ -75,18 +75,9 @@ public class VideoTrackTranscoder extends TrackTranscoder {
             duration = sourceVideoFormat.getLong(MediaFormat.KEY_DURATION);
             targetVideoFormat.setLong(MediaFormat.KEY_DURATION, (long) duration);
         }
-        // clear the rotation flag, we don't want any auto-rotation issues
-        int rotation = 0;
-        if (sourceVideoFormat.containsKey(KEY_ROTATION)) {
-            rotation = sourceVideoFormat.getInteger(KEY_ROTATION);
-        }
-        float aspectRatio = 1;
-        if (targetVideoFormat.containsKey(MediaFormat.KEY_WIDTH) && targetVideoFormat.containsKey(MediaFormat.KEY_HEIGHT)) {
-            aspectRatio = (float) targetVideoFormat.getInteger(MediaFormat.KEY_WIDTH) / targetVideoFormat.getInteger(MediaFormat.KEY_HEIGHT);
-        }
 
         encoder.init(targetFormat);
-        renderer.init(encoder.createInputSurface(), rotation, aspectRatio);
+        renderer.init(encoder.createInputSurface(), sourceVideoFormat, targetVideoFormat);
         decoder.init(sourceVideoFormat, renderer.getInputSurface());
     }
 

--- a/litr/src/test/java/com/linkedin/android/litr/TransformationJobShould.java
+++ b/litr/src/test/java/com/linkedin/android/litr/TransformationJobShould.java
@@ -16,7 +16,7 @@ import com.linkedin.android.litr.exception.InsufficientDiskSpaceException;
 import com.linkedin.android.litr.exception.TrackTranscoderException;
 import com.linkedin.android.litr.io.MediaSource;
 import com.linkedin.android.litr.io.MediaTarget;
-import com.linkedin.android.litr.render.VideoRenderer;
+import com.linkedin.android.litr.render.Renderer;
 import com.linkedin.android.litr.transcoder.PassthroughTranscoder;
 import com.linkedin.android.litr.transcoder.TrackTranscoder;
 import com.linkedin.android.litr.transcoder.TrackTranscoderFactory;
@@ -71,7 +71,7 @@ public class TransformationJobShould {
 
     @Mock private MediaSource mediaSource;
     @Mock private Decoder decoder;
-    @Mock private VideoRenderer renderer;
+    @Mock private Renderer renderer;
     @Mock private Encoder encoder;
     @Mock private MediaTarget mediaTarget;
     @Mock private VideoTrackTranscoder videoTrackTranscoder;

--- a/litr/src/test/java/com/linkedin/android/litr/transcoder/VideoTrackTranscoderShould.java
+++ b/litr/src/test/java/com/linkedin/android/litr/transcoder/VideoTrackTranscoderShould.java
@@ -169,7 +169,7 @@ public class VideoTrackTranscoderShould {
         verify(decoder, never()).stop();
         verify(encoder).start();
         verify(decoder).start();
-        verify(renderer).init(surface, 0, (float) TARGET_WIDTH / TARGET_HEIGHT);
+        verify(renderer).init(surface, sourceMediaFormat, targetVideoFormat);
     }
 
     @Test


### PR DESCRIPTION
In anticipation of software renderers (both for video and audio) we need to generalize renderer interface and change init method to accept source and target MediaFormat.