### PR TITLE
Pick highest supported codec profile

### DIFF
--- a/litr-demo/src/main/java/com/linkedin/android/litr/demo/data/TransformationPresenter.java
+++ b/litr-demo/src/main/java/com/linkedin/android/litr/demo/data/TransformationPresenter.java
@@ -35,6 +35,7 @@ import com.linkedin.android.litr.io.MediaMuxerMediaTarget;
 import com.linkedin.android.litr.io.MediaSource;
 import com.linkedin.android.litr.io.MediaTarget;
 import com.linkedin.android.litr.render.GlVideoRenderer;
+import com.linkedin.android.litr.utils.CodecUtils;
 import com.linkedin.android.litr.utils.TransformationUtil;
 
 import java.io.File;
@@ -321,12 +322,19 @@ public class TransformationPresenter {
             mediaFormat = new MediaFormat();
             if (targetTrack.format.mimeType.startsWith("video")) {
                 VideoTrackFormat trackFormat = (VideoTrackFormat) targetTrack.format;
-                mediaFormat.setString(MediaFormat.KEY_MIME, "video/avc");
+                String mimeType = CodecUtils.MIME_TYPE_VIDEO_AVC;
+                mediaFormat.setString(MediaFormat.KEY_MIME, mimeType);
                 mediaFormat.setInteger(MediaFormat.KEY_WIDTH, trackFormat.width);
                 mediaFormat.setInteger(MediaFormat.KEY_HEIGHT, trackFormat.height);
                 mediaFormat.setInteger(MediaFormat.KEY_BIT_RATE, trackFormat.bitrate);
                 mediaFormat.setInteger(MediaFormat.KEY_I_FRAME_INTERVAL, trackFormat.keyFrameInterval);
                 mediaFormat.setInteger(MediaFormat.KEY_FRAME_RATE, trackFormat.frameRate);
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                    int codecProfile = CodecUtils.getHighestSupportedProfile(mimeType, true);
+                    if (codecProfile != CodecUtils.UNDEFINED_VALUE) {
+                        mediaFormat.setInteger(MediaFormat.KEY_PROFILE, codecProfile);
+                    }
+                }
             } else if (targetTrack.format.mimeType.startsWith("audio")) {
                 AudioTrackFormat trackFormat = (AudioTrackFormat) targetTrack.format;
                 mediaFormat.setString(MediaFormat.KEY_MIME, trackFormat.mimeType);

--- a/litr/src/main/java/com/linkedin/android/litr/MediaTransformer.java
+++ b/litr/src/main/java/com/linkedin/android/litr/MediaTransformer.java
@@ -11,6 +11,7 @@ import android.content.Context;
 import android.media.MediaFormat;
 import android.media.MediaMuxer;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Looper;
 import android.util.Log;
 import androidx.annotation.IntRange;
@@ -29,6 +30,7 @@ import com.linkedin.android.litr.io.MediaSource;
 import com.linkedin.android.litr.io.MediaTarget;
 import com.linkedin.android.litr.render.GlVideoRenderer;
 import com.linkedin.android.litr.render.Renderer;
+import com.linkedin.android.litr.utils.CodecUtils;
 import com.linkedin.android.litr.utils.TranscoderUtils;
 
 import java.util.ArrayList;
@@ -316,6 +318,21 @@ public class MediaTransformer {
                     targetKeyFrameInterval = sourceMediaFormat.getInteger(MediaFormat.KEY_I_FRAME_INTERVAL);
                 }
                 targetMediaFormat.setInteger(MediaFormat.KEY_I_FRAME_INTERVAL, targetKeyFrameInterval);
+
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP
+                        && sourceMediaFormat.containsKey(MediaFormat.KEY_PROFILE)
+                        && sourceMediaFormat.containsKey(MediaFormat.KEY_MIME)) {
+                    int sourceCodecProfile = sourceMediaFormat.getInteger(MediaFormat.KEY_PROFILE);
+
+                    int targetCodecProfile = CodecUtils.getHighestSupportedProfile(
+                            targetMediaFormat.getString(MediaFormat.KEY_MIME),
+                            true,
+                            sourceCodecProfile);
+
+                    if (targetCodecProfile != CodecUtils.UNDEFINED_VALUE) {
+                        targetMediaFormat.setInteger(MediaFormat.KEY_PROFILE, targetCodecProfile);
+                    }
+                }
             } else if (mimeType.startsWith("audio")) {
                 targetMediaFormat = MediaFormat.createAudioFormat(mimeType,
                                                                   sourceMediaFormat.getInteger(MediaFormat.KEY_SAMPLE_RATE),

--- a/litr/src/main/java/com/linkedin/android/litr/utils/CodecUtils.java
+++ b/litr/src/main/java/com/linkedin/android/litr/utils/CodecUtils.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright 2019 LinkedIn Corporation
+ * All Rights Reserved.
+ *
+ * Licensed under the BSD 2-Clause License (the "License").  See License in the project root for
+ * license information.
+ */
+package com.linkedin.android.litr.utils;
+
+import android.media.MediaCodecInfo;
+import android.media.MediaCodecList;
+import android.os.Build;
+import android.text.TextUtils;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.RequiresApi;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class CodecUtils {
+
+    public static final int UNDEFINED_VALUE = -1;
+
+    public static final String MIME_TYPE_VIDEO_AV1 = "video/av01";
+    public static final String MIME_TYPE_VIDEO_AVC = "video/avc";
+    public static final String MIME_TYPE_VIDEO_HEVC = "video/hevc";
+    public static final String MIME_TYPE_VIDEO_VP8 = "video/x-vnd.on2.vp8";
+    public static final String MIME_TYPE_VIDEO_VP9 = "video/x-vnd.on2.vp9";
+
+    private static Map<String, int[]> CODEC_PROFILE_RANK_MAP = new HashMap<>();
+
+    static {
+        int[] avcProfileRanks = Build.VERSION.SDK_INT >= Build.VERSION_CODES.O_MR1
+                ?  new int[] {
+                    MediaCodecInfo.CodecProfileLevel.AVCProfileConstrainedBaseline,
+                    MediaCodecInfo.CodecProfileLevel.AVCProfileBaseline,
+                    MediaCodecInfo.CodecProfileLevel.AVCProfileExtended,
+                    MediaCodecInfo.CodecProfileLevel.AVCProfileMain,
+                    MediaCodecInfo.CodecProfileLevel.AVCProfileConstrainedHigh,
+                    MediaCodecInfo.CodecProfileLevel.AVCProfileHigh,
+                    MediaCodecInfo.CodecProfileLevel.AVCProfileHigh10,
+                    MediaCodecInfo.CodecProfileLevel.AVCProfileHigh422,
+                    MediaCodecInfo.CodecProfileLevel.AVCProfileHigh444}
+                :  new int[] {
+                    MediaCodecInfo.CodecProfileLevel.AVCProfileBaseline,
+                    MediaCodecInfo.CodecProfileLevel.AVCProfileExtended,
+                    MediaCodecInfo.CodecProfileLevel.AVCProfileMain,
+                    MediaCodecInfo.CodecProfileLevel.AVCProfileHigh,
+                    MediaCodecInfo.CodecProfileLevel.AVCProfileHigh10,
+                    MediaCodecInfo.CodecProfileLevel.AVCProfileHigh422,
+                    MediaCodecInfo.CodecProfileLevel.AVCProfileHigh444};
+        CODEC_PROFILE_RANK_MAP.put(MIME_TYPE_VIDEO_AVC, avcProfileRanks);
+
+        int[] vp8ProfileRanks = new int[] {
+                MediaCodecInfo.CodecProfileLevel.VP8ProfileMain
+        };
+        CODEC_PROFILE_RANK_MAP.put(MIME_TYPE_VIDEO_VP8, vp8ProfileRanks);
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            int[] hevcProfileRanks = Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q
+                    ? new int[] {
+                            MediaCodecInfo.CodecProfileLevel.HEVCProfileMain,
+                            MediaCodecInfo.CodecProfileLevel.HEVCProfileMain10,
+                            MediaCodecInfo.CodecProfileLevel.HEVCProfileMain10HDR10,
+                            MediaCodecInfo.CodecProfileLevel.HEVCProfileMain10HDR10Plus}
+                    : Build.VERSION.SDK_INT >= Build.VERSION_CODES.N
+                            ? new int[] {
+                                MediaCodecInfo.CodecProfileLevel.HEVCProfileMain,
+                                MediaCodecInfo.CodecProfileLevel.HEVCProfileMain10,
+                                MediaCodecInfo.CodecProfileLevel.HEVCProfileMain10HDR10}
+                            : new int[] {
+                                MediaCodecInfo.CodecProfileLevel.HEVCProfileMain,
+                                MediaCodecInfo.CodecProfileLevel.HEVCProfileMain10};
+            CODEC_PROFILE_RANK_MAP.put(MIME_TYPE_VIDEO_HEVC, hevcProfileRanks);
+        }
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            int[] vp9ProfileRanks = Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q
+                    ? new int[] {
+                            MediaCodecInfo.CodecProfileLevel.VP9Profile0,
+                            MediaCodecInfo.CodecProfileLevel.VP9Profile1,
+                            MediaCodecInfo.CodecProfileLevel.VP9Profile2,
+                            MediaCodecInfo.CodecProfileLevel.VP9Profile2HDR,
+                            MediaCodecInfo.CodecProfileLevel.VP9Profile2HDR10Plus,
+                            MediaCodecInfo.CodecProfileLevel.VP9Profile3,
+                            MediaCodecInfo.CodecProfileLevel.VP9Profile3HDR,
+                            MediaCodecInfo.CodecProfileLevel.VP9Profile3HDR10Plus}
+                    : new int[] {
+                        MediaCodecInfo.CodecProfileLevel.VP9Profile0,
+                        MediaCodecInfo.CodecProfileLevel.VP9Profile1,
+                        MediaCodecInfo.CodecProfileLevel.VP9Profile2,
+                        MediaCodecInfo.CodecProfileLevel.VP9Profile2HDR,
+                        MediaCodecInfo.CodecProfileLevel.VP9Profile3,
+                        MediaCodecInfo.CodecProfileLevel.VP9Profile3HDR};
+            CODEC_PROFILE_RANK_MAP.put(MIME_TYPE_VIDEO_VP9, vp9ProfileRanks);
+        }
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            int[] av1ProfileRanks = new int[] {
+                    MediaCodecInfo.CodecProfileLevel.AV1ProfileMain8,
+                    MediaCodecInfo.CodecProfileLevel.AV1ProfileMain10,
+                    MediaCodecInfo.CodecProfileLevel.AV1ProfileMain10HDR10,
+                    MediaCodecInfo.CodecProfileLevel.AV1ProfileMain10HDR10Plus
+            };
+            CODEC_PROFILE_RANK_MAP.put(MIME_TYPE_VIDEO_AV1, av1ProfileRanks);
+        }
+    }
+
+    private CodecUtils() {}
+
+    /**
+     * Attempts to find highest supported codec profile for a given MIME type. Iterates through all codecs available,
+     * filters for codecs that support provided MIME type and picks highest profile available among them.
+     * Works only on API level 21 and above (Lollipop +)
+     * @param mimeType media MIME type
+     * @param isEncoder search through encoder codecs if true, decoder codecs if false
+     * @return a {@link android.media.MediaCodecInfo.CodecProfileLevel} profile constant of successful, UNDEFINED_VALUE otherwise
+     */
+    @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
+    public static int getHighestSupportedProfile(@NonNull String mimeType, boolean isEncoder) {
+        return getHighestSupportedProfile(mimeType, isEncoder, UNDEFINED_VALUE);
+    }
+
+    /**
+     * Attempts to find highest supported codec profile for a given MIME type. Iterates through all codecs available,
+     * filters for codecs that support provided MIME type and picks highest profile available among them.
+     * Works only on API level 21 and above (Lollipop +)
+     * @param mimeType media MIME type
+     * @param isEncoder search through encoder codecs if true, decoder codecs if false
+     * @param targetProfile optional upper limit for codec profile, one of {@link android.media.MediaCodecInfo.CodecProfileLevel} profile constants,
+     *                      or UNDEFINED_VALUE for highest supported codec profile
+     * @return a {@link android.media.MediaCodecInfo.CodecProfileLevel} profile constant of successful, UNDEFINED_VALUE otherwise
+     */
+    @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
+    public static int getHighestSupportedProfile(@NonNull String mimeType, boolean isEncoder, int targetProfile) {
+        int highestSupportedProfile = UNDEFINED_VALUE;
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            int maxProfileRank = targetProfile == UNDEFINED_VALUE ? Integer.MAX_VALUE : getProfileRank(mimeType, targetProfile);
+
+            MediaCodecList mediaCodecList = new MediaCodecList(MediaCodecList.ALL_CODECS);
+            for (MediaCodecInfo mediaCodecInfo : mediaCodecList.getCodecInfos()) {
+                if (supportsType(mediaCodecInfo, mimeType) && mediaCodecInfo.isEncoder() == isEncoder) {
+                    MediaCodecInfo.CodecCapabilities codecCapabilities = mediaCodecInfo.getCapabilitiesForType(mimeType);
+                    for (MediaCodecInfo.CodecProfileLevel codecProfileLevel : codecCapabilities.profileLevels) {
+                        if (getProfileRank(mimeType, codecProfileLevel.profile) > getProfileRank(mimeType, highestSupportedProfile)
+                                && getProfileRank(mimeType, codecProfileLevel.profile) <= maxProfileRank) {
+                            highestSupportedProfile = codecProfileLevel.profile;
+                        }
+                    }
+                }
+            }
+        }
+
+        return highestSupportedProfile;
+    }
+
+    private static boolean supportsType(@NonNull MediaCodecInfo mediaCodecInfo, @NonNull String mimeType) {
+        String[] supportedTypes = mediaCodecInfo.getSupportedTypes();
+        for (String supportedType : supportedTypes) {
+            if (TextUtils.equals(mimeType, supportedType)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static int getProfileRank(@NonNull String mimeType, int profile) {
+        if (profile == UNDEFINED_VALUE) {
+            return UNDEFINED_VALUE;
+        }
+
+        int[] rankedProfiles = CODEC_PROFILE_RANK_MAP.get(mimeType);
+        if (rankedProfiles == null) {
+            return UNDEFINED_VALUE;
+        }
+
+        for (int ranking = 0; ranking < rankedProfiles.length; ranking++) {
+            if (profile == rankedProfiles[ranking]) {
+                return ranking;
+            }
+        }
+        return UNDEFINED_VALUE;
+    }
+}


### PR DESCRIPTION
Introducing a new utility, which allows picking highest supported codec profile. Optionally, clients can specify a "desired" profile, in which case utility will use it as a maximum.

If target profile is not specified, MediaCodec returns "most basic" profile (e.g. Baseline for AVC), even if hardware supports higher level (e.g. Main or High for AVC) profiles. This results lower quality output than device is capable of. This functionality is meant to fix that. 

One possible caveat is that this logic simply uses a list of codes and does not account for hardware capabilities, so transcoding may potentially fail if device capabilities are exceeded. We are hoping to address this in future work.