### PR TITLE
Support for custom video frame renderers

### DIFF
--- a/litr/src/main/java/com/linkedin/android/litr/filter/GlFrameRenderFilter.java
+++ b/litr/src/main/java/com/linkedin/android/litr/filter/GlFrameRenderFilter.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2019 LinkedIn Corporation
+ * All Rights Reserved.
+ *
+ * Licensed under the BSD 2-Clause License (the "License").  See License in the project root for
+ * license information.
+ */
+package com.linkedin.android.litr.filter;
+
+import androidx.annotation.NonNull;
+
+/**
+ * Interface for filters that implement rendering source video frame onto target video frame.
+ * In addition to target frame geometry (size, rotation, aspect ratio, etc.) frame renderer
+ * should also have access to source video frame texture.
+ */
+public interface GlFrameRenderFilter extends GlFilter {
+
+    /**
+     * Initialize texture associated with {@link android.graphics.SurfaceTexture} if input video frames
+     * @param textureId texture id of input video texture
+     * @param transformMatrix transform matrix of input video texture
+     */
+    void initInputFrameTexture(int textureId, @NonNull float[] transformMatrix);
+}

--- a/litr/src/main/java/com/linkedin/android/litr/filter/GlFrameRenderFilter.java
+++ b/litr/src/main/java/com/linkedin/android/litr/filter/GlFrameRenderFilter.java
@@ -18,8 +18,8 @@ public interface GlFrameRenderFilter extends GlFilter {
 
     /**
      * Initialize texture associated with {@link android.graphics.SurfaceTexture} if input video frames
-     * @param textureId texture id of input video texture
+     * @param textureHandle texture handle of input video texture
      * @param transformMatrix transform matrix of input video texture
      */
-    void initInputFrameTexture(int textureId, @NonNull float[] transformMatrix);
+    void initInputFrameTexture(int textureHandle, @NonNull float[] transformMatrix);
 }

--- a/litr/src/main/java/com/linkedin/android/litr/filter/video/gl/ScaleToFitGlFrameRenderFilter.java
+++ b/litr/src/main/java/com/linkedin/android/litr/filter/video/gl/ScaleToFitGlFrameRenderFilter.java
@@ -70,14 +70,14 @@ public class ScaleToFitGlFrameRenderFilter implements GlFrameRenderFilter {
     };
 
     private float[] mvpMatrix = new float[16];
-    private float[] inputTextureTransformMatrix = new float[16];
+    private float[] inputFrameTextureMatrix = new float[16];
 
     private int glProgram;
     private int mvpMatrixHandle;
     private int uStMatrixHandle;
     private int aPositionHandle;
     private int aTextureHandle;
-    private int inputTextureId;
+    private int inputFrameTextureHandle;
 
     @Override
     public void init(@NonNull float[] vpMatrix, int vpMatrixOffset) {
@@ -85,7 +85,7 @@ public class ScaleToFitGlFrameRenderFilter implements GlFrameRenderFilter {
                 triangleVerticesData.length * FLOAT_SIZE_BYTES)
                 .order(ByteOrder.nativeOrder()).asFloatBuffer();
         triangleVertices.put(triangleVerticesData).position(0);
-        Matrix.setIdentityM(inputTextureTransformMatrix, 0);
+        Matrix.setIdentityM(inputFrameTextureMatrix, 0);
 
         mvpMatrix = vpMatrix;
 
@@ -110,9 +110,9 @@ public class ScaleToFitGlFrameRenderFilter implements GlFrameRenderFilter {
     }
 
     @Override
-    public void initInputFrameTexture(int textureId, @NonNull float[] transformMatrix) {
-        inputTextureId = textureId;
-        inputTextureTransformMatrix = transformMatrix;
+    public void initInputFrameTexture(int textureHandle, @NonNull float[] transformMatrix) {
+        inputFrameTextureHandle = textureHandle;
+        inputFrameTextureMatrix = transformMatrix;
     }
 
     @Override
@@ -121,7 +121,7 @@ public class ScaleToFitGlFrameRenderFilter implements GlFrameRenderFilter {
         GLES20.glUseProgram(glProgram);
         GlRenderUtils.checkGlError("glUseProgram");
         GLES20.glActiveTexture(GLES20.GL_TEXTURE0);
-        GLES20.glBindTexture(GLES11Ext.GL_TEXTURE_EXTERNAL_OES, inputTextureId);
+        GLES20.glBindTexture(GLES11Ext.GL_TEXTURE_EXTERNAL_OES, inputFrameTextureHandle);
         triangleVertices.position(TRIANGLE_VERTICES_DATA_POS_OFFSET);
         GLES20.glVertexAttribPointer(aPositionHandle, 3, GLES20.GL_FLOAT, false,
                 TRIANGLE_VERTICES_DATA_STRIDE_BYTES, triangleVertices);
@@ -135,7 +135,7 @@ public class ScaleToFitGlFrameRenderFilter implements GlFrameRenderFilter {
         GLES20.glEnableVertexAttribArray(aTextureHandle);
         GlRenderUtils.checkGlError("glEnableVertexAttribArray aTextureHandle");
         GLES20.glUniformMatrix4fv(mvpMatrixHandle, 1, false, mvpMatrix, 0);
-        GLES20.glUniformMatrix4fv(uStMatrixHandle, 1, false, inputTextureTransformMatrix, 0);
+        GLES20.glUniformMatrix4fv(uStMatrixHandle, 1, false, inputFrameTextureMatrix, 0);
         GLES20.glDrawArrays(GLES20.GL_TRIANGLE_STRIP, 0, 4);
         GlRenderUtils.checkGlError("glDrawArrays");
     }

--- a/litr/src/main/java/com/linkedin/android/litr/filter/video/gl/ScaleToFitGlFrameRenderFilter.java
+++ b/litr/src/main/java/com/linkedin/android/litr/filter/video/gl/ScaleToFitGlFrameRenderFilter.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright (C) 2013 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// from: https://android.googlesource.com/platform/cts/+/lollipop-release/tests/tests/media/src/android/media/cts/TextureRender.java
+// blob: 4125dcfcfed6ed7fddba5b71d657dec0d433da6a
+// modified: removed unused method bodies
+// modified: use GL_LINEAR for GL_TEXTURE_MIN_FILTER to improve quality.
+// modified: added filters
+package com.linkedin.android.litr.filter.video.gl;
+
+import android.opengl.GLES11Ext;
+import android.opengl.GLES20;
+import android.opengl.Matrix;
+
+import androidx.annotation.NonNull;
+
+import com.linkedin.android.litr.filter.GlFrameRenderFilter;
+import com.linkedin.android.litr.render.GlRenderUtils;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.FloatBuffer;
+
+public class ScaleToFitGlFrameRenderFilter implements GlFrameRenderFilter {
+
+    private static final int FLOAT_SIZE_BYTES = 4;
+    private static final int TRIANGLE_VERTICES_DATA_STRIDE_BYTES = 5 * FLOAT_SIZE_BYTES;
+    private static final int TRIANGLE_VERTICES_DATA_POS_OFFSET = 0;
+    private static final int TRIANGLE_VERTICES_DATA_UV_OFFSET = 3;
+
+    // shaders
+    private static final String VERTEX_SHADER =
+            "uniform mat4 uMVPMatrix;\n" +
+                    "uniform mat4 uSTMatrix;\n" +
+                    "attribute vec4 aPosition;\n" +
+                    "attribute vec4 aTextureCoord;\n" +
+                    "varying vec2 vTextureCoord;\n" +
+                    "void main() {\n" +
+                    "  gl_Position = uMVPMatrix * aPosition;\n" +
+                    "  vTextureCoord = (uSTMatrix * aTextureCoord).xy;\n" +
+                    "}\n";
+    private static final String FRAGMENT_SHADER =
+            "#extension GL_OES_EGL_image_external : require\n" +
+                    "precision mediump float;\n" +      // highp here doesn't seem to matter
+                    "varying vec2 vTextureCoord;\n" +
+                    "uniform samplerExternalOES sTexture;\n" +
+                    "void main() {\n" +
+                    "  gl_FragColor = texture2D(sTexture, vTextureCoord);\n" +
+                    "}\n";
+
+    private FloatBuffer triangleVertices;
+    private final float[] triangleVerticesData = {
+            // X, Y, Z, U, V
+            -1.0f, -1.0f, 0, 0.f, 0.f,
+            1.0f, -1.0f, 0, 1.f, 0.f,
+            -1.0f, 1.0f, 0, 0.f, 1.f,
+            1.0f, 1.0f, 0, 1.f, 1.f,
+    };
+
+    private float[] mvpMatrix = new float[16];
+    private float[] inputTextureTransformMatrix = new float[16];
+
+    private int glProgram;
+    private int mvpMatrixHandle;
+    private int uStMatrixHandle;
+    private int aPositionHandle;
+    private int aTextureHandle;
+    private int inputTextureId;
+
+    @Override
+    public void init(@NonNull float[] vpMatrix, int vpMatrixOffset) {
+        triangleVertices = ByteBuffer.allocateDirect(
+                triangleVerticesData.length * FLOAT_SIZE_BYTES)
+                .order(ByteOrder.nativeOrder()).asFloatBuffer();
+        triangleVertices.put(triangleVerticesData).position(0);
+        Matrix.setIdentityM(inputTextureTransformMatrix, 0);
+
+        mvpMatrix = vpMatrix;
+
+        // Let's use features of VP matrix to extract frame aspect ratio and orientation from it
+        // and scale/rotate source video frame to match the size/orientation of target video frame
+        float videoAspectRatio;
+        float videoRotation;
+        if (vpMatrix[0] == 0) {
+            // portrait video
+            videoAspectRatio = 1 / Math.abs(vpMatrix[4]);
+            videoRotation = vpMatrix[4] > 0 ? 270 : 90;
+            Matrix.scaleM(mvpMatrix, 0, 1, -videoAspectRatio, 1);
+        } else {
+            // landscape video
+            videoAspectRatio = 1 / Math.abs(vpMatrix[0]);
+            videoRotation = vpMatrix[0] > 0 ? 0 : 180;
+            Matrix.scaleM(mvpMatrix, 0, videoAspectRatio, -1, 1);
+        }
+        Matrix.rotateM(mvpMatrix, vpMatrixOffset, videoRotation, 0, 0, 1);
+
+        initGl();
+    }
+
+    @Override
+    public void initInputFrameTexture(int textureId, @NonNull float[] transformMatrix) {
+        inputTextureId = textureId;
+        inputTextureTransformMatrix = transformMatrix;
+    }
+
+    @Override
+    public void apply(long presentationTimeNs) {
+        GlRenderUtils.checkGlError("onDrawFrame start");
+        GLES20.glUseProgram(glProgram);
+        GlRenderUtils.checkGlError("glUseProgram");
+        GLES20.glActiveTexture(GLES20.GL_TEXTURE0);
+        GLES20.glBindTexture(GLES11Ext.GL_TEXTURE_EXTERNAL_OES, inputTextureId);
+        triangleVertices.position(TRIANGLE_VERTICES_DATA_POS_OFFSET);
+        GLES20.glVertexAttribPointer(aPositionHandle, 3, GLES20.GL_FLOAT, false,
+                TRIANGLE_VERTICES_DATA_STRIDE_BYTES, triangleVertices);
+        GlRenderUtils.checkGlError("glVertexAttribPointer maPosition");
+        GLES20.glEnableVertexAttribArray(aPositionHandle);
+        GlRenderUtils.checkGlError("glEnableVertexAttribArray aPositionHandle");
+        triangleVertices.position(TRIANGLE_VERTICES_DATA_UV_OFFSET);
+        GLES20.glVertexAttribPointer(aTextureHandle, 2, GLES20.GL_FLOAT, false,
+                TRIANGLE_VERTICES_DATA_STRIDE_BYTES, triangleVertices);
+        GlRenderUtils.checkGlError("glVertexAttribPointer aTextureHandle");
+        GLES20.glEnableVertexAttribArray(aTextureHandle);
+        GlRenderUtils.checkGlError("glEnableVertexAttribArray aTextureHandle");
+        GLES20.glUniformMatrix4fv(mvpMatrixHandle, 1, false, mvpMatrix, 0);
+        GLES20.glUniformMatrix4fv(uStMatrixHandle, 1, false, inputTextureTransformMatrix, 0);
+        GLES20.glDrawArrays(GLES20.GL_TRIANGLE_STRIP, 0, 4);
+        GlRenderUtils.checkGlError("glDrawArrays");
+    }
+
+    /**
+     * Initializes GL state.  Call this after the EGL surface has been created and made current.
+     */
+    private void initGl() {
+        glProgram = GlRenderUtils.createProgram(VERTEX_SHADER, FRAGMENT_SHADER);
+        if (glProgram == 0) {
+            throw new RuntimeException("failed creating glProgram");
+        }
+        aPositionHandle = GLES20.glGetAttribLocation(glProgram, "aPosition");
+        GlRenderUtils.checkGlError("glGetAttribLocation aPosition");
+        if (aPositionHandle == -1) {
+            throw new RuntimeException("Could not get attrib location for aPosition");
+        }
+        aTextureHandle = GLES20.glGetAttribLocation(glProgram, "aTextureCoord");
+        GlRenderUtils.checkGlError("glGetAttribLocation aTextureCoord");
+        if (aTextureHandle == -1) {
+            throw new RuntimeException("Could not get attrib location for aTextureCoord");
+        }
+        mvpMatrixHandle = GLES20.glGetUniformLocation(glProgram, "uMVPMatrix");
+        GlRenderUtils.checkGlError("glGetUniformLocation uMVPMatrix");
+        if (mvpMatrixHandle == -1) {
+            throw new RuntimeException("Could not get attrib location for uMVPMatrix");
+        }
+        uStMatrixHandle = GLES20.glGetUniformLocation(glProgram, "uSTMatrix");
+        GlRenderUtils.checkGlError("glGetUniformLocation uSTMatrix");
+        if (uStMatrixHandle == -1) {
+            throw new RuntimeException("Could not get attrib location for uSTMatrix");
+        }
+    }
+}

--- a/litr/src/main/java/com/linkedin/android/litr/render/GlVideoRenderer.java
+++ b/litr/src/main/java/com/linkedin/android/litr/render/GlVideoRenderer.java
@@ -21,20 +21,20 @@
 package com.linkedin.android.litr.render;
 
 import android.media.MediaFormat;
-import android.opengl.GLES11Ext;
 import android.opengl.GLES20;
 import android.opengl.Matrix;
 import android.os.Build;
 import android.view.Surface;
+
 import androidx.annotation.Nullable;
+
 import com.linkedin.android.litr.codec.Frame;
 import com.linkedin.android.litr.filter.GlFilter;
+import com.linkedin.android.litr.filter.GlFrameRenderFilter;
+import com.linkedin.android.litr.filter.video.gl.ScaleToFitGlFrameRenderFilter;
 
-import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
-import java.nio.FloatBuffer;
+import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 /**
@@ -47,65 +47,37 @@ public class GlVideoRenderer implements Renderer {
                                                  ? MediaFormat.KEY_ROTATION
                                                  : "rotation-degrees";
 
-    private static final int FLOAT_SIZE_BYTES = 4;
-    private static final int TRIANGLE_VERTICES_DATA_STRIDE_BYTES = 5 * FLOAT_SIZE_BYTES;
-    private static final int TRIANGLE_VERTICES_DATA_POS_OFFSET = 0;
-    private static final int TRIANGLE_VERTICES_DATA_UV_OFFSET = 3;
-
-    // shaders
-    private static final String VERTEX_SHADER =
-        "uniform mat4 uMVPMatrix;\n" +
-            "uniform mat4 uSTMatrix;\n" +
-            "attribute vec4 aPosition;\n" +
-            "attribute vec4 aTextureCoord;\n" +
-            "varying vec2 vTextureCoord;\n" +
-            "void main() {\n" +
-            "  gl_Position = uMVPMatrix * aPosition;\n" +
-            "  vTextureCoord = (uSTMatrix * aTextureCoord).xy;\n" +
-            "}\n";
-    private static final String FRAGMENT_SHADER =
-        "#extension GL_OES_EGL_image_external : require\n" +
-            "precision mediump float;\n" +      // highp here doesn't seem to matter
-            "varying vec2 vTextureCoord;\n" +
-            "uniform samplerExternalOES sTexture;\n" +
-            "void main() {\n" +
-            "  gl_FragColor = texture2D(sTexture, vTextureCoord);\n" +
-            "}\n";
-
     private VideoRenderInputSurface inputSurface;
     private VideoRenderOutputSurface outputSurface;
     private List<GlFilter> filters;
 
-    private FloatBuffer triangleVertices;
-    private final float[] triangleVerticesData = {
-        // X, Y, Z, U, V
-        -1.0f, -1.0f, 0, 0.f, 0.f,
-        1.0f, -1.0f, 0, 1.f, 0.f,
-        -1.0f, 1.0f, 0, 0.f, 1.f,
-        1.0f, 1.0f, 0, 1.f, 1.f,
-        };
-
     private float[] mvpMatrix = new float[16];
-    private float[] stMatrix = new float[16];
-
-    private int glProgram;
-    private int mvpMatrixHandle;
-    private int uStMatrixHandle;
-    private int aPositionHandle;
-    private int aTextureHandle;
 
     /**
-     * Create an instance of GlVideoRenderer
+     * Create an instance of GlVideoRenderer. If filter list has a {@link GlFrameRenderFilter}, that filter
+     * will be used to render video frames. Otherwise, default {@link ScaleToFitGlFrameRenderFilter}
+     * will be used at lowest Z level to render video frames.
      * @param filters optional list of OpenGL filters to applied to output video frames
      */
     public GlVideoRenderer(@Nullable List<GlFilter> filters) {
-        this.filters = filters == null ? Collections.<GlFilter>emptyList() : filters;
+        this.filters = new ArrayList<>();
+        if (filters == null) {
+            this.filters.add(new ScaleToFitGlFrameRenderFilter());
+            return;
+        }
 
-        triangleVertices = ByteBuffer.allocateDirect(
-            triangleVerticesData.length * FLOAT_SIZE_BYTES)
-                                     .order(ByteOrder.nativeOrder()).asFloatBuffer();
-        triangleVertices.put(triangleVerticesData).position(0);
-        Matrix.setIdentityM(stMatrix, 0);
+        boolean hasFrameRenderFilter = false;
+        for (GlFilter filter : filters) {
+            if (filter instanceof GlFrameRenderFilter) {
+                hasFrameRenderFilter = true;
+                break;
+            }
+        }
+        if (!hasFrameRenderFilter) {
+            // if client provided filters don't have a frame render filter, insert default frame filter
+            this.filters.add(new ScaleToFitGlFrameRenderFilter());
+        }
+        this.filters.addAll(filters);
     }
 
     @Override
@@ -130,18 +102,13 @@ public class GlVideoRenderer implements Renderer {
         this.outputSurface = new VideoRenderOutputSurface(outputSurface);
 
         inputSurface = new VideoRenderInputSurface();
-        initGl();
         initMvpMatrix(rotation, aspectRatio);
 
         for (GlFilter filter : filters) {
             filter.init(Arrays.copyOf(mvpMatrix, mvpMatrix.length), 0);
-        }
-
-        // scale video frames to fit the projection
-        if (rotation == 90 || rotation == 270) {
-            Matrix.scaleM(mvpMatrix, 0, 1, aspectRatio, 1);
-        } else {
-            Matrix.scaleM(mvpMatrix, 0, aspectRatio, 1, 1);
+            if (filter instanceof GlFrameRenderFilter) {
+                ((GlFrameRenderFilter) filter).initInputFrameTexture(inputSurface.getTextureId(), inputSurface.getTransformMatrix());
+            }
         }
     }
 
@@ -174,63 +141,11 @@ public class GlVideoRenderer implements Renderer {
     }
 
     /**
-     * Initializes GL state.  Call this after the EGL surface has been created and made current.
-     */
-    private void initGl() {
-        glProgram = GlRenderUtils.createProgram(VERTEX_SHADER, FRAGMENT_SHADER);
-        if (glProgram == 0) {
-            throw new RuntimeException("failed creating glProgram");
-        }
-        aPositionHandle = GLES20.glGetAttribLocation(glProgram, "aPosition");
-        GlRenderUtils.checkGlError("glGetAttribLocation aPosition");
-        if (aPositionHandle == -1) {
-            throw new RuntimeException("Could not get attrib location for aPosition");
-        }
-        aTextureHandle = GLES20.glGetAttribLocation(glProgram, "aTextureCoord");
-        GlRenderUtils.checkGlError("glGetAttribLocation aTextureCoord");
-        if (aTextureHandle == -1) {
-            throw new RuntimeException("Could not get attrib location for aTextureCoord");
-        }
-        mvpMatrixHandle = GLES20.glGetUniformLocation(glProgram, "uMVPMatrix");
-        GlRenderUtils.checkGlError("glGetUniformLocation uMVPMatrix");
-        if (mvpMatrixHandle == -1) {
-            throw new RuntimeException("Could not get attrib location for uMVPMatrix");
-        }
-        uStMatrixHandle = GLES20.glGetUniformLocation(glProgram, "uSTMatrix");
-        GlRenderUtils.checkGlError("glGetUniformLocation uSTMatrix");
-        if (uStMatrixHandle == -1) {
-            throw new RuntimeException("Could not get attrib location for uSTMatrix");
-        }
-    }
-
-    /**
      * Draws the data from SurfaceTexture onto the current EGL surface.
      */
     private void drawFrame(long presentationTimeNs) {
-        GlRenderUtils.checkGlError("onDrawFrame start");
-        inputSurface.getTransformMatrix(stMatrix);
         GLES20.glClearColor(0.0f, 1.0f, 0.0f, 1.0f);
         GLES20.glClear(GLES20.GL_DEPTH_BUFFER_BIT | GLES20.GL_COLOR_BUFFER_BIT);
-        GLES20.glUseProgram(glProgram);
-        GlRenderUtils.checkGlError("glUseProgram");
-        GLES20.glActiveTexture(GLES20.GL_TEXTURE0);
-        GLES20.glBindTexture(GLES11Ext.GL_TEXTURE_EXTERNAL_OES, inputSurface.getTextureId());
-        triangleVertices.position(TRIANGLE_VERTICES_DATA_POS_OFFSET);
-        GLES20.glVertexAttribPointer(aPositionHandle, 3, GLES20.GL_FLOAT, false,
-                                     TRIANGLE_VERTICES_DATA_STRIDE_BYTES, triangleVertices);
-        GlRenderUtils.checkGlError("glVertexAttribPointer maPosition");
-        GLES20.glEnableVertexAttribArray(aPositionHandle);
-        GlRenderUtils.checkGlError("glEnableVertexAttribArray aPositionHandle");
-        triangleVertices.position(TRIANGLE_VERTICES_DATA_UV_OFFSET);
-        GLES20.glVertexAttribPointer(aTextureHandle, 2, GLES20.GL_FLOAT, false,
-                                     TRIANGLE_VERTICES_DATA_STRIDE_BYTES, triangleVertices);
-        GlRenderUtils.checkGlError("glVertexAttribPointer aTextureHandle");
-        GLES20.glEnableVertexAttribArray(aTextureHandle);
-        GlRenderUtils.checkGlError("glEnableVertexAttribArray aTextureHandle");
-        GLES20.glUniformMatrix4fv(mvpMatrixHandle, 1, false, mvpMatrix, 0);
-        GLES20.glUniformMatrix4fv(uStMatrixHandle, 1, false, stMatrix, 0);
-        GLES20.glDrawArrays(GLES20.GL_TRIANGLE_STRIP, 0, 4);
-        GlRenderUtils.checkGlError("glDrawArrays");
 
         for (GlFilter filter : filters) {
             filter.apply(presentationTimeNs);

--- a/litr/src/main/java/com/linkedin/android/litr/render/VideoRenderInputSurface.java
+++ b/litr/src/main/java/com/linkedin/android/litr/render/VideoRenderInputSurface.java
@@ -90,8 +90,11 @@ class VideoRenderInputSurface implements SurfaceTexture.OnFrameAvailableListener
         return textureId;
     }
 
-    void getTransformMatrix(@NonNull float[] transformMatrix) {
+    @NonNull
+    float[] getTransformMatrix() {
+        float[] transformMatrix = new float[16];
         surfaceTexture.getTransformMatrix(transformMatrix);
+        return transformMatrix;
     }
 
     /**


### PR DESCRIPTION
GlVideoRenderer performed both management of input/output surfaces and rendering from input onto output surface. Rendering was very simple "scale to fit" between the two surfaces. 

Now splitting that logic into two: 
 - renderer manages surfaces
 - video frame rendering from input onto output surface is implemented as a filter. We introduce new type of filters to do this, which is given access to input video surface texture id and matrix.
 - default frame rendering filter implementation is current "scale to fit" mapping.

This refactor will allow us to add more sophisticated frame rendering filters implementing transformations like cropping, rotation, etc. 