### PR TITLE
Filter for free transform video frame rendering

### DIFF
--- a/litr-demo/src/main/java/com/linkedin/android/litr/demo/BaseTransformationFragment.java
+++ b/litr-demo/src/main/java/com/linkedin/android/litr/demo/BaseTransformationFragment.java
@@ -47,6 +47,10 @@ public class BaseTransformationFragment extends Fragment {
         pickMedia("image/*", mediaPickerListener);
     }
 
+    public void pickBackground(@Nullable MediaPickerListener mediaPickerListener) {
+        pickMedia("image/*", mediaPickerListener);
+    }
+
     @Override
     public void onActivityResult(int requestCode, int resultCode, Intent data) {
         super.onActivityResult(requestCode, resultCode, data);

--- a/litr-demo/src/main/java/com/linkedin/android/litr/demo/DemoCase.java
+++ b/litr-demo/src/main/java/com/linkedin/android/litr/demo/DemoCase.java
@@ -13,6 +13,7 @@ import androidx.fragment.app.Fragment;
 
 public enum DemoCase {
     TRANSCODE_VIDEO_GL(R.string.demo_case_transcode_video_gl, "TranscodeVideoGl", new TranscodeVideoGlFragment()),
+    VIDEO_OVERLAY_GL(R.string.demo_case_free_transform_video_gl, "FreeTransformVideoGl", new FreeTransformVideoGlFragment()),
     TRANSCODE_VIDEO_MOCK(R.string.demo_case_mock_transcode_video, "TranscodeVideoMock", new MockTranscodeFragment());
 
     @StringRes int displayName;

--- a/litr-demo/src/main/java/com/linkedin/android/litr/demo/FreeTransformVideoGlFragment.java
+++ b/litr-demo/src/main/java/com/linkedin/android/litr/demo/FreeTransformVideoGlFragment.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2019 LinkedIn Corporation
+ * All Rights Reserved.
+ *
+ * Licensed under the BSD 2-Clause License (the "License").  See License in the project root for
+ * license information.
+ */
+package com.linkedin.android.litr.demo;
+
+import android.net.Uri;
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.linkedin.android.litr.MediaTransformer;
+import com.linkedin.android.litr.demo.data.SourceMedia;
+import com.linkedin.android.litr.demo.data.TargetMedia;
+import com.linkedin.android.litr.demo.data.TargetVideoConfiguration;
+import com.linkedin.android.litr.demo.data.TransformationPresenter;
+import com.linkedin.android.litr.demo.data.TransformationState;
+import com.linkedin.android.litr.demo.databinding.FragmentVideoOverlayGlBinding;
+import com.linkedin.android.litr.utils.TransformationUtil;
+
+import java.io.File;
+
+public class FreeTransformVideoGlFragment extends BaseTransformationFragment implements MediaPickerListener {
+
+    private FragmentVideoOverlayGlBinding binding;
+
+    private MediaTransformer mediaTransformer;
+    private TargetMedia targetMedia;
+
+    @Override
+    public void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        mediaTransformer = new MediaTransformer(getContext().getApplicationContext());
+        targetMedia = new TargetMedia();
+    }
+
+    @Override
+    public void onDestroy() {
+        super.onDestroy();
+        mediaTransformer.release();
+    }
+
+    @Override
+    public View onCreateView(@NonNull LayoutInflater inflater,
+                             ViewGroup container, Bundle savedInstanceState) {
+        binding = FragmentVideoOverlayGlBinding.inflate(inflater, container, false);
+
+        SourceMedia sourceMedia = new SourceMedia();
+        binding.setSourceMedia(sourceMedia);
+
+        binding.sectionPickVideo.buttonPickVideo.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                pickVideo(FreeTransformVideoGlFragment.this);
+            }
+        });
+
+        binding.buttonPickBackground.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                pickBackground(new MediaPickerListener() {
+                    @Override
+                    public void onMediaPicked(@NonNull Uri uri) {
+                        targetMedia.backgroundImageUri = uri;
+                    }
+                });
+            }
+        });
+
+        TargetVideoConfiguration targetVideoConfiguration = new TargetVideoConfiguration();
+        binding.setTargetVideoConfiguration(targetVideoConfiguration);
+
+        binding.setTransformationState(new TransformationState());
+        binding.setTransformationPresenter(new TransformationPresenter(getContext(), mediaTransformer));
+
+        binding.setTargetMedia(targetMedia);
+
+        return binding.getRoot();
+    }
+
+    @Override
+    public void onMediaPicked(@NonNull Uri uri) {
+        SourceMedia sourceMedia = binding.getSourceMedia();
+        updateSourceMedia(sourceMedia, uri);
+        File targetFile = new File(TransformationUtil.getTargetFileDirectory(),
+                              "transcoded_" + TransformationUtil.getDisplayName(getContext(), sourceMedia.uri));
+        binding.getTargetMedia().setTargetFile(targetFile);
+        binding.getTargetMedia().setTracks(sourceMedia.tracks);
+
+        binding.getTransformationState().setState(TransformationState.STATE_IDLE);
+        binding.getTransformationState().setStats(null);
+    }
+
+}

--- a/litr-demo/src/main/java/com/linkedin/android/litr/demo/data/TargetMedia.java
+++ b/litr-demo/src/main/java/com/linkedin/android/litr/demo/data/TargetMedia.java
@@ -7,6 +7,8 @@
  */
 package com.linkedin.android.litr.demo.data;
 
+import android.net.Uri;
+
 import androidx.annotation.NonNull;
 import androidx.databinding.BaseObservable;
 
@@ -24,6 +26,7 @@ public class TargetMedia extends BaseObservable {
 
     public File targetFile;
     public List<TargetTrack> tracks = new ArrayList<>();
+    public Uri backgroundImageUri;
 
     public void setTracks(@NonNull List<MediaTrackFormat> sourceTracks) {
         tracks = new ArrayList<>(sourceTracks.size());

--- a/litr-demo/src/main/java/com/linkedin/android/litr/demo/data/TargetVideoConfiguration.java
+++ b/litr-demo/src/main/java/com/linkedin/android/litr/demo/data/TargetVideoConfiguration.java
@@ -1,0 +1,34 @@
+package com.linkedin.android.litr.demo.data;
+
+import android.view.View;
+import android.widget.AdapterView;
+
+import androidx.databinding.BaseObservable;
+
+public class TargetVideoConfiguration extends BaseObservable {
+
+    public int rotation;
+
+    public void onRotationSelected(AdapterView<?> parent, View view, int pos, long id) {
+        switch (pos) {
+            case 0:
+                // landscape
+                rotation = 0;
+                break;
+            case 1:
+                // portrait
+                rotation = 90;
+                break;
+            case 2:
+                // reverse landscape
+                rotation = 180;
+                break;
+            case 3:
+                // reverse portrait
+                rotation = 270;
+                break;
+            default:
+                // nor handled yet
+        }
+    }
+}

--- a/litr-demo/src/main/java/com/linkedin/android/litr/demo/data/TransformationPresenter.java
+++ b/litr-demo/src/main/java/com/linkedin/android/litr/demo/data/TransformationPresenter.java
@@ -15,16 +15,21 @@ import android.graphics.PointF;
 import android.media.MediaFormat;
 import android.media.MediaMuxer;
 import android.net.Uri;
+import android.os.Build;
 import android.util.Log;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.core.content.FileProvider;
+
 import com.linkedin.android.litr.MediaTransformer;
 import com.linkedin.android.litr.TrackTransform;
 import com.linkedin.android.litr.codec.MediaCodecDecoder;
 import com.linkedin.android.litr.codec.MediaCodecEncoder;
 import com.linkedin.android.litr.exception.MediaTransformationException;
 import com.linkedin.android.litr.filter.GlFilter;
+import com.linkedin.android.litr.filter.GlFrameRenderFilter;
+import com.linkedin.android.litr.filter.video.gl.FreeTransformFrameRenderFilter;
 import com.linkedin.android.litr.io.MediaExtractorMediaSource;
 import com.linkedin.android.litr.io.MediaMuxerMediaTarget;
 import com.linkedin.android.litr.io.MediaSource;
@@ -35,13 +40,16 @@ import com.linkedin.android.litr.utils.TransformationUtil;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
 public class TransformationPresenter {
 
     private static final String TAG = TransformationPresenter.class.getSimpleName();
+
+    private static final String KEY_ROTATION = Build.VERSION.SDK_INT >= Build.VERSION_CODES.M
+            ? MediaFormat.KEY_ROTATION
+            : "rotation-degrees";
 
     private final Context context;
     private final MediaTransformer mediaTransformer;
@@ -96,7 +104,11 @@ public class TransformationPresenter {
                     .setEncoder(new MediaCodecEncoder())
                     .setDecoder(new MediaCodecDecoder());
                 if (targetTrack.format instanceof VideoTrackFormat) {
-                    trackTransformBuilder.setRenderer(new GlVideoRenderer(createGlFilters(sourceMedia, (TargetVideoTrack) targetTrack)));
+                    trackTransformBuilder.setRenderer(new GlVideoRenderer(createGlFilters(sourceMedia,
+                            (TargetVideoTrack) targetTrack,
+                            0.56f,
+                            new PointF(0.6f, 0.4f),
+                            30)));
                 }
 
                 trackTransforms.add(trackTransformBuilder.build());
@@ -106,6 +118,85 @@ public class TransformationPresenter {
                                        trackTransforms,
                                        transformationListener,
                                        MediaTransformer.GRANULARITY_DEFAULT);
+        } catch (MediaTransformationException ex) {
+            Log.e(TAG, "Exception when trying to perform track operation", ex);
+        }
+    }
+
+    public void startVideoOverlayTransformation(@NonNull SourceMedia sourceMedia,
+                                                @NonNull TargetMedia targetMedia,
+                                                @NonNull TargetVideoConfiguration targetVideoConfiguration,
+                                                @NonNull TransformationState transformationState) {
+        if (targetMedia.getIncludedTrackCount() < 1) {
+            return;
+        }
+
+        if (targetMedia.targetFile.exists()) {
+            targetMedia.targetFile.delete();
+        }
+
+        transformationState.requestId = UUID.randomUUID().toString();
+        MediaTransformationListener transformationListener = new MediaTransformationListener(context,
+                transformationState.requestId,
+                transformationState);
+
+        try {
+            int videoRotation = 0;
+            for (MediaTrackFormat trackFormat : sourceMedia.tracks) {
+                if (trackFormat.mimeType.startsWith("video")) {
+                    videoRotation = ((VideoTrackFormat) trackFormat).rotation;
+                    break;
+                }
+            }
+
+            MediaTarget mediaTarget = new MediaMuxerMediaTarget(targetMedia.targetFile.getPath(),
+                    targetMedia.getIncludedTrackCount(),
+                    targetVideoConfiguration.rotation,
+                    MediaMuxer.OutputFormat.MUXER_OUTPUT_MPEG_4);
+
+            List<TrackTransform> trackTransforms = new ArrayList<>(targetMedia.tracks.size());
+            MediaSource mediaSource = new MediaExtractorMediaSource(context, sourceMedia.uri);
+
+            for (TargetTrack targetTrack : targetMedia.tracks) {
+                if (!targetTrack.shouldInclude) {
+                    continue;
+                }
+                MediaFormat mediaFormat = createMediaFormat(targetTrack);
+                if (mediaFormat != null && targetTrack.format instanceof VideoTrackFormat) {
+                    mediaFormat.setInteger(KEY_ROTATION, targetVideoConfiguration.rotation);
+                }
+                TrackTransform.Builder trackTransformBuilder = new TrackTransform.Builder(mediaSource,
+                        targetTrack.sourceTrackIndex,
+                        mediaTarget)
+                        .setTargetTrack(trackTransforms.size())
+                        .setTargetFormat(mediaFormat)
+                        .setEncoder(new MediaCodecEncoder())
+                        .setDecoder(new MediaCodecDecoder());
+                if (targetTrack.format instanceof VideoTrackFormat) {
+                    // adding background bitmap first, to ensure that video renders on top of it
+                    List<GlFilter> filters = new ArrayList<>();
+                    if (targetMedia.backgroundImageUri != null) {
+                        GlFilter backgroundImageFilter = TransformationUtil.createGlFilter(context,
+                                targetMedia.backgroundImageUri,
+                                new PointF(1, 1),
+                                new PointF(0.5f, 0.5f),
+                                0);
+                        filters.add(backgroundImageFilter);
+                    }
+
+                    GlFrameRenderFilter frameRenderFilter = new FreeTransformFrameRenderFilter(videoRotation, new PointF(0.3164f, 1.0f), new PointF(0.5f, 0.5f), 0);
+                    filters.add(frameRenderFilter);
+
+                    trackTransformBuilder.setRenderer(new GlVideoRenderer(filters));
+                }
+
+                trackTransforms.add(trackTransformBuilder.build());
+            }
+
+            mediaTransformer.transform(transformationState.requestId,
+                    trackTransforms,
+                    transformationListener,
+                    MediaTransformer.GRANULARITY_DEFAULT);
         } catch (MediaTransformationException ex) {
             Log.e(TAG, "Exception when trying to perform track operation", ex);
         }
@@ -129,13 +220,16 @@ public class TransformationPresenter {
     }
 
     @Nullable
-    private List<GlFilter> createGlFilters(@NonNull SourceMedia sourceMedia, @Nullable TargetVideoTrack targetTrack) {
+    private List<GlFilter> createGlFilters(@NonNull SourceMedia sourceMedia,
+                                           @Nullable TargetVideoTrack targetTrack,
+                                           float overlayWidth,
+                                           @NonNull PointF position,
+                                           float rotation) {
         List<GlFilter> glFilters = null;
         if (targetTrack != null && targetTrack.overlay != null) {
             try {
                 Bitmap bitmap = BitmapFactory.decodeStream(context.getContentResolver().openInputStream(targetTrack.overlay));
                 if (bitmap != null) {
-                    float overlayWidth = 0.56f;
                     float overlayHeight;
                     VideoTrackFormat sourceVideoTrackFormat = (VideoTrackFormat) sourceMedia.tracks.get(targetTrack.sourceTrackIndex);
                     if (sourceVideoTrackFormat.rotation == 90 || sourceVideoTrackFormat.rotation == 270) {
@@ -148,9 +242,7 @@ public class TransformationPresenter {
                         overlayHeight = overlayHeightPixels / sourceVideoTrackFormat.height;
                     }
 
-                    PointF position = new PointF(0.6f, 0.4f);
                     PointF size = new PointF(overlayWidth, overlayHeight);
-                    float rotation = 30;
 
                     GlFilter filter = TransformationUtil.createGlFilter(context,
                                                                         targetTrack.overlay,
@@ -158,7 +250,8 @@ public class TransformationPresenter {
                                                                         position,
                                                                         rotation);
                     if (filter != null) {
-                        glFilters = Collections.singletonList(filter);
+                        glFilters = new ArrayList<>();
+                        glFilters.add(filter);
                     }
                 }
             } catch (IOException ex) {

--- a/litr-demo/src/main/res/layout/fragment_video_overlay_gl.xml
+++ b/litr-demo/src/main/res/layout/fragment_video_overlay_gl.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2019 LinkedIn Corporation -->
+<!-- All Rights Reserved. -->
+<!-- -->
+<!-- Licensed under the BSD 2-Clause License (the "License").  See License in the project root -->
+<!-- for license information. -->
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <data>
+        <import type="android.view.View"/>
+
+        <variable
+            name="sourceMedia"
+            type="com.linkedin.android.litr.demo.data.SourceMedia" />
+
+        <variable
+            name="targetMedia"
+            type="com.linkedin.android.litr.demo.data.TargetMedia" />
+
+        <variable
+            name="transformationState"
+            type="com.linkedin.android.litr.demo.data.TransformationState" />
+
+        <variable
+            name="targetVideoConfiguration"
+            type="com.linkedin.android.litr.demo.data.TargetVideoConfiguration" />
+
+        <variable
+            name="transformationPresenter"
+            type="com.linkedin.android.litr.demo.data.TransformationPresenter" />
+
+    </data>
+
+    <androidx.core.widget.NestedScrollView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <LinearLayout
+            android:orientation="vertical"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+
+            <include layout="@layout/section_pick_video"
+                android:id="@+id/section_pick_video"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:sourceMedia="@{sourceMedia}"/>
+
+            <Button
+                android:id="@+id/button_pick_background"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/pick_background"
+                android:enabled="@{sourceMedia != null &amp;&amp; (transformationState.state != transformationState.STATE_RUNNING)}"
+                android:padding="@dimen/cell_padding"/>
+
+            <include layout="@layout/section_target_video_configuration"
+                android:id="@+id/section_target_video"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:padding="@dimen/cell_padding"
+                app:sourceMedia="@{sourceMedia}"
+                app:targetVideoConfiguration="@{targetVideoConfiguration}"/>
+
+            <Button
+                android:id="@+id/button_transcode"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/transcode"
+                android:enabled="@{sourceMedia != null &amp;&amp; targetMedia != null &amp;&amp; targetMedia.getIncludedTrackCount() > 0 &amp;&amp; (transformationState.state != transformationState.STATE_RUNNING)}"
+                android:padding="@dimen/cell_padding"
+                android:onClick="@{() -> transformationPresenter.startVideoOverlayTransformation(sourceMedia, targetMedia, targetVideoConfiguration, transformationState)}"/>
+
+            <include layout="@layout/section_transformation_progress"
+                android:id="@+id/section_transformation_progress"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:visibility="@{transformationState.state == transformationState.STATE_IDLE ? View.GONE : View.VISIBLE}"
+                app:transformationState="@{transformationState}"
+                app:presenter="@{transformationPresenter}"/>
+
+            <Button
+                android:id="@+id/button_play"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/play"
+                android:enabled="@{transformationState.state == transformationState.STATE_COMPLETED}"
+                android:padding="@dimen/cell_padding"
+                android:onClick="@{() -> transformationPresenter.play(targetMedia.targetFile)}"/>
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:padding="@dimen/cell_padding"
+                android:text="@{transformationState.stats}"
+                android:visibility="@{transformationState.state == transformationState.STATE_RUNNING || transformationState.stats == null ? View.GONE : View.VISIBLE}"/>
+
+        </LinearLayout>
+
+    </androidx.core.widget.NestedScrollView>
+
+</layout>

--- a/litr-demo/src/main/res/layout/section_target_video_configuration.xml
+++ b/litr-demo/src/main/res/layout/section_target_video_configuration.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2019 LinkedIn Corporation -->
+<!-- All Rights Reserved. -->
+<!-- -->
+<!-- Licensed under the BSD 2-Clause License (the "License").  See License in the project root -->
+<!-- for license information. -->
+<layout xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <data>
+
+        <variable
+            name="sourceMedia"
+            type="com.linkedin.android.litr.demo.data.SourceMedia" />
+
+        <variable
+            name="targetVideoConfiguration"
+            type="com.linkedin.android.litr.demo.data.TargetVideoConfiguration" />
+    </data>
+
+    <LinearLayout
+        android:orientation="vertical"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/target_video"
+            android:padding="@dimen/cell_padding"
+            android:textStyle="bold"/>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal">
+
+            <TextView
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="@string/rotation"
+                android:paddingStart="@dimen/cell_padding"
+                android:paddingEnd="@dimen/cell_padding"/>
+
+            <Spinner
+                android:id="@+id/spinner_aspect_ratio"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:spinnerMode="dropdown"
+                android:entries="@array/rotation_array"
+                android:enabled="@{sourceMedia != null &amp;&amp; sourceMedia.uri != null}"
+                android:onItemSelected="@{(parent,view,pos,id)->targetVideoConfiguration.onRotationSelected(parent,view,pos,id)}"/>
+        </LinearLayout>
+
+    </LinearLayout>
+
+</layout>

--- a/litr-demo/src/main/res/values/strings.xml
+++ b/litr-demo/src/main/res/values/strings.xml
@@ -7,6 +7,7 @@
     <string name="app_name">LiTr</string>
 
     <string name="demo_case_transcode_video_gl">Transcode Video/Audio (GL Renderer)</string>
+    <string name="demo_case_free_transform_video_gl">Free Transform Video (GL Renderer)</string>
     <string name="demo_case_mock_transcode_video">Mock Transcode Video</string>
 
     <string name="include">Include</string>
@@ -24,6 +25,10 @@
 
     <string name="default_video_mime_type">video/avc</string>
 
+    <string name="target_video">Target Video</string>
+    <string name="aspect_ratio">Aspect Ratio</string>
+
+    <string name="pick_background">Pick Background</string>
     <string name="transcode">Transcode</string>
     <string name="cancel">Cancel</string>
 
@@ -108,5 +113,12 @@
     <string name="stats_decoder" formatted="true">Decoder: %s\n</string>
     <string name="stats_encoder" formatted="true">Encoder: %s\n</string>
     <string name="stats_transformation_duration" formatted="true">Transformation duration: %d ms\n</string>
+
+    <string-array name="rotation_array">
+        <item>0</item>
+        <item>90</item>
+        <item>180</item>
+        <item>270</item>
+    </string-array>
 
 </resources>

--- a/litr-filters/src/main/java/com/linkedin/android/litr/filter/video/gl/FreeTransformFrameRenderFilter.java
+++ b/litr-filters/src/main/java/com/linkedin/android/litr/filter/video/gl/FreeTransformFrameRenderFilter.java
@@ -1,0 +1,171 @@
+package com.linkedin.android.litr.filter.video.gl;
+
+import android.graphics.PointF;
+import android.opengl.GLES11Ext;
+import android.opengl.GLES20;
+import android.opengl.Matrix;
+
+import androidx.annotation.NonNull;
+
+import com.linkedin.android.litr.filter.GlFrameRenderFilter;
+import com.linkedin.android.litr.render.GlRenderUtils;
+
+/**
+ * Implementation of {@link GlFrameRenderFilter} which can transform (scale, rotate, translate)
+ * source video frame when rendering it onto targetVideoFrame
+ */
+public class FreeTransformFrameRenderFilter implements GlFrameRenderFilter {
+
+    // shaders
+    private static final String VERTEX_SHADER =
+            "uniform mat4 uMVPMatrix;\n" +
+                    "uniform mat4 uSTMatrix;\n" +
+                    "attribute vec4 aPosition;\n" +
+                    "attribute vec4 aTextureCoord;\n" +
+                    "varying vec2 vTextureCoord;\n" +
+                    "void main() {\n" +
+                    "  gl_Position = uMVPMatrix * aPosition;\n" +
+                    "  vTextureCoord = (uSTMatrix * aTextureCoord).xy;\n" +
+                    "}\n";
+    private static final String FRAGMENT_SHADER =
+            "#extension GL_OES_EGL_image_external : require\n" +
+                    "precision mediump float;\n" +      // highp here doesn't seem to matter
+                    "varying vec2 vTextureCoord;\n" +
+                    "uniform samplerExternalOES sTexture;\n" +
+                    "void main() {\n" +
+                    "  gl_FragColor = texture2D(sTexture, vTextureCoord);\n" +
+                    "}\n";
+
+    private float[] mvpMatrix = new float[16];
+    private float[] inputTextureTransformMatrix = new float[16];
+    private int mvpMatrixOffset;
+
+    private int glProgram;
+    private int mvpMatrixHandle;
+    private int uStMatrixHandle;
+    private int inputTextureId;
+
+    private final float videoRotation;
+    private final PointF position;
+    private final PointF size;
+    private final float rotation;
+
+    /**
+     * Create frame render filter with source video frame, then scale, then position and then rotate the bitmap around its center as specified.
+     * @param videoRotation rotation (orientation) of source video frame, usually in increments of 90 degrees
+     * @param size size in X and Y direction, relative to target video frame
+     * @param position position of source video frame  center, in relative coordinate in 0 - 1 range
+     *                 in fourth quadrant (0,0 is top left corner)
+     * @param rotation rotation angle of overlay, relative to target video frame, counter-clockwise, in degrees
+     */
+    public FreeTransformFrameRenderFilter(int videoRotation, @NonNull PointF size, @NonNull PointF position, float rotation) {
+        this.videoRotation = videoRotation;
+        this.size = size;
+        this.position = position;
+        this.rotation = rotation;
+    }
+
+    @Override
+    public void init(@NonNull float[] vpMatrix, int vpMatrixOffset) {
+        Matrix.setIdentityM(inputTextureTransformMatrix, 0);
+
+        // Let's use features of VP matrix to extract frame aspect ratio and orientation from it
+        // for 90 and 270 degree rotations (portrait orientation) top left element will be zero
+        boolean isPortraitVideo = vpMatrix[0] == 0;
+
+        // orthogonal projection matrix is basically a scaling matrix, which scales along X axis.
+        // 0 and 180 degree rotations keep the scaling factor in top left element (they don't move it)
+        // 90 and 270 degree rotations move it to one position right in top row
+        // Inverting scaling factor gives us the aspect ratio.
+        // Scale can be negative if video is flipped, so we use absolute value.
+        float videoAspectRatio;
+        if (isPortraitVideo) {
+            videoAspectRatio = 1 / Math.abs(vpMatrix[4]);
+        } else {
+            videoAspectRatio = 1 / Math.abs(vpMatrix[0]);
+        }
+
+        // Size is respective to video frame, and frame will later be scaled by perspective and view matrices.
+        // So we have to adjust the scale accordingly.
+        float scaleX;
+        float scaleY;
+        if (isPortraitVideo) {
+            scaleX = size.x;
+            scaleY = size.y * videoAspectRatio;
+        } else {
+            scaleX = size.x * videoAspectRatio;
+            scaleY = size.y;
+        }
+
+        // Position values are in relative (0, 1) range, which means they have to be mapped from (-1, 1) range
+        // and adjusted for aspect ratio.
+        float translateX;
+        float translateY;
+        if (isPortraitVideo) {
+            translateX = position.x * 2 - 1;
+            translateY = (1 - position.y * 2) * videoAspectRatio;
+        } else {
+            translateX = (position.x * 2 - 1) * videoAspectRatio;
+            translateY = 1 - position.y * 2;
+        }
+
+        // Matrix operations in OpenGL are done in reverse.
+        // First, we have to rotate the video into correct orientation (portrait/landscape)
+        // Then, we scale (and flip vertically) first, then rotate
+        // around the center, and then translate into desired position.
+        float[] modelMatrix = new float[16];
+        Matrix.setIdentityM(modelMatrix, 0);
+        Matrix.translateM(modelMatrix, 0, translateX, translateY, 0);
+        Matrix.rotateM(modelMatrix, 0, rotation, 0, 0, 1);
+        Matrix.scaleM(modelMatrix, 0, scaleX, -scaleY, 1);
+        Matrix.rotateM(modelMatrix, 0, videoRotation, 0, 0, 1);
+
+        // last, we multiply the model matrix by the view matrix to get final MVP matrix for an overlay
+        mvpMatrix = new float[16];
+        mvpMatrixOffset = vpMatrixOffset;
+        Matrix.multiplyMM(this.mvpMatrix, this.mvpMatrixOffset, vpMatrix, 0, modelMatrix, 0);
+
+        initGl();
+    }
+
+    @Override
+    public void initInputFrameTexture(int textureId, @NonNull float[] transformMatrix) {
+        inputTextureId = textureId;
+        inputTextureTransformMatrix = transformMatrix;
+    }
+
+    @Override
+    public void apply(long presentationTimeNs) {
+        GlRenderUtils.checkGlError("onDrawFrame start");
+        GLES20.glUseProgram(glProgram);
+        GlRenderUtils.checkGlError("glUseProgram");
+        GLES20.glActiveTexture(GLES20.GL_TEXTURE0);
+        GLES20.glBindTexture(GLES11Ext.GL_TEXTURE_EXTERNAL_OES, inputTextureId);
+
+        GLES20.glUniformMatrix4fv(mvpMatrixHandle, 1, false, mvpMatrix, mvpMatrixOffset);
+        GLES20.glUniformMatrix4fv(uStMatrixHandle, 1, false, inputTextureTransformMatrix, 0);
+
+        GLES20.glDrawArrays(GLES20.GL_TRIANGLE_STRIP, 0, 4);
+        GlRenderUtils.checkGlError("glDrawArrays");
+    }
+
+    /**
+     * Initializes GL state.  Call this after the EGL surface has been created and made current.
+     */
+    private void initGl() {
+        glProgram = GlRenderUtils.createProgram(VERTEX_SHADER, FRAGMENT_SHADER);
+        if (glProgram == 0) {
+            throw new RuntimeException("failed creating glProgram");
+        }
+        mvpMatrixHandle = GLES20.glGetUniformLocation(glProgram, "uMVPMatrix");
+        GlRenderUtils.checkGlError("glGetUniformLocation uMVPMatrix");
+        if (mvpMatrixHandle == -1) {
+            throw new RuntimeException("Could not get attrib location for uMVPMatrix");
+        }
+        uStMatrixHandle = GLES20.glGetUniformLocation(glProgram, "uSTMatrix");
+        GlRenderUtils.checkGlError("glGetUniformLocation uSTMatrix");
+        if (uStMatrixHandle == -1) {
+            throw new RuntimeException("Could not get attrib location for uSTMatrix");
+        }
+    }
+}

--- a/litr/src/main/java/com/linkedin/android/litr/render/GlVideoRenderer.java
+++ b/litr/src/main/java/com/linkedin/android/litr/render/GlVideoRenderer.java
@@ -135,9 +135,11 @@ public class GlVideoRenderer implements Renderer {
                 .order(ByteOrder.nativeOrder()).asFloatBuffer();
         triangleVertices.put(triangleVerticesData).position(0);
 
-        // clear the rotation flag, we don't want any auto-rotation issues
+        // prioritize target video rotation value, fall back to source video rotation value
         int rotation = 0;
-        if (sourceMediaFormat != null && sourceMediaFormat.containsKey(KEY_ROTATION)) {
+        if (targetMediaFormat.containsKey(KEY_ROTATION)) {
+            rotation = targetMediaFormat.getInteger(KEY_ROTATION);
+        } else if (sourceMediaFormat != null && sourceMediaFormat.containsKey(KEY_ROTATION)) {
             rotation = sourceMediaFormat.getInteger(KEY_ROTATION);
         }
         float aspectRatio = 1;


### PR DESCRIPTION
A frame render filter, which supports geometric transformation of a source video frame when rendering it onto a target video frame:
 - since source and target video orientations no longer match, client must pass in target video orientation when using this renderer, if orientations don't match
 - scaling/rotating/positioning logic works pretty much the same way as for bitmap overlays. Except now we have to know orientation of a source video to display it correctly. 
 - new demo fragment allows experimenting with different setups: target video orientation, transform parameters, etc.