### PR TITLE
Pass presentation time to audio renderer in nanoseconds

### DIFF
--- a/litr/src/main/java/com/linkedin/android/litr/render/PassthroughSoftwareRenderer.java
+++ b/litr/src/main/java/com/linkedin/android/litr/render/PassthroughSoftwareRenderer.java
@@ -64,7 +64,7 @@ public class PassthroughSoftwareRenderer implements Renderer {
             outputFrame.bufferInfo.set(
                     0,
                     frame.bufferInfo.size,
-                    presentationTimeNs,
+                    TimeUnit.NANOSECONDS.toMicros(presentationTimeNs),
                     frame.bufferInfo.flags);
             encoder.queueInputFrame(outputFrame);
         } else {

--- a/litr/src/main/java/com/linkedin/android/litr/transcoder/AudioTrackTranscoder.java
+++ b/litr/src/main/java/com/linkedin/android/litr/transcoder/AudioTrackTranscoder.java
@@ -21,6 +21,8 @@ import com.linkedin.android.litr.io.MediaSource;
 import com.linkedin.android.litr.io.MediaTarget;
 import com.linkedin.android.litr.render.Renderer;
 
+import java.util.concurrent.TimeUnit;
+
 @RestrictTo(RestrictTo.Scope.LIBRARY)
 public class AudioTrackTranscoder extends TrackTranscoder {
     private static final String TAG = AudioTrackTranscoder.class.getSimpleName();
@@ -168,7 +170,8 @@ public class AudioTrackTranscoder extends TrackTranscoder {
 
             if (decoderOutputFrame.bufferInfo.presentationTimeUs >= sourceMediaSelection.getStart()
                     || (decoderOutputFrame.bufferInfo.flags & MediaCodec.BUFFER_FLAG_END_OF_STREAM) != 0) {
-                renderer.renderFrame(decoderOutputFrame, decoderOutputFrame.bufferInfo.presentationTimeUs - sourceMediaSelection.getStart());
+                renderer.renderFrame(decoderOutputFrame,
+                        TimeUnit.MICROSECONDS.toNanos(decoderOutputFrame.bufferInfo.presentationTimeUs - sourceMediaSelection.getStart()));
             }
             decoder.releaseOutputFrame(tag, false);
 

--- a/litr/src/main/java/com/linkedin/android/litr/transcoder/VideoTrackTranscoder.java
+++ b/litr/src/main/java/com/linkedin/android/litr/transcoder/VideoTrackTranscoder.java
@@ -22,14 +22,14 @@ import com.linkedin.android.litr.io.MediaTarget;
 import com.linkedin.android.litr.render.GlVideoRenderer;
 import com.linkedin.android.litr.render.Renderer;
 
+import java.util.concurrent.TimeUnit;
+
 /**
  * Transcoder that processes video tracks.
  */
 @RestrictTo(RestrictTo.Scope.LIBRARY)
 public class VideoTrackTranscoder extends TrackTranscoder {
     private static final String TAG = VideoTrackTranscoder.class.getSimpleName();
-
-    private static final long MILLISECONDS_IN_SECOND = 1000;
 
     @VisibleForTesting int lastExtractFrameResult;
     @VisibleForTesting int lastDecodeFrameResult;
@@ -193,7 +193,8 @@ public class VideoTrackTranscoder extends TrackTranscoder {
             } else {
                 decoder.releaseOutputFrame(tag, true);
                 if (frame.bufferInfo.presentationTimeUs >= sourceMediaSelection.getStart()) {
-                    renderer.renderFrame(null, (frame.bufferInfo.presentationTimeUs - sourceMediaSelection.getStart()) * MILLISECONDS_IN_SECOND);
+                    renderer.renderFrame(null,
+                            TimeUnit.MICROSECONDS.toNanos(frame.bufferInfo.presentationTimeUs - sourceMediaSelection.getStart()));
                 }
             }
         } else {

--- a/litr/src/test/java/com/linkedin/android/litr/transcoder/AudioTrackTranscoderShould.java
+++ b/litr/src/test/java/com/linkedin/android/litr/transcoder/AudioTrackTranscoderShould.java
@@ -558,7 +558,7 @@ public class AudioTrackTranscoderShould {
 
         audioTrackTranscoder.processNextFrame();
 
-        verify(renderer).renderFrame(frame, CURRENT_PRESENTATION_TIME - SELECTION_START);
+        verify(renderer).renderFrame(frame, TimeUnit.MICROSECONDS.toNanos(CURRENT_PRESENTATION_TIME - SELECTION_START));
         verify(decoder).releaseOutputFrame(tag, false);
     }
 

--- a/litr/src/test/java/com/linkedin/android/litr/transcoder/AudioTrackTranscoderShould.java
+++ b/litr/src/test/java/com/linkedin/android/litr/transcoder/AudioTrackTranscoderShould.java
@@ -25,6 +25,7 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import java.nio.ByteBuffer;
+import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
@@ -325,7 +326,7 @@ public class AudioTrackTranscoderShould {
 
         int result = audioTrackTranscoder.processNextFrame();
 
-        verify(renderer).renderFrame(frame, CURRENT_PRESENTATION_TIME);
+        verify(renderer).renderFrame(frame, TimeUnit.MICROSECONDS.toNanos(CURRENT_PRESENTATION_TIME));
         verify(encoder, never()).getInputFrame(anyInt());
 
         assertThat(result, is(TrackTranscoder.RESULT_FRAME_PROCESSED));
@@ -351,7 +352,7 @@ public class AudioTrackTranscoderShould {
 
         int result = audioTrackTranscoder.processNextFrame();
 
-        verify(renderer).renderFrame(decoderOutputFrame, CURRENT_PRESENTATION_TIME);
+        verify(renderer).renderFrame(decoderOutputFrame, TimeUnit.MICROSECONDS.toNanos(CURRENT_PRESENTATION_TIME));
         verify(decoder).releaseOutputFrame(BUFFER_INDEX, false);
 
         assertThat(result, is(TrackTranscoder.RESULT_EOS_REACHED));


### PR DESCRIPTION
Audio transcoder was passing in time stamp to its renderer in microseconds, directly from BufferInfo.presentationTimeUs. According to `Renderer.render` interface spec, timestamp must be in nanoseconds. Fixing this. 
Also, using same `TimeUnit` util in video track transcoder.