### PR TITLE
Default encoder to use COLOR_FormatSurface

### DIFF
--- a/litr-demo/src/main/java/com/linkedin/android/litr/demo/data/TransformationPresenter.java
+++ b/litr-demo/src/main/java/com/linkedin/android/litr/demo/data/TransformationPresenter.java
@@ -12,7 +12,6 @@ import android.content.Intent;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.graphics.PointF;
-import android.media.MediaCodecInfo;
 import android.media.MediaFormat;
 import android.media.MediaMuxer;
 import android.net.Uri;
@@ -183,7 +182,6 @@ public class TransformationPresenter {
                 mediaFormat.setInteger(MediaFormat.KEY_BIT_RATE, trackFormat.bitrate);
                 mediaFormat.setInteger(MediaFormat.KEY_I_FRAME_INTERVAL, trackFormat.keyFrameInterval);
                 mediaFormat.setInteger(MediaFormat.KEY_FRAME_RATE, trackFormat.frameRate);
-                mediaFormat.setInteger(MediaFormat.KEY_COLOR_FORMAT, MediaCodecInfo.CodecCapabilities.COLOR_FormatSurface);
             } else if (targetTrack.format.mimeType.startsWith("audio")) {
                 AudioTrackFormat trackFormat = (AudioTrackFormat) targetTrack.format;
                 mediaFormat.setString(MediaFormat.KEY_MIME, trackFormat.mimeType);

--- a/litr/src/main/java/com/linkedin/android/litr/codec/MediaCodecEncoder.java
+++ b/litr/src/main/java/com/linkedin/android/litr/codec/MediaCodecEncoder.java
@@ -8,6 +8,7 @@
 package com.linkedin.android.litr.codec;
 
 import android.media.MediaCodec;
+import android.media.MediaCodecInfo;
 import android.media.MediaCodecList;
 import android.media.MediaFormat;
 import android.os.Build;
@@ -33,6 +34,11 @@ public class MediaCodecEncoder implements Encoder {
     public void init(@NonNull MediaFormat targetFormat) throws TrackTranscoderException {
         mediaCodec = null;
         MediaCodecList mediaCodecList = null;
+
+        // unless specified otherwise, we use default color format for the surface
+        if (!targetFormat.containsKey(MediaFormat.KEY_COLOR_FORMAT)) {
+            targetFormat.setInteger(MediaFormat.KEY_COLOR_FORMAT, MediaCodecInfo.CodecCapabilities.COLOR_FormatSurface);
+        }
 
         try {
             if (Build.VERSION.SDK_INT > Build.VERSION_CODES.LOLLIPOP) {


### PR DESCRIPTION
When running in Surface mode, on many devices MediaCodec encoder requires color format to be set in target format. COLOR_FormatSurface is most compatible for surface mode. 