### PR TITLE
Encoder and/or decoder not found exception erroneously thrown #85

### DIFF
--- a/litr/src/main/java/com/linkedin/android/litr/codec/MediaCodecDecoder.java
+++ b/litr/src/main/java/com/linkedin/android/litr/codec/MediaCodecDecoder.java
@@ -16,6 +16,7 @@ import androidx.annotation.IntRange;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.linkedin.android.litr.exception.TrackTranscoderException;
+import com.linkedin.android.litr.utils.CodecUtils;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -38,6 +39,9 @@ public final class MediaCodecDecoder implements Decoder {
             if (Build.VERSION.SDK_INT > Build.VERSION_CODES.LOLLIPOP) {
                 mediaCodecList = new MediaCodecList(MediaCodecList.ALL_CODECS);
                 String decoderCodecName = mediaCodecList.findDecoderForFormat(mediaFormat);
+                if (decoderCodecName == null) {
+                    decoderCodecName = CodecUtils.getSupportedCodecName(sourceMimeType, false);
+                }
                 if (decoderCodecName != null) {
                     mediaCodec = MediaCodec.createByCodecName(decoderCodecName);
                 }

--- a/litr/src/main/java/com/linkedin/android/litr/codec/MediaCodecEncoder.java
+++ b/litr/src/main/java/com/linkedin/android/litr/codec/MediaCodecEncoder.java
@@ -17,6 +17,7 @@ import androidx.annotation.IntRange;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.linkedin.android.litr.exception.TrackTranscoderException;
+import com.linkedin.android.litr.utils.CodecUtils;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -44,6 +45,9 @@ public class MediaCodecEncoder implements Encoder {
             if (Build.VERSION.SDK_INT > Build.VERSION_CODES.LOLLIPOP) {
                 mediaCodecList = new MediaCodecList(MediaCodecList.ALL_CODECS);
                 String encoderCodecName = mediaCodecList.findEncoderForFormat(targetFormat);
+                if (encoderCodecName == null) {
+                    encoderCodecName = CodecUtils.getSupportedCodecName(targetFormat.getString(MediaFormat.KEY_MIME), true);
+                }
                 if (encoderCodecName != null) {
                     mediaCodec = MediaCodec.createByCodecName(encoderCodecName);
                 }

--- a/litr/src/main/java/com/linkedin/android/litr/utils/CodecUtils.java
+++ b/litr/src/main/java/com/linkedin/android/litr/utils/CodecUtils.java
@@ -156,6 +156,34 @@ public class CodecUtils {
         return highestSupportedProfile;
     }
 
+    /**
+     * Attempts to find a supported codec name for a given MIME type. Iterates through all codecs
+     * available, and filters by encoders and/or decoders, depending on the flag passed in the
+     * parameters.
+     *
+     * @param mimeType media MIME type
+     * @param isEncoder search through encoder codecs if true, decoder codecs if false
+     * @return a String with the first codec name supported in the device for that MIME type
+     */
+    public static String getSupportedCodecName(String mimeType, boolean isEncoder) {
+        int numCodecs = MediaCodecList.getCodecCount();
+        for (int i = 0; i < numCodecs; i++) {
+            MediaCodecInfo codecInfo = MediaCodecList.getCodecInfoAt(i);
+
+            if (codecInfo.isEncoder() != isEncoder) {
+                continue;
+            }
+
+            String[] types = codecInfo.getSupportedTypes();
+            for (int j = 0; j < types.length; j++) {
+                if (types[j].equalsIgnoreCase(mimeType)) {
+                    return codecInfo.getName();
+                }
+            }
+        }
+        return null;
+    }
+
     private static boolean supportsType(@NonNull MediaCodecInfo mediaCodecInfo, @NonNull String mimeType) {
         String[] supportedTypes = mediaCodecInfo.getSupportedTypes();
         for (String supportedType : supportedTypes) {


### PR DESCRIPTION
# Description

## Story Type (bug fix)
[LiTr-85](https://github.com/linkedin/LiTr/issues/85)

## Problem
While testing the new trimming capabilities in different devices I noticed that the `TrackTranscoderException.Error.ENCODER_NOT_FOUND` was thrown in most of my test devices. While doing few more tests and debugging I think that the issue might be originated by the way the method `isFormatSupported` in `MediaCodecInfo` from the Android media API is implemented to find out if a MediaFormat is supported on a device.

'MediaCodecList` class in LiTr has the following method:

```
    private String findCodecForFormat(boolean encoder, MediaFormat format) {
        String mime = format.getString(MediaFormat.KEY_MIME);
        for (MediaCodecInfo info: mCodecInfos) {
            if (info.isEncoder() != encoder) {
                continue;
            }
            try {
                MediaCodecInfo.CodecCapabilities caps = info.getCapabilitiesForType(mime);
                if (caps != null && caps.isFormatSupported(format)) {
                    return info.getName();
                }
            } catch (IllegalArgumentException e) {
                // type is not supported
            }
        }
        return null;
    }
```

In the method shown above, the call to `caps.isFormatSupported(format)` always returns false in some of the devices that I used for my tests which also causes that 'mediaCodec' in the `init` method of `MediaCodecEncoder` and `MediaCodecDecoder` could not be initialized and the `TrackTranscoderException.Error.ENCODER_NOT_FOUND` is thrown.

I believe this might be a bug, since the devices that I used for tests have encoders and decoders that can be used to transcode the media formats that were passed during those tests. I think that this bug might not allow some transcoding features using LiTr library to work on devices that could.
 
## Changes
Created a `getSupportedCodecName` method in `CodecUtils` which attempts to find a supported codec name for a given MIME type. This method is called in the `init` method of `MediaCodecEncoder` and `MediaCodecDecoder` to initialize the 'mediaCodec' object.

## Devices used for tests:

- Google Pixel 3a with Android 11
- Huawei Nexus 6P with Android 8.1
- Motorola e4 with Android 7.1.1
- LG G Pad F2 8.0 with Android 7.1.1
