### PR TITLE
Implementation of PassthroughSoftwareRenderer

### DIFF
--- a/litr/src/main/java/com/linkedin/android/litr/render/PassthroughSoftwareRenderer.java
+++ b/litr/src/main/java/com/linkedin/android/litr/render/PassthroughSoftwareRenderer.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2019 LinkedIn Corporation
+ * All Rights Reserved.
+ *
+ * Licensed under the BSD 2-Clause License (the "License").  See License in the project root for
+ * license information.
+ */
+package com.linkedin.android.litr.render;
+
+import android.media.MediaCodec;
+import android.media.MediaFormat;
+import android.util.Log;
+import android.view.Surface;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
+
+import com.linkedin.android.litr.codec.Encoder;
+import com.linkedin.android.litr.codec.Frame;
+
+import java.nio.ByteBuffer;
+import java.util.concurrent.TimeUnit;
+
+public class PassthroughSoftwareRenderer implements Renderer {
+
+    @VisibleForTesting static final long FRAME_WAIT_TIMEOUT = TimeUnit.SECONDS.toMicros(10);
+
+    private static final String TAG = "PassthroughSwRenderer";
+
+    @NonNull public final Encoder encoder;
+
+    public PassthroughSoftwareRenderer(@NonNull Encoder encoder) {
+        this.encoder = encoder;
+    }
+
+    @Override
+    public void init(@Nullable Surface outputSurface, @Nullable MediaFormat sourceMediaFormat, @Nullable MediaFormat targetMediaFormat) {}
+
+    @Nullable
+    @Override
+    public Surface getInputSurface() {
+        return null;
+    }
+
+    @Override
+    public void renderFrame(@Nullable Frame frame, long presentationTimeNs) {
+        if (frame == null || frame.buffer == null) {
+            Log.e(TAG, "Null or empty input frame provided");
+            return;
+        }
+        int tag = encoder.dequeueInputFrame(FRAME_WAIT_TIMEOUT);
+        if (tag >= 0) {
+            Frame outputFrame = encoder.getInputFrame(tag);
+            if (outputFrame == null) {
+                Log.e(TAG, "No input frame returned by an encoder, dropping a frame");
+                return;
+            }
+
+            ByteBuffer inputBuffer = frame.buffer.asReadOnlyBuffer();
+            inputBuffer.rewind();
+            outputFrame.buffer.put(inputBuffer);
+
+            outputFrame.bufferInfo.set(
+                    0,
+                    frame.bufferInfo.size,
+                    frame.bufferInfo.presentationTimeUs,
+                    frame.bufferInfo.flags);
+            encoder.queueInputFrame(outputFrame);
+        } else {
+            switch (tag) {
+                case MediaCodec.INFO_TRY_AGAIN_LATER:
+                    Log.e(TAG, "Encoder input frame timeout, dropping a frame");
+                    break;
+                default:
+                    Log.e(TAG, "Unhandled value " + tag + " when receiving decoded input frame");
+                    break;
+            }
+        }
+    }
+
+    @Override
+    public void release() {}
+
+    @Override
+    public boolean hasFilters() {
+        return false;
+    }
+}

--- a/litr/src/main/java/com/linkedin/android/litr/transcoder/PassthroughTranscoder.java
+++ b/litr/src/main/java/com/linkedin/android/litr/transcoder/PassthroughTranscoder.java
@@ -37,7 +37,7 @@ public class PassthroughTranscoder extends TrackTranscoder {
                           int sourceTrack,
                           @NonNull MediaTarget mediaTarget,
                           int targetTrack) {
-        super(mediaSource, sourceTrack, mediaTarget, targetTrack, null, null, null);
+        super(mediaSource, sourceTrack, mediaTarget, targetTrack, null, null, null, null);
     }
 
     @Override

--- a/litr/src/main/java/com/linkedin/android/litr/transcoder/TrackTranscoder.java
+++ b/litr/src/main/java/com/linkedin/android/litr/transcoder/TrackTranscoder.java
@@ -16,6 +16,7 @@ import com.linkedin.android.litr.codec.Encoder;
 import com.linkedin.android.litr.exception.TrackTranscoderException;
 import com.linkedin.android.litr.io.MediaSource;
 import com.linkedin.android.litr.io.MediaTarget;
+import com.linkedin.android.litr.render.Renderer;
 
 @RestrictTo(RestrictTo.Scope.LIBRARY)
 public abstract class TrackTranscoder {
@@ -30,6 +31,7 @@ public abstract class TrackTranscoder {
 
     @NonNull protected final MediaSource mediaSource;
     @NonNull protected final MediaTarget mediaMuxer;
+    @Nullable protected final Renderer renderer;
     @Nullable protected final Decoder decoder;
     @Nullable protected final Encoder encoder;
 
@@ -48,6 +50,7 @@ public abstract class TrackTranscoder {
                     @NonNull MediaTarget mediaTarget,
                     int targetTrack,
                     @Nullable MediaFormat targetFormat,
+                    @Nullable Renderer renderer,
                     @Nullable Decoder decoder,
                     @Nullable Encoder encoder) {
         this.mediaSource = mediaSource;
@@ -55,6 +58,7 @@ public abstract class TrackTranscoder {
         this.targetTrack = targetTrack;
         this.mediaMuxer = mediaTarget;
         this.targetFormat = targetFormat;
+        this.renderer = renderer;
         this.decoder = decoder;
         this.encoder = encoder;
 

--- a/litr/src/main/java/com/linkedin/android/litr/transcoder/TrackTranscoderFactory.java
+++ b/litr/src/main/java/com/linkedin/android/litr/transcoder/TrackTranscoderFactory.java
@@ -20,6 +20,8 @@ import com.linkedin.android.litr.codec.MediaCodecEncoder;
 import com.linkedin.android.litr.exception.TrackTranscoderException;
 import com.linkedin.android.litr.io.MediaSource;
 import com.linkedin.android.litr.io.MediaTarget;
+import com.linkedin.android.litr.render.GlVideoRenderer;
+import com.linkedin.android.litr.render.PassthroughSoftwareRenderer;
 import com.linkedin.android.litr.render.Renderer;
 
 @RestrictTo(RestrictTo.Scope.LIBRARY)
@@ -84,13 +86,20 @@ public class TrackTranscoderFactory {
                                             decoder,
                                             encoder);
         } else if (trackMimeType.startsWith("audio")) {
+            Decoder audioDecoder = new MediaCodecDecoder();
+            Encoder audioEncoder = new MediaCodecEncoder();
+            Renderer audioRenderer = renderer == null
+                    ? new PassthroughSoftwareRenderer(audioEncoder)
+                    : renderer;
+
             return new AudioTrackTranscoder(mediaSource,
                                             sourceTrack,
                                             mediaTarget,
                                             targetTrack,
                                             targetFormat,
-                                            new MediaCodecDecoder(),
-                                            new MediaCodecEncoder());
+                                            audioRenderer,
+                                            audioDecoder,
+                                            audioEncoder);
         } else {
             Log.i(TAG, "Unsupported track mime type: " + trackMimeType + ", will use passthrough transcoder");
             return new PassthroughTranscoder(mediaSource, sourceTrack, mediaTarget, targetTrack);

--- a/litr/src/main/java/com/linkedin/android/litr/transcoder/VideoTrackTranscoder.java
+++ b/litr/src/main/java/com/linkedin/android/litr/transcoder/VideoTrackTranscoder.java
@@ -48,7 +48,7 @@ public class VideoTrackTranscoder extends TrackTranscoder {
                          @NonNull Renderer renderer,
                          @NonNull Decoder decoder,
                          @NonNull Encoder encoder) throws TrackTranscoderException {
-        super(mediaSource, sourceTrack, mediaTarget, targetTrack, targetFormat, decoder, encoder);
+        super(mediaSource, sourceTrack, mediaTarget, targetTrack, targetFormat, renderer, decoder, encoder);
 
         lastExtractFrameResult = RESULT_FRAME_PROCESSED;
         lastDecodeFrameResult = RESULT_FRAME_PROCESSED;

--- a/litr/src/test/java/com/linkedin/android/litr/render/PassthroughSoftwareRendererShould.java
+++ b/litr/src/test/java/com/linkedin/android/litr/render/PassthroughSoftwareRendererShould.java
@@ -1,0 +1,120 @@
+package com.linkedin.android.litr.render;
+
+import android.media.MediaCodec;
+
+import com.linkedin.android.litr.codec.Encoder;
+import com.linkedin.android.litr.codec.Frame;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.nio.ByteBuffer;
+
+import static com.linkedin.android.litr.render.PassthroughSoftwareRenderer.FRAME_WAIT_TIMEOUT;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertNull;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class PassthroughSoftwareRendererShould {
+
+    private static final long FRAME_PRESENTATION_TIME = 42L;
+    private static final int FRAME_TAG = 1;
+    private static final int FRAME_SIZE = 128;
+    private static final int FRAME_OFFSET = 0;
+
+    @Mock private Encoder encoder;
+
+    private PassthroughSoftwareRenderer renderer;
+
+    private Frame frame;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+
+        MediaCodec.BufferInfo bufferInfo = new MediaCodec.BufferInfo();
+        bufferInfo.set(FRAME_OFFSET, FRAME_SIZE, FRAME_PRESENTATION_TIME, 0);
+
+        ByteBuffer inputBuffer = ByteBuffer.allocate(FRAME_SIZE);
+        for (int index = 0; index < FRAME_SIZE; index++) {
+            inputBuffer.put((byte) index);
+        }
+
+        frame = new Frame(
+                0,
+                inputBuffer,
+                bufferInfo);
+
+        renderer = new PassthroughSoftwareRenderer(encoder);
+    }
+
+    @Test
+    public void notUseInputSurface() {
+        assertNull(renderer.getInputSurface());
+    }
+
+    @Test
+    public void notRenderWhenNoFrameProvided() {
+        renderer.renderFrame(null, FRAME_PRESENTATION_TIME);
+
+        verify(encoder, never()).dequeueInputFrame(anyLong());
+    }
+
+    @Test
+    public void notRenderWhenFrameHasNullBuffer() {
+        Frame frame = new Frame(0, null, null);
+
+        renderer.renderFrame(frame, FRAME_PRESENTATION_TIME);
+
+        verify(encoder, never()).dequeueInputFrame(anyLong());
+    }
+
+    @Test
+    public void dropFrameWhenCannotQueueToEncoder() {
+        when(encoder.dequeueInputFrame(FRAME_WAIT_TIMEOUT)).thenReturn(MediaCodec.INFO_TRY_AGAIN_LATER);
+
+        renderer.renderFrame(frame, FRAME_PRESENTATION_TIME);
+
+        verify(encoder, never()).getInputFrame(anyInt());
+    }
+
+    @Test
+    public void notRenderWhenEncoderReturnsNullInputFrame() {
+        when(encoder.dequeueInputFrame(FRAME_WAIT_TIMEOUT)).thenReturn(FRAME_TAG);
+        when(encoder.getInputFrame(FRAME_TAG)).thenReturn(null);
+
+        renderer.renderFrame(frame, FRAME_PRESENTATION_TIME);
+
+        verify(encoder, never()).queueInputFrame(frame);
+    }
+
+    @Test
+    public void renderWhenEncoderAcceptsFrames() {
+        int encoderFrameTag = 2;
+        ByteBuffer encoderInputBuffer = ByteBuffer.allocate(FRAME_SIZE);
+        MediaCodec.BufferInfo encoderBufferInfo = new MediaCodec.BufferInfo();
+        Frame encoderInputFrame = new Frame(encoderFrameTag, encoderInputBuffer, encoderBufferInfo);
+
+        when(encoder.dequeueInputFrame(FRAME_WAIT_TIMEOUT)).thenReturn(FRAME_TAG);
+        when(encoder.getInputFrame(FRAME_TAG)).thenReturn(encoderInputFrame);
+
+        renderer.renderFrame(frame, FRAME_PRESENTATION_TIME);
+
+        verify(encoder).queueInputFrame(encoderInputFrame);
+        assertThat(encoderInputFrame.bufferInfo.flags, is(frame.bufferInfo.flags));
+        assertThat(encoderInputFrame.bufferInfo.presentationTimeUs, is(frame.bufferInfo.presentationTimeUs));
+        assertThat(encoderInputFrame.bufferInfo.offset, is(0));
+        assertThat(encoderInputFrame.bufferInfo.size, is(frame.bufferInfo.size));
+
+        for (int index = 0; index < FRAME_SIZE; index++) {
+            assertThat(frame.buffer.get(index), is(encoderInputBuffer.get(index)));
+        }
+    }
+}


### PR DESCRIPTION
Factoring out "rendering" logic in AudioTrackTranscoder into a separate PassthroughSoftwareRenderer, which simply copies decoder output buffer into encoder input buffer. Renderer is "synchronous" - when it is asked to render, it waits for encoder to dequeue an input buffer, then fills it with input frame data and releases back to encoder. If wait times out, buffer is dropped, similar to video GL renderer.