### PR TITLE
Video filter preview functionality

### DIFF
--- a/litr-demo/build.gradle
+++ b/litr-demo/build.gradle
@@ -13,6 +13,11 @@ android {
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
     lintOptions {
         abortOnError true
         checkDependencies true
@@ -32,6 +37,8 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'androidx.recyclerview:recyclerview:1.1.0'
     implementation 'com.github.bumptech.glide:glide:4.10.0'
+    implementation 'com.google.android.exoplayer:exoplayer-core:2.11.3'
+    implementation 'com.google.android.exoplayer:exoplayer-ui:2.11.3'
 
     annotationProcessor 'com.github.bumptech.glide:compiler:4.10.0'
 }

--- a/litr-demo/src/main/java/com/linkedin/android/litr/demo/DemoCase.java
+++ b/litr-demo/src/main/java/com/linkedin/android/litr/demo/DemoCase.java
@@ -16,6 +16,7 @@ public enum DemoCase {
     VIDEO_OVERLAY_GL(R.string.demo_case_free_transform_video_gl, "FreeTransformVideoGl", new FreeTransformVideoGlFragment()),
     VIDEO_WATERMARK(R.string.demo_case_video_watermark, "VideoWatermark", new VideoWatermarkFragment()),
     VIDEO_FILTERS(R.string.demo_case_video_filters, "VideoFilters", new VideoFiltersFragment()),
+    VIDEO_FILTERS_PREVIEW(R.string.demo_case_video_filters_preview, "VideoFiltersPreview", new VideoFilterPreviewFragment()),
     TRANSCODE_VIDEO_MOCK(R.string.demo_case_mock_transcode_video, "TranscodeVideoMock", new MockTranscodeFragment());
 
     @StringRes int displayName;

--- a/litr-demo/src/main/java/com/linkedin/android/litr/demo/VideoFilterPreviewFragment.java
+++ b/litr-demo/src/main/java/com/linkedin/android/litr/demo/VideoFilterPreviewFragment.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2019 LinkedIn Corporation
+ * All Rights Reserved.
+ *
+ * Licensed under the BSD 2-Clause License (the "License").  See License in the project root for
+ * license information.
+ */
+package com.linkedin.android.litr.demo;
+
+import android.content.Context;
+import android.net.Uri;
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.AdapterView;
+import android.widget.ArrayAdapter;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.google.android.exoplayer2.ExoPlayer;
+import com.google.android.exoplayer2.SimpleExoPlayer;
+import com.google.android.exoplayer2.source.ProgressiveMediaSource;
+import com.google.android.exoplayer2.trackselection.DefaultTrackSelector;
+import com.google.android.exoplayer2.upstream.DataSource;
+import com.google.android.exoplayer2.upstream.DefaultDataSourceFactory;
+import com.google.android.exoplayer2.video.VideoListener;
+import com.linkedin.android.litr.demo.data.SourceMedia;
+import com.linkedin.android.litr.demo.databinding.FragmentVideoFilterPreviewBinding;
+import com.linkedin.android.litr.filter.GlFrameRenderFilter;
+import com.linkedin.android.litr.preview.VideoPreviewRenderer;
+
+public class VideoFilterPreviewFragment extends BaseTransformationFragment implements MediaPickerListener {
+
+    private FragmentVideoFilterPreviewBinding binding;
+
+    private ArrayAdapter<DemoFilter> adapter;
+
+    private DataSource.Factory dataSourceFactory;
+    private SimpleExoPlayer exoPlayer;
+
+    private VideoPreviewRenderer renderer;
+
+    private VideoListener videoListener = new VideoListener() {
+        @Override
+        public void onVideoSizeChanged(int width, int height, int unappliedRotationDegrees, float pixelWidthHeightRatio) {
+            if (binding != null) {
+                binding.videoFrame.setAspectRatio((float) width / height);
+            }
+        }
+    };
+
+    @Override
+    public void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        adapter = new ArrayAdapter<>(getContext(), android.R.layout.simple_spinner_item, DemoFilter.values());
+        adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
+
+        Context context = getContext().getApplicationContext();
+        dataSourceFactory = new DefaultDataSourceFactory(context, "LiTr");
+        DefaultTrackSelector trackSelector = new DefaultTrackSelector(context);
+        exoPlayer = new SimpleExoPlayer.Builder(context)
+                .setTrackSelector(trackSelector)
+                .build();
+        renderer = new VideoPreviewRenderer(surface -> exoPlayer.setVideoSurface(surface));
+    }
+
+    @Override
+    public View onCreateView(@NonNull LayoutInflater inflater,
+                             ViewGroup container, Bundle savedInstanceState) {
+        binding = FragmentVideoFilterPreviewBinding.inflate(inflater, container, false);
+
+        SourceMedia sourceMedia = new SourceMedia();
+        binding.setSourceMedia(sourceMedia);
+
+        binding.sectionPickVideo.buttonPickVideo.setOnClickListener(view -> pickVideo(VideoFilterPreviewFragment.this));
+
+        binding.spinnerFilters.setAdapter(adapter);
+        binding.spinnerFilters.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
+            @Override
+            public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
+                renderer.setFilter((GlFrameRenderFilter) adapter.getItem(position).filter);
+            }
+
+            @Override
+            public void onNothingSelected(AdapterView<?> parent) {}
+        });
+
+        exoPlayer.setVideoSurfaceView(binding.videoPreview);
+        exoPlayer.setRepeatMode(ExoPlayer.REPEAT_MODE_ALL);
+        exoPlayer.addVideoListener(videoListener);
+
+        binding.videoPreview.setRenderer(renderer);
+
+        return binding.getRoot();
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        exoPlayer.setPlayWhenReady(true);
+    }
+
+    @Override
+    public void onPause() {
+        super.onPause();
+        exoPlayer.setPlayWhenReady(false);
+    }
+
+    @Override
+    public void onDetach() {
+        super.onDetach();
+
+        exoPlayer.removeVideoListener(videoListener);
+        renderer.release();
+        exoPlayer.release();
+    }
+
+    @Override
+    public void onMediaPicked(@NonNull Uri uri) {
+        SourceMedia sourceMedia = binding.getSourceMedia();
+        updateSourceMedia(sourceMedia, uri);
+
+        ProgressiveMediaSource mediaSource = new ProgressiveMediaSource.Factory(dataSourceFactory).createMediaSource(uri);
+        exoPlayer.prepare(mediaSource);
+        exoPlayer.setPlayWhenReady(true);
+    }
+}

--- a/litr-demo/src/main/res/layout/fragment_video_filter_preview.xml
+++ b/litr-demo/src/main/res/layout/fragment_video_filter_preview.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2019 LinkedIn Corporation -->
+<!-- All Rights Reserved. -->
+<!-- -->
+<!-- Licensed under the BSD 2-Clause License (the "License").  See License in the project root -->
+<!-- for license information. -->
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <data>
+        <import type="android.view.View"/>
+
+        <variable
+            name="sourceMedia"
+            type="com.linkedin.android.litr.demo.data.SourceMedia" />
+
+        <variable
+            name="targetMedia"
+            type="com.linkedin.android.litr.demo.data.TargetMedia" />
+
+    </data>
+
+    <FrameLayout
+        android:orientation="vertical"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <com.google.android.exoplayer2.ui.AspectRatioFrameLayout
+            android:id="@+id/video_frame"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_gravity="center">
+
+            <com.linkedin.android.litr.preview.VideoFilterPreviewView
+                android:id="@+id/video_preview"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"/>
+
+        </com.google.android.exoplayer2.ui.AspectRatioFrameLayout>
+
+        <include layout="@layout/section_pick_video"
+            android:id="@+id/section_pick_video"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_gravity="top"
+            app:sourceMedia="@{sourceMedia}"/>
+
+        <Spinner
+            android:id="@+id/spinner_filters"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_gravity="bottom"
+            android:background="@android:color/darker_gray"
+            android:padding="@dimen/cell_padding"
+            android:layout_margin="@dimen/section_margin"
+            android:enabled="@{sourceMedia != null}" />
+
+    </FrameLayout>
+
+</layout>

--- a/litr-demo/src/main/res/values/strings.xml
+++ b/litr-demo/src/main/res/values/strings.xml
@@ -10,6 +10,7 @@
     <string name="demo_case_free_transform_video_gl">Free Transform Video (GL Renderer)</string>
     <string name="demo_case_video_watermark">Video Watermark</string>
     <string name="demo_case_video_filters">Video Filters</string>
+    <string name="demo_case_video_filters_preview">Video Filters Preview</string>
     <string name="demo_case_mock_transcode_video">Mock Transcode Video</string>
 
     <string name="include">Include</string>

--- a/litr/src/main/java/com/linkedin/android/litr/preview/PreviewEglConfigChooser.java
+++ b/litr/src/main/java/com/linkedin/android/litr/preview/PreviewEglConfigChooser.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2018 Masayuki Suda
+ *
+ * The MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE
+ * AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.linkedin.android.litr.preview;
+
+import android.opengl.GLSurfaceView;
+import android.os.Build;
+
+import javax.microedition.khronos.egl.EGL10;
+import javax.microedition.khronos.egl.EGLConfig;
+import javax.microedition.khronos.egl.EGLDisplay;
+
+import static javax.microedition.khronos.egl.EGL10.EGL_ALPHA_SIZE;
+import static javax.microedition.khronos.egl.EGL10.EGL_BLUE_SIZE;
+import static javax.microedition.khronos.egl.EGL10.EGL_DEPTH_SIZE;
+import static javax.microedition.khronos.egl.EGL10.EGL_GREEN_SIZE;
+import static javax.microedition.khronos.egl.EGL10.EGL_NONE;
+import static javax.microedition.khronos.egl.EGL10.EGL_RED_SIZE;
+import static javax.microedition.khronos.egl.EGL10.EGL_RENDERABLE_TYPE;
+import static javax.microedition.khronos.egl.EGL10.EGL_STENCIL_SIZE;
+
+class PreviewEglConfigChooser implements GLSurfaceView.EGLConfigChooser {
+
+    private final int[] configSpec;
+    private final int redSize;
+    private final int greenSize;
+    private final int blueSize;
+    private final int alphaSize;
+    private final int depthSize;
+    private final int stencilSize;
+
+    private static final int EGL_CONTEXT_CLIENT_VERSION = 2;
+
+    private static final boolean USE_RGB_888 = Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1;
+
+    PreviewEglConfigChooser() {
+        this(
+                USE_RGB_888 ? 8 : 5,
+                USE_RGB_888 ? 8 : 6,
+                USE_RGB_888 ? 8 : 5,
+                0,
+                0,
+                0,
+                EGL_CONTEXT_CLIENT_VERSION
+        );
+    }
+
+    PreviewEglConfigChooser(
+            final int redSize,
+            final int greenSize,
+            final int blueSize,
+            final int alphaSize,
+            final int depthSize,
+            final int stencilSize,
+            final int version) {
+        configSpec = filterConfigSpec(new int[]{
+                EGL_RED_SIZE, redSize,
+                EGL_GREEN_SIZE, greenSize,
+                EGL_BLUE_SIZE, blueSize,
+                EGL_ALPHA_SIZE, alphaSize,
+                EGL_DEPTH_SIZE, depthSize,
+                EGL_STENCIL_SIZE, stencilSize,
+                EGL_NONE
+        }, version);
+        this.redSize = redSize;
+        this.greenSize = greenSize;
+        this.blueSize = blueSize;
+        this.alphaSize = alphaSize;
+        this.depthSize = depthSize;
+        this.stencilSize = stencilSize;
+    }
+
+    private static final int EGL_OPENGL_ES2_BIT = 4;
+
+    private int[] filterConfigSpec(final int[] configSpec, final int version) {
+        if (version != 2) {
+            return configSpec;
+        }
+
+        final int len = configSpec.length;
+        final int[] newConfigSpec = new int[len + 2];
+        System.arraycopy(configSpec, 0, newConfigSpec, 0, len - 1);
+        newConfigSpec[len - 1] = EGL_RENDERABLE_TYPE;
+        newConfigSpec[len] = EGL_OPENGL_ES2_BIT;
+        newConfigSpec[len + 1] = EGL_NONE;
+        return newConfigSpec;
+    }
+
+    //////////////////////////////////////////////////////////////////////////
+
+    @Override
+    public EGLConfig chooseConfig(final EGL10 egl, final EGLDisplay display) {
+        final int[] num_config = new int[1];
+        if (!egl.eglChooseConfig(display, configSpec, null, 0, num_config)) {
+            throw new IllegalArgumentException("eglChooseConfig failed");
+        }
+        final int config_size = num_config[0];
+        if (config_size <= 0) {
+            throw new IllegalArgumentException("No configs match configSpec");
+        }
+
+        final EGLConfig[] configs = new EGLConfig[config_size];
+        if (!egl.eglChooseConfig(display, configSpec, configs, config_size, num_config)) {
+            throw new IllegalArgumentException("eglChooseConfig#2 failed");
+        }
+        final EGLConfig config = chooseConfig(egl, display, configs);
+        if (config == null) {
+            throw new IllegalArgumentException("No config chosen");
+        }
+        return config;
+    }
+
+    private EGLConfig chooseConfig(final EGL10 egl, final EGLDisplay display, final EGLConfig[] configs) {
+        for (final EGLConfig config : configs) {
+            final int d = findConfigAttrib(egl, display, config, EGL_DEPTH_SIZE, 0);
+            final int s = findConfigAttrib(egl, display, config, EGL_STENCIL_SIZE, 0);
+            if ((d >= depthSize) && (s >= stencilSize)) {
+                final int r = findConfigAttrib(egl, display, config, EGL_RED_SIZE, 0);
+                final int g = findConfigAttrib(egl, display, config, EGL_GREEN_SIZE, 0);
+                final int b = findConfigAttrib(egl, display, config, EGL_BLUE_SIZE, 0);
+                final int a = findConfigAttrib(egl, display, config, EGL_ALPHA_SIZE, 0);
+                if ((r == redSize) && (g == greenSize) && (b == blueSize) && (a == alphaSize)) {
+                    return config;
+                }
+            }
+        }
+        return null;
+    }
+
+    private int findConfigAttrib(final EGL10 egl, final EGLDisplay display, final EGLConfig config, final int attribute, final int defaultValue) {
+        final int[] value = new int[1];
+        if (egl.eglGetConfigAttrib(display, config, attribute, value)) {
+            return value[0];
+        }
+        return defaultValue;
+    }
+}

--- a/litr/src/main/java/com/linkedin/android/litr/preview/PreviewEglContextFactory.java
+++ b/litr/src/main/java/com/linkedin/android/litr/preview/PreviewEglContextFactory.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2018 Masayuki Suda
+ *
+ * The MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE
+ * AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.linkedin.android.litr.preview;
+
+import android.opengl.GLSurfaceView;
+import android.util.Log;
+
+import javax.microedition.khronos.egl.EGL10;
+import javax.microedition.khronos.egl.EGLConfig;
+import javax.microedition.khronos.egl.EGLContext;
+import javax.microedition.khronos.egl.EGLDisplay;
+
+import static javax.microedition.khronos.egl.EGL10.EGL_NONE;
+import static javax.microedition.khronos.egl.EGL10.EGL_NO_CONTEXT;
+
+class PreviewEglContextFactory implements GLSurfaceView.EGLContextFactory {
+
+    private static final String TAG = "EContextFactory";
+
+    private final int EGL_CLIENT_VERSION = 2;
+
+    private static final int EGL_CONTEXT_CLIENT_VERSION = 0x3098;
+
+    @Override
+    public EGLContext createContext(final EGL10 egl, final EGLDisplay display, final EGLConfig config) {
+        final int[] attrib_list;
+        attrib_list = new int[]{EGL_CONTEXT_CLIENT_VERSION, EGL_CLIENT_VERSION, EGL_NONE};
+        return egl.eglCreateContext(display, config, EGL_NO_CONTEXT, attrib_list);
+    }
+
+    @Override
+    public void destroyContext(final EGL10 egl, final EGLDisplay display, final EGLContext context) {
+        if (!egl.eglDestroyContext(display, context)) {
+            Log.e(TAG, "display:" + display + " context: " + context);
+            throw new RuntimeException("eglDestroyContex" + egl.eglGetError());
+        }
+    }
+}

--- a/litr/src/main/java/com/linkedin/android/litr/preview/VideoFilterPreviewView.java
+++ b/litr/src/main/java/com/linkedin/android/litr/preview/VideoFilterPreviewView.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2019 LinkedIn Corporation
+ * All Rights Reserved.
+ *
+ * Licensed under the BSD 2-Clause License (the "License").  See License in the project root for
+ * license information.
+ */
+package com.linkedin.android.litr.preview;
+
+import android.content.Context;
+import android.opengl.GLSurfaceView;
+import android.util.AttributeSet;
+
+import androidx.annotation.NonNull;
+
+public class VideoFilterPreviewView extends GLSurfaceView {
+
+    public VideoFilterPreviewView(Context context) {
+        this(context, null);
+    }
+
+    public VideoFilterPreviewView(Context context, AttributeSet attributeSet) {
+        super(context, attributeSet);
+
+        setEGLContextFactory(new PreviewEglContextFactory());
+        setEGLConfigChooser(new PreviewEglConfigChooser());
+    }
+
+    @Override
+    public void setRenderer(Renderer renderer) {
+        super.setRenderer(renderer);
+
+        if (renderer instanceof VideoPreviewRenderer) {
+            ((VideoPreviewRenderer) renderer).setPreviewRenderListener(new VideoPreviewRenderer.PreviewRenderListener() {
+                @Override
+                public void onRenderRequested() {
+                    requestRender();
+                }
+
+                @Override
+                public void onEventQueued(@NonNull Runnable runnable) {
+                    queueEvent(runnable);
+                }
+            });
+        }
+    }
+}

--- a/litr/src/main/java/com/linkedin/android/litr/preview/VideoPreviewRenderer.java
+++ b/litr/src/main/java/com/linkedin/android/litr/preview/VideoPreviewRenderer.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright 2019 LinkedIn Corporation
+ * All Rights Reserved.
+ *
+ * Licensed under the BSD 2-Clause License (the "License").  See License in the project root for
+ * license information.
+ */
+package com.linkedin.android.litr.preview;
+
+import android.graphics.SurfaceTexture;
+import android.opengl.GLES20;
+import android.opengl.GLSurfaceView;
+import android.opengl.Matrix;
+import android.view.Surface;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.linkedin.android.litr.filter.GlFrameRenderFilter;
+import com.linkedin.android.litr.filter.video.gl.DefaultVideoFrameRenderFilter;
+
+import java.util.Arrays;
+
+import javax.microedition.khronos.egl.EGLConfig;
+import javax.microedition.khronos.opengles.GL10;
+
+import static android.opengl.GLES20.GL_CLAMP_TO_EDGE;
+import static android.opengl.GLES20.GL_COLOR_BUFFER_BIT;
+import static android.opengl.GLES20.GL_LINEAR;
+import static android.opengl.GLES20.GL_MAX_TEXTURE_SIZE;
+import static android.opengl.GLES20.GL_NEAREST;
+import static android.opengl.GLES20.GL_TEXTURE_2D;
+import static android.opengl.GLES20.GL_TEXTURE_MAG_FILTER;
+import static android.opengl.GLES20.GL_TEXTURE_MIN_FILTER;
+import static android.opengl.GLES20.GL_TEXTURE_WRAP_S;
+import static android.opengl.GLES20.GL_TEXTURE_WRAP_T;
+
+/**
+ * An implementation of {@link GLSurfaceView.Renderer} which renders a preview of a video with
+ * {@link GlFrameRenderFilter} applied. Works in conjunction with {@link VideoFilterPreviewView}
+ * Once initialization is completed, calls back {@link InputSurfaceListener} with an instance of
+ * a {@link Surface} video player (e.g. ExoPlayer) should render onto.
+ */
+public class VideoPreviewRenderer implements GLSurfaceView.Renderer {
+
+    private static final String TAG = VideoPreviewRenderer.class.getSimpleName();
+
+    private static final int GL_TEXTURE_EXTERNAL_OES = 0x8D65;
+
+    private final InputSurfaceListener inputSurfaceListener;
+
+    private float[] stMatrix = new float[16];
+    private float[] mvpMatrix = new float[16];
+
+    private SurfaceTexture previewSurfaceTexture;
+    private int textureHandle;
+
+    private GlFrameRenderFilter frameRenderFilter;
+
+    private PreviewRenderListener previewRenderListener;
+
+    private SurfaceTexture.OnFrameAvailableListener onFrameAvailableListener = new SurfaceTexture.OnFrameAvailableListener() {
+        @Override
+        public void onFrameAvailable(SurfaceTexture surfaceTexture) {
+            previewRenderListener.onRenderRequested();
+        }
+    };
+
+    public VideoPreviewRenderer(@NonNull InputSurfaceListener inputSurfaceListener) {
+        this.inputSurfaceListener = inputSurfaceListener;
+        this.frameRenderFilter = new DefaultVideoFrameRenderFilter();
+
+        Matrix.setIdentityM(stMatrix, 0);
+    }
+
+    public void setFilter(@NonNull final GlFrameRenderFilter frameRenderFilter) {
+        if (this.frameRenderFilter != frameRenderFilter && previewRenderListener != null) {
+            previewRenderListener.onEventQueued(new Runnable() {
+                @Override
+                public void run() {
+                    VideoPreviewRenderer.this.frameRenderFilter.release();
+                    if (previewSurfaceTexture != null) {
+                        frameRenderFilter.init();
+                        frameRenderFilter.setVpMatrix(Arrays.copyOf(mvpMatrix, mvpMatrix.length), 0);
+                    }
+                    VideoPreviewRenderer.this.frameRenderFilter = frameRenderFilter;
+                }
+            });
+        }
+    }
+
+    public void setPreviewRenderListener(@Nullable PreviewRenderListener previewRenderListener) {
+        this.previewRenderListener = previewRenderListener;
+    }
+
+    @Override
+    public void onSurfaceCreated(GL10 gl, EGLConfig config) {
+        final int[] args = new int[1];
+
+        GLES20.glGenTextures(args.length, args, 0);
+        textureHandle = args[0];
+
+        previewSurfaceTexture = new SurfaceTexture(textureHandle);
+        previewSurfaceTexture.setOnFrameAvailableListener(onFrameAvailableListener);
+
+        GLES20.glBindTexture(GL_TEXTURE_EXTERNAL_OES, textureHandle);
+        GLES20.glTexParameterf(GL_TEXTURE_EXTERNAL_OES, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+        GLES20.glTexParameterf(GL_TEXTURE_EXTERNAL_OES, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+        GLES20.glTexParameteri(GL_TEXTURE_EXTERNAL_OES, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+        GLES20.glTexParameteri(GL_TEXTURE_EXTERNAL_OES, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+        GLES20.glBindTexture(GL_TEXTURE_2D, 0);
+
+        Surface surface = new Surface(previewSurfaceTexture);
+        inputSurfaceListener.onSurfaceCreated(surface);
+
+        frameRenderFilter.init();
+
+        GLES20.glGetIntegerv(GL_MAX_TEXTURE_SIZE, args, 0);
+    }
+
+    @Override
+    public void onSurfaceChanged(GL10 gl, int width, int height) {
+        initMvpMatrix((float) width / height);
+        frameRenderFilter.setVpMatrix(Arrays.copyOf(mvpMatrix, mvpMatrix.length), 0);
+    }
+
+    @Override
+    public void onDrawFrame(GL10 gl) {
+        synchronized (this) {
+            previewSurfaceTexture.updateTexImage();
+            previewSurfaceTexture.getTransformMatrix(stMatrix);
+        }
+
+        GLES20.glClear(GL_COLOR_BUFFER_BIT);
+
+        frameRenderFilter.initInputFrameTexture(textureHandle, stMatrix);
+        frameRenderFilter.apply(previewSurfaceTexture.getTimestamp());
+    }
+
+    public void release() {
+        frameRenderFilter.release();
+
+        if (previewSurfaceTexture != null) {
+            previewSurfaceTexture.release();
+        }
+    }
+
+    private void initMvpMatrix(float videoAspectRatio) {
+        float[] projectionMatrix = new float[16];
+        Matrix.setIdentityM(projectionMatrix, 0);
+        Matrix.orthoM(projectionMatrix, 0, -videoAspectRatio, videoAspectRatio, -1, 1, -1, 1);
+
+        // rotate the camera to match video frame rotation
+        float[] viewMatrix = new float[16];
+        Matrix.setIdentityM(viewMatrix, 0);
+        Matrix.setLookAtM(viewMatrix, 0,
+                0, 0, 1,
+                0, 0, 0,
+                0, 1, 0);
+
+        Matrix.setIdentityM(mvpMatrix, 0);
+        Matrix.multiplyMM(mvpMatrix, 0, projectionMatrix, 0, viewMatrix, 0);
+    }
+
+    /**
+     * A listener which notifies when input surface is created.
+     */
+    public interface InputSurfaceListener {
+
+        /**
+         * Input surface is created
+         * @param surface input surface, typically a surface a video player renders onto
+         */
+        void onSurfaceCreated(@NonNull Surface surface);
+    }
+
+    /**
+     * A listener used for communication with preview view
+     */
+    interface PreviewRenderListener {
+
+        /**
+         * Requesting preview view to render
+         */
+        void onRenderRequested();
+
+        /**
+         * Queue a {@link Runnable} to be run on preview surface render thread
+         * @param runnable Runnable to run
+         */
+        void onEventQueued(@NonNull Runnable runnable);
+    }
+}


### PR DESCRIPTION
A combination of custom implementations of `GLSurfaceView` and `GlSurfaceView.Renderer` that allows previewing the effect of `GlFrameRenderFilter` on a video. Renderer creates a `Surface`, which video player (such as ExoPlayer) can render onto. This surface effectively becomes an analog of `Decoder`'s output surface, which `GlFrameRenderFilter` is then applied to. 