### PR TITLE
Initialize input surface texture matrix correctly.

### DIFF
--- a/litr-demo/src/main/java/com/linkedin/android/litr/demo/data/TransformationPresenter.java
+++ b/litr-demo/src/main/java/com/linkedin/android/litr/demo/data/TransformationPresenter.java
@@ -141,14 +141,6 @@ public class TransformationPresenter {
                 transformationState);
 
         try {
-            int videoRotation = 0;
-            for (MediaTrackFormat trackFormat : sourceMedia.tracks) {
-                if (trackFormat.mimeType.startsWith("video")) {
-                    videoRotation = ((VideoTrackFormat) trackFormat).rotation;
-                    break;
-                }
-            }
-
             MediaTarget mediaTarget = new MediaMuxerMediaTarget(targetMedia.targetFile.getPath(),
                     targetMedia.getIncludedTrackCount(),
                     targetVideoConfiguration.rotation,
@@ -184,7 +176,7 @@ public class TransformationPresenter {
                         filters.add(backgroundImageFilter);
                     }
 
-                    GlFrameRenderFilter frameRenderFilter = new FreeTransformFrameRenderFilter(videoRotation, new PointF(0.3164f, 1.0f), new PointF(0.5f, 0.5f), 0);
+                    GlFrameRenderFilter frameRenderFilter = new FreeTransformFrameRenderFilter(new PointF(0.25f, 0.25f), new PointF(0.65f, 0.55f), 30);
                     filters.add(frameRenderFilter);
 
                     trackTransformBuilder.setRenderer(new GlVideoRenderer(filters));

--- a/litr-filters/src/main/java/com/linkedin/android/litr/filter/video/gl/FreeTransformFrameRenderFilter.java
+++ b/litr-filters/src/main/java/com/linkedin/android/litr/filter/video/gl/FreeTransformFrameRenderFilter.java
@@ -45,10 +45,22 @@ public class FreeTransformFrameRenderFilter implements GlFrameRenderFilter {
     private int uStMatrixHandle;
     private int inputTextureId;
 
-    private final float videoRotation;
     private final PointF position;
     private final PointF size;
     private final float rotation;
+
+    /**
+     * Create frame render filter with source video frame, then scale, then position and then rotate the bitmap around its center as specified.
+     * @param size size in X and Y direction, relative to target video frame
+     * @param position position of source video frame  center, in relative coordinate in 0 - 1 range
+     *                 in fourth quadrant (0,0 is top left corner)
+     * @param rotation rotation angle of overlay, relative to target video frame, counter-clockwise, in degrees
+     */
+    public FreeTransformFrameRenderFilter(@NonNull PointF size, @NonNull PointF position, float rotation) {
+        this.size = size;
+        this.position = position;
+        this.rotation = rotation;
+    }
 
     /**
      * Create frame render filter with source video frame, then scale, then position and then rotate the bitmap around its center as specified.
@@ -57,9 +69,10 @@ public class FreeTransformFrameRenderFilter implements GlFrameRenderFilter {
      * @param position position of source video frame  center, in relative coordinate in 0 - 1 range
      *                 in fourth quadrant (0,0 is top left corner)
      * @param rotation rotation angle of overlay, relative to target video frame, counter-clockwise, in degrees
+     * @deprecated use FreeTransformFrameRenderFilter(PointF, PointF, float)
      */
+    @Deprecated
     public FreeTransformFrameRenderFilter(int videoRotation, @NonNull PointF size, @NonNull PointF position, float rotation) {
-        this.videoRotation = videoRotation;
         this.size = size;
         this.position = position;
         this.rotation = rotation;
@@ -117,8 +130,7 @@ public class FreeTransformFrameRenderFilter implements GlFrameRenderFilter {
         Matrix.setIdentityM(modelMatrix, 0);
         Matrix.translateM(modelMatrix, 0, translateX, translateY, 0);
         Matrix.rotateM(modelMatrix, 0, rotation, 0, 0, 1);
-        Matrix.scaleM(modelMatrix, 0, scaleX, -scaleY, 1);
-        Matrix.rotateM(modelMatrix, 0, videoRotation, 0, 0, 1);
+        Matrix.scaleM(modelMatrix, 0, scaleX, scaleY, 1);
 
         // last, we multiply the model matrix by the view matrix to get final MVP matrix for an overlay
         mvpMatrix = new float[16];

--- a/litr/src/main/java/com/linkedin/android/litr/filter/video/gl/ScaleToFitGlFrameRenderFilter.java
+++ b/litr/src/main/java/com/linkedin/android/litr/filter/video/gl/ScaleToFitGlFrameRenderFilter.java
@@ -65,22 +65,18 @@ public class ScaleToFitGlFrameRenderFilter implements GlFrameRenderFilter {
 
         mvpMatrix = vpMatrix;
 
-        // Let's use features of VP matrix to extract frame aspect ratio and orientation from it
-        // and scale/rotate source video frame to match the size/orientation of target video frame
+        // Let's use features of VP matrix to extract frame aspect ratio from it
+        // and scale source video frame to match the size of target video frame
         float videoAspectRatio;
-        float videoRotation;
         if (vpMatrix[0] == 0) {
             // portrait video
             videoAspectRatio = 1 / Math.abs(vpMatrix[4]);
-            videoRotation = vpMatrix[4] > 0 ? 270 : 90;
-            Matrix.scaleM(mvpMatrix, 0, 1, -videoAspectRatio, 1);
+            Matrix.scaleM(mvpMatrix, 0, 1, videoAspectRatio, 1);
         } else {
             // landscape video
             videoAspectRatio = 1 / Math.abs(vpMatrix[0]);
-            videoRotation = vpMatrix[0] > 0 ? 0 : 180;
-            Matrix.scaleM(mvpMatrix, 0, videoAspectRatio, -1, 1);
+            Matrix.scaleM(mvpMatrix, 0, videoAspectRatio, 1, 1);
         }
-        Matrix.rotateM(mvpMatrix, vpMatrixOffset, videoRotation, 0, 0, 1);
 
         initGl();
     }

--- a/litr/src/main/java/com/linkedin/android/litr/render/GlVideoRenderer.java
+++ b/litr/src/main/java/com/linkedin/android/litr/render/GlVideoRenderer.java
@@ -94,6 +94,8 @@ public class GlVideoRenderer implements Renderer {
     private int aPositionHandle;
     private int aTextureHandle;
 
+    private boolean inputSurfaceTextureInitialized;
+
     /**
      * Create an instance of GlVideoRenderer. If filter list has a {@link GlFrameRenderFilter}, that filter
      * will be used to render video frames. Otherwise, default {@link ScaleToFitGlFrameRenderFilter}
@@ -155,9 +157,6 @@ public class GlVideoRenderer implements Renderer {
 
         for (GlFilter filter : filters) {
             filter.init(Arrays.copyOf(mvpMatrix, mvpMatrix.length), 0);
-            if (filter instanceof GlFrameRenderFilter) {
-                ((GlFrameRenderFilter) filter).initInputFrameTexture(inputSurface.getTextureId(), inputSurface.getTransformMatrix());
-            }
         }
     }
 
@@ -193,6 +192,8 @@ public class GlVideoRenderer implements Renderer {
      * Draws the data from SurfaceTexture onto the current EGL surface.
      */
     private void drawFrame(long presentationTimeNs) {
+        initInputSurfaceTexture();
+
         GLES20.glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
         GLES20.glClear(GLES20.GL_DEPTH_BUFFER_BIT | GLES20.GL_COLOR_BUFFER_BIT);
 
@@ -275,6 +276,17 @@ public class GlVideoRenderer implements Renderer {
         GlRenderUtils.checkGlError("glGetAttribLocation aTextureCoord");
         if (aTextureHandle == -1) {
             throw new RuntimeException("Could not get attrib location for aTextureCoord");
+        }
+    }
+
+    private void initInputSurfaceTexture() {
+        if (!inputSurfaceTextureInitialized) {
+            for (GlFilter filter : filters) {
+                if (filter instanceof GlFrameRenderFilter) {
+                    ((GlFrameRenderFilter) filter).initInputFrameTexture(inputSurface.getTextureId(), inputSurface.getTransformMatrix());
+                }
+            }
+            inputSurfaceTextureInitialized = true;
         }
     }
 }


### PR DESCRIPTION
Texture matrix for input surface was not initialized correctly when it was just created and then queried to initialize frame renderer filters. It was identity matrix at that point. It is initialized correctly later, when we actually start drawing. Performing single time initialization on a first draw now. 
This now rotates/scales video frames correctly within the target rectangle, so we no longer have to adjust for rotation/scaling in MVP matrix. Removing that logic.