### PR TITLE
Fixing MarshallingHandler not using provided looper

### DIFF
--- a/litr/src/main/java/com/linkedin/android/litr/MarshallingTransformationListener.java
+++ b/litr/src/main/java/com/linkedin/android/litr/MarshallingTransformationListener.java
@@ -46,7 +46,7 @@ class MarshallingTransformationListener {
         this.listener = listener;
 
         if (looper != null) {
-            handler = new MarshallingHandler(listener);
+            handler = new MarshallingHandler(looper, listener);
         }
     }
 
@@ -127,7 +127,8 @@ class MarshallingTransformationListener {
 
         private final TransformationListener listener;
 
-        private MarshallingHandler(@NonNull TransformationListener listener) {
+        private MarshallingHandler(@NonNull Looper looper, @NonNull TransformationListener listener) {
+            super(looper);
             this.listener = listener;
         }
 


### PR DESCRIPTION
Provided looper was not used to initialize the MarshallingHandler which would use the `Looper.myLooper()` of whatever thread the transform job was submitted on.

I'm not sure how to test this nor if it makes sense to. But happy to follow your guidance if you have any idea :)

Best and thanks for this library 👍 