### PR TITLE
Support for trimming media

### DIFF
--- a/litr-demo/src/main/java/com/linkedin/android/litr/demo/data/TransformationPresenter.java
+++ b/litr-demo/src/main/java/com/linkedin/android/litr/demo/data/TransformationPresenter.java
@@ -33,6 +33,7 @@ import com.linkedin.android.litr.filter.Transform;
 import com.linkedin.android.litr.filter.video.gl.DefaultVideoFrameRenderFilter;
 import com.linkedin.android.litr.io.MediaExtractorMediaSource;
 import com.linkedin.android.litr.io.MediaMuxerMediaTarget;
+import com.linkedin.android.litr.io.MediaRange;
 import com.linkedin.android.litr.io.MediaSource;
 import com.linkedin.android.litr.io.MediaTarget;
 import com.linkedin.android.litr.render.GlVideoRenderer;
@@ -45,6 +46,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 
 public class TransformationPresenter {
 
@@ -65,6 +67,7 @@ public class TransformationPresenter {
 
     public void startTransformation(@NonNull SourceMedia sourceMedia,
                                     @NonNull TargetMedia targetMedia,
+                                    @NonNull TrimConfig trimConfig,
                                     @NonNull TransformationState transformationState) {
         if (targetMedia.getIncludedTrackCount() < 1) {
             return;
@@ -93,7 +96,14 @@ public class TransformationPresenter {
                                                                 MediaMuxer.OutputFormat.MUXER_OUTPUT_MPEG_4);
 
             List<TrackTransform> trackTransforms = new ArrayList<>(targetMedia.tracks.size());
-            MediaSource mediaSource = new MediaExtractorMediaSource(context, sourceMedia.uri);
+
+
+            MediaRange mediaRange = trimConfig.enabled
+                    ? new MediaRange(
+                            TimeUnit.MILLISECONDS.toMicros((long) (trimConfig.range.get(0) * 1000)),
+                            TimeUnit.MILLISECONDS.toMicros((long) (trimConfig.range.get(1) * 1000)))
+                    : new MediaRange(0, Long.MAX_VALUE);
+            MediaSource mediaSource = new MediaExtractorMediaSource(context, sourceMedia.uri, mediaRange);
 
             for (TargetTrack targetTrack : targetMedia.tracks) {
                 if (!targetTrack.shouldInclude) {

--- a/litr-demo/src/main/res/layout/fragment_transcode_video_gl.xml
+++ b/litr-demo/src/main/res/layout/fragment_transcode_video_gl.xml
@@ -72,7 +72,7 @@
                 android:text="@string/transcode"
                 android:enabled="@{sourceMedia != null &amp;&amp; targetMedia != null &amp;&amp; targetMedia.getIncludedTrackCount() > 0 &amp;&amp; (transformationState.state != transformationState.STATE_RUNNING)}"
                 android:padding="@dimen/cell_padding"
-                android:onClick="@{() -> transformationPresenter.startTransformation(sourceMedia, targetMedia, transformationState)}"/>
+                android:onClick="@{() -> transformationPresenter.startTransformation(sourceMedia, targetMedia, trimConfig, transformationState)}"/>
 
             <include layout="@layout/section_transformation_progress"
                 android:id="@+id/section_transformation_progress"

--- a/litr/src/main/java/com/linkedin/android/litr/io/MediaExtractorMediaSource.java
+++ b/litr/src/main/java/com/linkedin/android/litr/io/MediaExtractorMediaSource.java
@@ -26,17 +26,25 @@ import static com.linkedin.android.litr.exception.MediaSourceException.Error.DAT
  */
 public class MediaExtractorMediaSource implements MediaSource {
 
-    private MediaExtractor mediaExtractor;
+    private final MediaExtractor mediaExtractor;
+    private final MediaRange mediaRange;
 
     private int orientationHint;
     private long size;
 
     public MediaExtractorMediaSource(@NonNull Context context, @NonNull Uri uri) throws MediaSourceException {
+        this(context, uri, new MediaRange(0, Long.MAX_VALUE));
+    }
+
+    public MediaExtractorMediaSource(@NonNull Context context, @NonNull Uri uri, @NonNull MediaRange mediaRange) throws MediaSourceException {
+        this.mediaRange = mediaRange;
+
         mediaExtractor = new MediaExtractor();
         MediaMetadataRetriever mediaMetadataRetriever = new MediaMetadataRetriever();
         try {
             mediaExtractor.setDataSource(context, uri, null);
             mediaMetadataRetriever.setDataSource(context, uri);
+            mediaExtractor.seekTo(mediaRange.getStart(), MediaExtractor.SEEK_TO_PREVIOUS_SYNC);
         } catch (IOException ex) {
             throw new MediaSourceException(DATA_SOURCE, uri, ex);
         }
@@ -106,5 +114,11 @@ public class MediaExtractorMediaSource implements MediaSource {
     @Override
     public long getSize() {
         return size;
+    }
+
+    @NonNull
+    @Override
+    public MediaRange getSelection() {
+        return mediaRange;
     }
 }

--- a/litr/src/main/java/com/linkedin/android/litr/io/MediaRange.java
+++ b/litr/src/main/java/com/linkedin/android/litr/io/MediaRange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 LinkedIn Corporation
+ * Copyright 2020 LinkedIn Corporation
  * All Rights Reserved.
  *
  * Licensed under the BSD 2-Clause License (the "License").  See License in the project root for
@@ -19,11 +19,15 @@ public class MediaRange {
     /**
      * Create an instance of MediaRange
      * @param start range start, in microseconds
-     * @param end range end, in microseconds
+     * @param end range end, in microseconds, greater than start
      */
     public MediaRange(long start, long end) {
         this.start = start;
         this.end = end;
+
+        if (end < start) {
+            throw new IllegalArgumentException("Range end should be greater than range start");
+        }
     }
 
     /**

--- a/litr/src/main/java/com/linkedin/android/litr/io/MediaRange.java
+++ b/litr/src/main/java/com/linkedin/android/litr/io/MediaRange.java
@@ -24,10 +24,6 @@ public class MediaRange {
     public MediaRange(long start, long end) {
         this.start = start;
         this.end = end;
-
-        if (end < start) {
-            throw new IllegalArgumentException("Range end should be greater than range start");
-        }
     }
 
     /**

--- a/litr/src/main/java/com/linkedin/android/litr/io/MediaRange.java
+++ b/litr/src/main/java/com/linkedin/android/litr/io/MediaRange.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2019 LinkedIn Corporation
+ * All Rights Reserved.
+ *
+ * Licensed under the BSD 2-Clause License (the "License").  See License in the project root for
+ * license information.
+ */
+package com.linkedin.android.litr.io;
+
+/**
+ * Data class used to define a range (start, stop) of media. For example, it can be used to
+ * define a "selection" in a MediaSource
+ */
+public class MediaRange {
+
+    private final long start;
+    private final long end;
+
+    /**
+     * Create an instance of MediaRange
+     * @param start range start, in microseconds
+     * @param end range end, in microseconds
+     */
+    public MediaRange(long start, long end) {
+        this.start = start;
+        this.end = end;
+    }
+
+    /**
+     * Get range start, in microseconds
+     */
+    public long getStart() {
+        return start;
+    }
+
+    /**
+     * Get range end, in microseconds
+     */
+    public long getEnd() {
+        return end;
+    }
+}

--- a/litr/src/main/java/com/linkedin/android/litr/io/MediaSource.java
+++ b/litr/src/main/java/com/linkedin/android/litr/io/MediaSource.java
@@ -91,4 +91,12 @@ public interface MediaSource {
      * @return size in bytes, -1 if unknown
      */
     long getSize();
+
+    /**
+     * Get media selection. Default selection is entire media.
+     */
+    @NonNull
+    default MediaRange getSelection() {
+        return new MediaRange(0, Long.MAX_VALUE);
+    }
 }

--- a/litr/src/main/java/com/linkedin/android/litr/render/PassthroughSoftwareRenderer.java
+++ b/litr/src/main/java/com/linkedin/android/litr/render/PassthroughSoftwareRenderer.java
@@ -64,7 +64,7 @@ public class PassthroughSoftwareRenderer implements Renderer {
             outputFrame.bufferInfo.set(
                     0,
                     frame.bufferInfo.size,
-                    frame.bufferInfo.presentationTimeUs,
+                    presentationTimeNs,
                     frame.bufferInfo.flags);
             encoder.queueInputFrame(outputFrame);
         } else {

--- a/litr/src/main/java/com/linkedin/android/litr/transcoder/AudioTrackTranscoder.java
+++ b/litr/src/main/java/com/linkedin/android/litr/transcoder/AudioTrackTranscoder.java
@@ -136,7 +136,15 @@ public class AudioTrackTranscoder extends TrackTranscoder {
                         extractFrameResult = RESULT_EOS_REACHED;
                         Log.d(TAG, "Selection end reached on the input stream");
                     }
-                    mediaSource.advance();
+                    // done with this track, advance until track switches to let other track transcoders finish work
+                    while (mediaSource.getSampleTrackIndex() == sourceTrack) {
+                        mediaSource.advance();
+                        if ((mediaSource.getSampleFlags() & MediaCodec.BUFFER_FLAG_END_OF_STREAM) != 0) {
+                            // reached the end of container, no more tracks left
+                            extractFrameResult = RESULT_EOS_REACHED;
+                            break;
+                        }
+                    }
                 } else {
                     frame.bufferInfo.set(0, bytesRead, sampleTime, sampleFlags);
                     decoder.queueInputFrame(frame);

--- a/litr/src/main/java/com/linkedin/android/litr/transcoder/AudioTrackTranscoder.java
+++ b/litr/src/main/java/com/linkedin/android/litr/transcoder/AudioTrackTranscoder.java
@@ -122,18 +122,26 @@ public class AudioTrackTranscoder extends TrackTranscoder {
                     throw new TrackTranscoderException(TrackTranscoderException.Error.NO_FRAME_AVAILABLE);
                 }
                 int bytesRead = mediaSource.readSampleData(frame.buffer, 0);
-                if (bytesRead > 0) {
-                    long sampleTime = mediaSource.getSampleTime();
-                    int sampleFlags = mediaSource.getSampleFlags();
-                    frame.bufferInfo.set(0, bytesRead, sampleTime, sampleFlags);
-                    decoder.queueInputFrame(frame);
-                    mediaSource.advance();
-                    //Log.d(TAG, "Sample time: " + sampleTime + ", source bytes read: " + bytesRead);
-                } else {
+                long sampleTime = mediaSource.getSampleTime();
+                int sampleFlags = mediaSource.getSampleFlags();
+                if (bytesRead <= 0 || (sampleFlags & MediaCodec.BUFFER_FLAG_END_OF_STREAM) != 0) {
                     frame.bufferInfo.set(0, 0, -1, MediaCodec.BUFFER_FLAG_END_OF_STREAM);
                     decoder.queueInputFrame(frame);
                     extractFrameResult = RESULT_EOS_REACHED;
                     Log.d(TAG, "EoS reached on the input stream");
+                } else if (sampleTime >= sourceMediaSelection.getEnd()) {
+                    if (extractFrameResult != RESULT_EOS_REACHED) {
+                        frame.bufferInfo.set(0, 0, -1, MediaCodec.BUFFER_FLAG_END_OF_STREAM);
+                        decoder.queueInputFrame(frame);
+                        extractFrameResult = RESULT_EOS_REACHED;
+                        Log.d(TAG, "Selection end reached on the input stream");
+                    }
+                    mediaSource.advance();
+                } else {
+                    frame.bufferInfo.set(0, bytesRead, sampleTime, sampleFlags);
+                    decoder.queueInputFrame(frame);
+                    mediaSource.advance();
+                    //Log.d(TAG, "Sample time: " + sampleTime + ", source bytes read: " + bytesRead);
                 }
             } else {
                 switch (tag) {
@@ -160,7 +168,10 @@ public class AudioTrackTranscoder extends TrackTranscoder {
                 throw new TrackTranscoderException(TrackTranscoderException.Error.NO_FRAME_AVAILABLE);
             }
 
-            renderer.renderFrame(decoderOutputFrame, decoderOutputFrame.bufferInfo.presentationTimeUs);
+            if (decoderOutputFrame.bufferInfo.presentationTimeUs >= sourceMediaSelection.getStart()
+                    || (decoderOutputFrame.bufferInfo.flags & MediaCodec.BUFFER_FLAG_END_OF_STREAM) != 0) {
+                renderer.renderFrame(decoderOutputFrame, decoderOutputFrame.bufferInfo.presentationTimeUs - sourceMediaSelection.getStart());
+            }
             decoder.releaseOutputFrame(tag, false);
 
             if ((decoderOutputFrame.bufferInfo.flags & MediaCodec.BUFFER_FLAG_END_OF_STREAM) != 0) {

--- a/litr/src/main/java/com/linkedin/android/litr/transcoder/AudioTrackTranscoder.java
+++ b/litr/src/main/java/com/linkedin/android/litr/transcoder/AudioTrackTranscoder.java
@@ -130,21 +130,11 @@ public class AudioTrackTranscoder extends TrackTranscoder {
                     extractFrameResult = RESULT_EOS_REACHED;
                     Log.d(TAG, "EoS reached on the input stream");
                 } else if (sampleTime >= sourceMediaSelection.getEnd()) {
-                    if (extractFrameResult != RESULT_EOS_REACHED) {
-                        frame.bufferInfo.set(0, 0, -1, MediaCodec.BUFFER_FLAG_END_OF_STREAM);
-                        decoder.queueInputFrame(frame);
-                        extractFrameResult = RESULT_EOS_REACHED;
-                        Log.d(TAG, "Selection end reached on the input stream");
-                    }
-                    // done with this track, advance until track switches to let other track transcoders finish work
-                    while (mediaSource.getSampleTrackIndex() == sourceTrack) {
-                        mediaSource.advance();
-                        if ((mediaSource.getSampleFlags() & MediaCodec.BUFFER_FLAG_END_OF_STREAM) != 0) {
-                            // reached the end of container, no more tracks left
-                            extractFrameResult = RESULT_EOS_REACHED;
-                            break;
-                        }
-                    }
+                    frame.bufferInfo.set(0, 0, -1, MediaCodec.BUFFER_FLAG_END_OF_STREAM);
+                    decoder.queueInputFrame(frame);
+                    advanceToNextTrack();
+                    extractFrameResult = RESULT_EOS_REACHED;
+                    Log.d(TAG, "Selection end reached on the input stream");
                 } else {
                     frame.bufferInfo.set(0, bytesRead, sampleTime, sampleFlags);
                     decoder.queueInputFrame(frame);

--- a/litr/src/main/java/com/linkedin/android/litr/transcoder/PassthroughTranscoder.java
+++ b/litr/src/main/java/com/linkedin/android/litr/transcoder/PassthroughTranscoder.java
@@ -101,23 +101,13 @@ public class PassthroughTranscoder extends TrackTranscoder {
             lastResult = RESULT_EOS_REACHED;
             Log.d(TAG, "Reach EoS on input stream");
         } else if (sampleTime >= sourceMediaSelection.getEnd()) {
-            if (lastResult != RESULT_EOS_REACHED) {
-                outputBuffer.clear();
-                progress = 1.0f;
-                lastResult = RESULT_EOS_REACHED;
-                outputBufferInfo.set(0, 0, sampleTime - sourceMediaSelection.getStart(), outputBufferInfo.flags | MediaCodec.BUFFER_FLAG_END_OF_STREAM);
-                mediaMuxer.writeSampleData(targetTrack, outputBuffer, outputBufferInfo);
-                Log.d(TAG, "Reach selection end on input stream");
-            }
-            // done with this track, advance until track switches to let other track transcoders finish work
-            while (mediaSource.getSampleTrackIndex() == sourceTrack) {
-                mediaSource.advance();
-                if ((mediaSource.getSampleFlags() & MediaCodec.BUFFER_FLAG_END_OF_STREAM) != 0) {
-                    // reached the end of container, no more tracks left
-                    lastResult = RESULT_EOS_REACHED;
-                    break;
-                }
-            }
+            outputBuffer.clear();
+            progress = 1.0f;
+            outputBufferInfo.set(0, 0, sampleTime - sourceMediaSelection.getStart(), outputBufferInfo.flags | MediaCodec.BUFFER_FLAG_END_OF_STREAM);
+            mediaMuxer.writeSampleData(targetTrack, outputBuffer, outputBufferInfo);
+            advanceToNextTrack();
+            lastResult = RESULT_EOS_REACHED;
+            Log.d(TAG, "Reach selection end on input stream");
         } else {
             if (sampleTime >= sourceMediaSelection.getStart()) {
                 int outputFlags = 0;

--- a/litr/src/main/java/com/linkedin/android/litr/transcoder/PassthroughTranscoder.java
+++ b/litr/src/main/java/com/linkedin/android/litr/transcoder/PassthroughTranscoder.java
@@ -109,7 +109,15 @@ public class PassthroughTranscoder extends TrackTranscoder {
                 mediaMuxer.writeSampleData(targetTrack, outputBuffer, outputBufferInfo);
                 Log.d(TAG, "Reach selection end on input stream");
             }
-            mediaSource.advance();
+            // done with this track, advance until track switches to let other track transcoders finish work
+            while (mediaSource.getSampleTrackIndex() == sourceTrack) {
+                mediaSource.advance();
+                if ((mediaSource.getSampleFlags() & MediaCodec.BUFFER_FLAG_END_OF_STREAM) != 0) {
+                    // reached the end of container, no more tracks left
+                    lastResult = RESULT_EOS_REACHED;
+                    break;
+                }
+            }
         } else {
             if (sampleTime >= sourceMediaSelection.getStart()) {
                 int outputFlags = 0;

--- a/litr/src/main/java/com/linkedin/android/litr/transcoder/TrackTranscoder.java
+++ b/litr/src/main/java/com/linkedin/android/litr/transcoder/TrackTranscoder.java
@@ -74,6 +74,11 @@ public abstract class TrackTranscoder {
             }
         }
 
+
+        if (sourceMediaSelection.getEnd() < sourceMediaSelection.getStart()) {
+            throw new IllegalArgumentException("Range end should be greater than range start");
+        }
+
         // adjust for range
         duration = Math.min(duration, sourceMediaSelection.getEnd());
         duration -= sourceMediaSelection.getStart();

--- a/litr/src/main/java/com/linkedin/android/litr/transcoder/TrackTranscoder.java
+++ b/litr/src/main/java/com/linkedin/android/litr/transcoder/TrackTranscoder.java
@@ -14,6 +14,7 @@ import androidx.annotation.RestrictTo;
 import com.linkedin.android.litr.codec.Decoder;
 import com.linkedin.android.litr.codec.Encoder;
 import com.linkedin.android.litr.exception.TrackTranscoderException;
+import com.linkedin.android.litr.io.MediaRange;
 import com.linkedin.android.litr.io.MediaSource;
 import com.linkedin.android.litr.io.MediaTarget;
 import com.linkedin.android.litr.render.Renderer;
@@ -34,6 +35,7 @@ public abstract class TrackTranscoder {
     @Nullable protected final Renderer renderer;
     @Nullable protected final Decoder decoder;
     @Nullable protected final Encoder encoder;
+    @NonNull protected final MediaRange sourceMediaSelection;
 
     protected int sourceTrack;
     protected int targetTrack;
@@ -61,6 +63,7 @@ public abstract class TrackTranscoder {
         this.renderer = renderer;
         this.decoder = decoder;
         this.encoder = encoder;
+        this.sourceMediaSelection = mediaSource.getSelection();
 
         MediaFormat sourceMedia = mediaSource.getTrackFormat(sourceTrack);
         if (sourceMedia.containsKey(MediaFormat.KEY_DURATION)) {
@@ -69,6 +72,10 @@ public abstract class TrackTranscoder {
                 targetFormat.setLong(MediaFormat.KEY_DURATION, duration);
             }
         }
+
+        // adjust for range
+        duration = Math.min(duration, sourceMediaSelection.getEnd());
+        duration -= sourceMediaSelection.getStart();
     }
 
     public abstract void start() throws TrackTranscoderException;

--- a/litr/src/main/java/com/linkedin/android/litr/transcoder/TrackTranscoder.java
+++ b/litr/src/main/java/com/linkedin/android/litr/transcoder/TrackTranscoder.java
@@ -7,6 +7,7 @@
  */
 package com.linkedin.android.litr.transcoder;
 
+import android.media.MediaCodec;
 import android.media.MediaFormat;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -109,6 +110,17 @@ public abstract class TrackTranscoder {
     @NonNull
     public MediaFormat getTargetMediaFormat() {
         return targetFormat;
+    }
+
+    protected void advanceToNextTrack() {
+        // done with this track, advance until track switches to let other track transcoders finish work
+        while (mediaSource.getSampleTrackIndex() == sourceTrack) {
+            mediaSource.advance();
+            if ((mediaSource.getSampleFlags() & MediaCodec.BUFFER_FLAG_END_OF_STREAM) != 0) {
+                // reached the end of container, no more tracks left
+                return;
+            }
+        }
     }
 
 }

--- a/litr/src/main/java/com/linkedin/android/litr/transcoder/VideoTrackTranscoder.java
+++ b/litr/src/main/java/com/linkedin/android/litr/transcoder/VideoTrackTranscoder.java
@@ -150,21 +150,11 @@ public class VideoTrackTranscoder extends TrackTranscoder {
                     extractFrameResult = RESULT_EOS_REACHED;
                     Log.d(TAG, "EoS reached on the input stream");
                 } else if (sampleTime >= sourceMediaSelection.getEnd()) {
-                    if (extractFrameResult != RESULT_EOS_REACHED) {
-                        frame.bufferInfo.set(0, 0, -1, MediaCodec.BUFFER_FLAG_END_OF_STREAM);
-                        decoder.queueInputFrame(frame);
-                        extractFrameResult = RESULT_EOS_REACHED;
-                        Log.d(TAG, "EoS reached on the input stream");
-                    }
-                    // done with this track, advance until track switches to let other track transcoders finish work
-                    while (mediaSource.getSampleTrackIndex() == sourceTrack) {
-                        mediaSource.advance();
-                        if ((mediaSource.getSampleFlags() & MediaCodec.BUFFER_FLAG_END_OF_STREAM) != 0) {
-                            // reached the end of container, no more tracks left
-                            extractFrameResult = RESULT_EOS_REACHED;
-                            break;
-                        }
-                    }
+                    frame.bufferInfo.set(0, 0, -1, MediaCodec.BUFFER_FLAG_END_OF_STREAM);
+                    decoder.queueInputFrame(frame);
+                    advanceToNextTrack();
+                    extractFrameResult = RESULT_EOS_REACHED;
+                    Log.d(TAG, "EoS reached on the input stream");
                 } else {
                     frame.bufferInfo.set(0, bytesRead, sampleTime, sampleFlags);
                     decoder.queueInputFrame(frame);

--- a/litr/src/main/java/com/linkedin/android/litr/transcoder/VideoTrackTranscoder.java
+++ b/litr/src/main/java/com/linkedin/android/litr/transcoder/VideoTrackTranscoder.java
@@ -156,7 +156,15 @@ public class VideoTrackTranscoder extends TrackTranscoder {
                         extractFrameResult = RESULT_EOS_REACHED;
                         Log.d(TAG, "EoS reached on the input stream");
                     }
-                    mediaSource.advance();
+                    // done with this track, advance until track switches to let other track transcoders finish work
+                    while (mediaSource.getSampleTrackIndex() == sourceTrack) {
+                        mediaSource.advance();
+                        if ((mediaSource.getSampleFlags() & MediaCodec.BUFFER_FLAG_END_OF_STREAM) != 0) {
+                            // reached the end of container, no more tracks left
+                            extractFrameResult = RESULT_EOS_REACHED;
+                            break;
+                        }
+                    }
                 } else {
                     frame.bufferInfo.set(0, bytesRead, sampleTime, sampleFlags);
                     decoder.queueInputFrame(frame);

--- a/litr/src/test/java/com/linkedin/android/litr/transcoder/AudioTrackTranscoderShould.java
+++ b/litr/src/test/java/com/linkedin/android/litr/transcoder/AudioTrackTranscoderShould.java
@@ -13,6 +13,7 @@ import com.linkedin.android.litr.codec.Decoder;
 import com.linkedin.android.litr.codec.Encoder;
 import com.linkedin.android.litr.codec.Frame;
 import com.linkedin.android.litr.exception.TrackTranscoderException;
+import com.linkedin.android.litr.io.MediaRange;
 import com.linkedin.android.litr.io.MediaSource;
 import com.linkedin.android.litr.io.MediaTarget;
 import com.linkedin.android.litr.render.Renderer;
@@ -39,6 +40,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class AudioTrackTranscoderShould {
 
@@ -72,6 +74,9 @@ public class AudioTrackTranscoderShould {
         doReturn(sourceMediaFormat).when(mediaSource).getTrackFormat(anyInt());
         doReturn(true).when(decoder).isRunning();
         doReturn(true).when(encoder).isRunning();
+
+        MediaRange mediaRange = new MediaRange(0, Long.MAX_VALUE);
+        when(mediaSource.getSelection()).thenReturn(mediaRange);
 
         targetAudioFormat = new MediaFormat();
         targetAudioFormat.setString(MediaFormat.KEY_MIME, "audio/aac");

--- a/litr/src/test/java/com/linkedin/android/litr/transcoder/PassthroughTranscoderShould.java
+++ b/litr/src/test/java/com/linkedin/android/litr/transcoder/PassthroughTranscoderShould.java
@@ -9,6 +9,8 @@ package com.linkedin.android.litr.transcoder;
 
 import android.media.MediaCodec;
 import android.media.MediaFormat;
+
+import com.linkedin.android.litr.io.MediaRange;
 import com.linkedin.android.litr.io.MediaSource;
 import com.linkedin.android.litr.io.MediaTarget;
 import org.junit.Before;
@@ -53,6 +55,9 @@ public class PassthroughTranscoderShould {
         sourceMediaFormat = new MediaFormat();
         sourceMediaFormat.setLong(MediaFormat.KEY_DURATION, DURATION);
         when(mediaSource.getTrackFormat(SOURCE_TRACK)).thenReturn(sourceMediaFormat);
+
+        MediaRange mediaRange = new MediaRange(0, Long.MAX_VALUE);
+        when(mediaSource.getSelection()).thenReturn(mediaRange);
 
         passthroughTranscoder = spy(new PassthroughTranscoder(mediaSource, SOURCE_TRACK, mediaTarget, TARGET_TRACK));
         passthroughTranscoder.start();

--- a/litr/src/test/java/com/linkedin/android/litr/transcoder/VideoTrackTranscoderShould.java
+++ b/litr/src/test/java/com/linkedin/android/litr/transcoder/VideoTrackTranscoderShould.java
@@ -14,6 +14,7 @@ import com.linkedin.android.litr.codec.Decoder;
 import com.linkedin.android.litr.codec.Encoder;
 import com.linkedin.android.litr.codec.Frame;
 import com.linkedin.android.litr.exception.TrackTranscoderException;
+import com.linkedin.android.litr.io.MediaRange;
 import com.linkedin.android.litr.io.MediaSource;
 import com.linkedin.android.litr.io.MediaTarget;
 import com.linkedin.android.litr.render.GlVideoRenderer;
@@ -86,6 +87,9 @@ public class VideoTrackTranscoderShould {
         doReturn(surface).when(renderer).getInputSurface();
         doReturn(true).when(decoder).isRunning();
         doReturn(true).when(encoder).isRunning();
+
+        MediaRange mediaRange = new MediaRange(0, Long.MAX_VALUE);
+        when(mediaSource.getSelection()).thenReturn(mediaRange);
 
         when(targetVideoFormat.containsKey(MediaFormat.KEY_MIME)).thenReturn(true);
         when(targetVideoFormat.getString(MediaFormat.KEY_MIME)).thenReturn(TARGET_MIME_TYPE);


### PR DESCRIPTION
New functionality that allows selecting a range within MediaSource (effectively allowing to trim media):
 - new MediaRange data is introduced to define range (more verbose than Java `Range`), values are in microseconds to match MediaSource.seekTo
 - if no range is specified, default range is passed in, which contains entire MediaSource duration (0 to Long.MAX_VALUE)
 - MediaExtractorMediaSource automatically seeks to range start, to speed up transformation
 - track transcoders decide which frames to process and which to discard
 - frame presentation times are modified when trimming

Source selection is only supported through APIs that use MediaSource. Support in basic API will be added in upcoming PR.

Behavior is verified using manual testing. Unit tests are coming in upcoming PR.