### PR TITLE
Take MediaRange into account when estimating target size

### DIFF
--- a/litr/src/test/java/com/linkedin/android/litr/TransformationJobShould.java
+++ b/litr/src/test/java/com/linkedin/android/litr/TransformationJobShould.java
@@ -14,6 +14,7 @@ import com.linkedin.android.litr.codec.Decoder;
 import com.linkedin.android.litr.codec.Encoder;
 import com.linkedin.android.litr.exception.InsufficientDiskSpaceException;
 import com.linkedin.android.litr.exception.TrackTranscoderException;
+import com.linkedin.android.litr.io.MediaRange;
 import com.linkedin.android.litr.io.MediaSource;
 import com.linkedin.android.litr.io.MediaTarget;
 import com.linkedin.android.litr.render.Renderer;
@@ -94,6 +95,8 @@ public class TransformationJobShould {
 
         doReturn(sourceVideoFormat).when(mediaSource).getTrackFormat(0);
         doReturn(sourceAudioFormat).when(mediaSource).getTrackFormat(1);
+
+        when(mediaSource.getSelection()).thenReturn(new MediaRange(0, Long.MAX_VALUE));
 
         doReturn("video/avc").when(sourceVideoFormat).getString(MediaFormat.KEY_MIME);
         doReturn("audio/aac").when(sourceAudioFormat).getString(MediaFormat.KEY_MIME);

--- a/litr/src/test/java/com/linkedin/android/litr/utils/TranscoderUtilsShould.java
+++ b/litr/src/test/java/com/linkedin/android/litr/utils/TranscoderUtilsShould.java
@@ -8,7 +8,10 @@
 package com.linkedin.android.litr.utils;
 
 import android.media.MediaFormat;
+
+import com.linkedin.android.litr.io.MediaRange;
 import com.linkedin.android.litr.io.MediaSource;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -69,6 +72,7 @@ public class TranscoderUtilsShould {
 
         when(mediaSource.getTrackFormat(0)).thenReturn(videoMediaFormat);
         when(mediaSource.getTrackFormat(1)).thenReturn(audioMediaFormat);
+        when(mediaSource.getSelection()).thenReturn(new MediaRange(0, Long.MAX_VALUE));
     }
 
     @Test


### PR DESCRIPTION
Whenever the library estimates the target media's size, it always checks for the track durations, not the user defined `MediaRange`s. This PR adds the missing functionality which will improve the size estimation when video trimming is involved.

PR includes a test where the trimmed (half the mocked track length) estimated size is half of the default track size.