### PR TITLE
Handling tracks with no duration

### DIFF
--- a/litr/src/main/java/com/linkedin/android/litr/transcoder/AudioTrackTranscoder.java
+++ b/litr/src/main/java/com/linkedin/android/litr/transcoder/AudioTrackTranscoder.java
@@ -59,13 +59,6 @@ public class AudioTrackTranscoder extends TrackTranscoder {
         sourceAudioFormat = mediaSource.getTrackFormat(sourceTrack);
 
         encoder.init(targetFormat);
-
-        // extract and store the duration, we will use it to track transcoding progress
-        if (sourceAudioFormat.containsKey(MediaFormat.KEY_DURATION)) {
-            duration = sourceAudioFormat.getLong(MediaFormat.KEY_DURATION);
-            targetFormat.setLong(MediaFormat.KEY_DURATION, (long) duration);
-        }
-
         decoder.init(sourceAudioFormat, null);
     }
 

--- a/litr/src/main/java/com/linkedin/android/litr/transcoder/AudioTrackTranscoder.java
+++ b/litr/src/main/java/com/linkedin/android/litr/transcoder/AudioTrackTranscoder.java
@@ -235,7 +235,9 @@ public class AudioTrackTranscoder extends TrackTranscoder {
             if (frame.bufferInfo.size > 0
                 && (frame.bufferInfo.flags & MediaCodec.BUFFER_FLAG_CODEC_CONFIG) == 0) {
                 mediaMuxer.writeSampleData(targetTrack, frame.buffer, frame.bufferInfo);
-                progress = ((float) frame.bufferInfo.presentationTimeUs) / duration;
+                if (duration > 0) {
+                    progress = ((float) frame.bufferInfo.presentationTimeUs) / duration;
+                }
             }
 
             if ((frame.bufferInfo.flags & MediaCodec.BUFFER_FLAG_END_OF_STREAM) != 0) {

--- a/litr/src/main/java/com/linkedin/android/litr/transcoder/PassthroughTranscoder.java
+++ b/litr/src/main/java/com/linkedin/android/litr/transcoder/PassthroughTranscoder.java
@@ -65,7 +65,9 @@ public class PassthroughTranscoder extends TrackTranscoder {
         // TranscoderJob expects the first result to be RESULT_OUTPUT_MEDIA_FORMAT_CHANGED, so that it can start the mediaMuxer
         if (!targetTrackAdded) {
             targetFormat = mediaSource.getTrackFormat(sourceTrack);
-            duration = targetFormat.getLong(MediaFormat.KEY_DURATION);
+            if (duration > 0) {
+                targetFormat.setLong(MediaFormat.KEY_DURATION, duration);
+            }
 
             targetTrack = mediaMuxer.addTrack(targetFormat, targetTrack);
             targetTrackAdded = true;
@@ -98,7 +100,9 @@ public class PassthroughTranscoder extends TrackTranscoder {
                     outputFlags = MediaCodec.BUFFER_FLAG_SYNC_FRAME;
                 }
             }
-            progress = ((float) sampleTime) / duration;
+            if (duration > 0) {
+                progress = ((float) sampleTime) / duration;
+            }
             outputBufferInfo.set(0, bytesRead, sampleTime, outputFlags);
             mediaMuxer.writeSampleData(targetTrack, outputBuffer, outputBufferInfo);
             mediaSource.advance();

--- a/litr/src/main/java/com/linkedin/android/litr/transcoder/TrackTranscoder.java
+++ b/litr/src/main/java/com/linkedin/android/litr/transcoder/TrackTranscoder.java
@@ -40,7 +40,7 @@ public abstract class TrackTranscoder {
 
     @Nullable protected MediaFormat targetFormat;
 
-    protected float duration = UNDEFINED_VALUE;
+    protected long duration = UNDEFINED_VALUE;
     protected float progress;
 
     TrackTranscoder(@NonNull MediaSource mediaSource,
@@ -57,6 +57,14 @@ public abstract class TrackTranscoder {
         this.targetFormat = targetFormat;
         this.decoder = decoder;
         this.encoder = encoder;
+
+        MediaFormat sourceMedia = mediaSource.getTrackFormat(sourceTrack);
+        if (sourceMedia.containsKey(MediaFormat.KEY_DURATION)) {
+            duration = sourceMedia.getLong(MediaFormat.KEY_DURATION);
+            if (targetFormat != null) {
+                targetFormat.setLong(MediaFormat.KEY_DURATION, duration);
+            }
+        }
     }
 
     public abstract void start() throws TrackTranscoderException;

--- a/litr/src/main/java/com/linkedin/android/litr/transcoder/VideoTrackTranscoder.java
+++ b/litr/src/main/java/com/linkedin/android/litr/transcoder/VideoTrackTranscoder.java
@@ -225,7 +225,9 @@ public class VideoTrackTranscoder extends TrackTranscoder {
             if (frame.bufferInfo.size > 0
                 && (frame.bufferInfo.flags & MediaCodec.BUFFER_FLAG_CODEC_CONFIG) == 0) {
                 mediaMuxer.writeSampleData(targetTrack, frame.buffer, frame.bufferInfo);
-                progress = ((float) frame.bufferInfo.presentationTimeUs) / duration;
+                if (duration > 0) {
+                    progress = ((float) frame.bufferInfo.presentationTimeUs) / duration;
+                }
             }
 
             if ((frame.bufferInfo.flags & MediaCodec.BUFFER_FLAG_END_OF_STREAM) != 0) {

--- a/litr/src/main/java/com/linkedin/android/litr/transcoder/VideoTrackTranscoder.java
+++ b/litr/src/main/java/com/linkedin/android/litr/transcoder/VideoTrackTranscoder.java
@@ -70,11 +70,6 @@ public class VideoTrackTranscoder extends TrackTranscoder {
             int sourceFrameRate = sourceVideoFormat.getInteger(MediaFormat.KEY_FRAME_RATE);
             targetVideoFormat.setInteger(MediaFormat.KEY_FRAME_RATE, sourceFrameRate);
         }
-        // extract and store the duration, we will use it to track transcoding progress
-        if (sourceVideoFormat.containsKey(MediaFormat.KEY_DURATION)) {
-            duration = sourceVideoFormat.getLong(MediaFormat.KEY_DURATION);
-            targetVideoFormat.setLong(MediaFormat.KEY_DURATION, (long) duration);
-        }
 
         encoder.init(targetFormat);
         renderer.init(encoder.createInputSurface(), sourceVideoFormat, targetVideoFormat);

--- a/litr/src/main/java/com/linkedin/android/litr/utils/TranscoderUtils.java
+++ b/litr/src/main/java/com/linkedin/android/litr/utils/TranscoderUtils.java
@@ -51,7 +51,7 @@ public final class TranscoderUtils {
         long maxDurationUs = 0;
         for (TrackTransform trackTransform : trackTransforms) {
             MediaFormat trackFormat = trackTransform.getMediaSource().getTrackFormat(trackTransform.getSourceTrack());
-            long durationUs = trackFormat.getLong(MediaFormat.KEY_DURATION);
+            long durationUs = getDuration(trackFormat);
             maxDurationUs = Math.max(durationUs, maxDurationUs);
         }
 
@@ -75,7 +75,7 @@ public final class TranscoderUtils {
             }
 
             if (bitrate < 0) {
-                Log.d(TAG, "Bitrate is not available, cannot use that track to estimate sie");
+                Log.d(TAG, "Bitrate is not available, cannot use that track to estimate size");
                 bitrate = 0;
             }
 

--- a/litr/src/test/java/com/linkedin/android/litr/transcoder/AudioTrackTranscoderShould.java
+++ b/litr/src/test/java/com/linkedin/android/litr/transcoder/AudioTrackTranscoderShould.java
@@ -45,7 +45,7 @@ public class AudioTrackTranscoderShould {
     private static final int AUDIO_TRACK = 0;
     private static final int BUFFER_INDEX = 0;
     private static final int BUFFER_SIZE = 42;
-    private static final float DURATION = 84f;
+    private static final long DURATION = 84;
     private static final long CURRENT_PRESENTATION_TIME = 42L;
     private static final float CURRENT_PROGRESS = 0.5f;
 

--- a/litr/src/test/java/com/linkedin/android/litr/transcoder/VideoTrackTranscoderShould.java
+++ b/litr/src/test/java/com/linkedin/android/litr/transcoder/VideoTrackTranscoderShould.java
@@ -46,7 +46,7 @@ public class VideoTrackTranscoderShould {
     private static final int VIDEO_TRACK = 0;
     private static final int BUFFER_INDEX = 0;
     private static final int BUFFER_SIZE = 42;
-    private static final float DURATION = 84f;
+    private static final long DURATION = 84;
     private static final long CURRENT_PRESENTATION_TIME = 42L;
     private static final float CURRENT_PROGRESS = 0.5f;
 


### PR DESCRIPTION
Some tracks (for example, metadata track) do not have duration. In our code we assume that they do. No longer making that assumption.

We are also moving duration extraction into base class.