### PR TITLE
Not try to write encoded audio frame with negative presentation time

### DIFF
--- a/litr/src/main/java/com/linkedin/android/litr/transcoder/AudioTrackTranscoder.java
+++ b/litr/src/main/java/com/linkedin/android/litr/transcoder/AudioTrackTranscoder.java
@@ -207,19 +207,16 @@ public class AudioTrackTranscoder extends TrackTranscoder {
                 throw new TrackTranscoderException(TrackTranscoderException.Error.NO_FRAME_AVAILABLE);
             }
 
-            if (frame.bufferInfo.size > 0
-                    && (frame.bufferInfo.flags & MediaCodec.BUFFER_FLAG_CODEC_CONFIG) == 0
-                    && frame.bufferInfo.presentationTimeUs >= 0) {
-                mediaMuxer.writeSampleData(targetTrack, frame.buffer, frame.bufferInfo);
-                if (duration > 0) {
-                    progress = ((float) frame.bufferInfo.presentationTimeUs) / duration;
-                }
-            }
-
             if ((frame.bufferInfo.flags & MediaCodec.BUFFER_FLAG_END_OF_STREAM) != 0) {
                 Log.d(TAG, "Encoder produced EoS, we are done");
                 progress = 1.0f;
                 encodeFrameResult = RESULT_EOS_REACHED;
+            } else if (frame.bufferInfo.size > 0
+                    && (frame.bufferInfo.flags & MediaCodec.BUFFER_FLAG_CODEC_CONFIG) == 0) {
+                mediaMuxer.writeSampleData(targetTrack, frame.buffer, frame.bufferInfo);
+                if (duration > 0) {
+                    progress = ((float) frame.bufferInfo.presentationTimeUs) / duration;
+                }
             }
 
             encoder.releaseOutputFrame(tag);

--- a/litr/src/main/java/com/linkedin/android/litr/transcoder/AudioTrackTranscoder.java
+++ b/litr/src/main/java/com/linkedin/android/litr/transcoder/AudioTrackTranscoder.java
@@ -208,7 +208,8 @@ public class AudioTrackTranscoder extends TrackTranscoder {
             }
 
             if (frame.bufferInfo.size > 0
-                && (frame.bufferInfo.flags & MediaCodec.BUFFER_FLAG_CODEC_CONFIG) == 0) {
+                    && (frame.bufferInfo.flags & MediaCodec.BUFFER_FLAG_CODEC_CONFIG) == 0
+                    && frame.bufferInfo.presentationTimeUs >= 0) {
                 mediaMuxer.writeSampleData(targetTrack, frame.buffer, frame.bufferInfo);
                 if (duration > 0) {
                     progress = ((float) frame.bufferInfo.presentationTimeUs) / duration;

--- a/litr/src/main/java/com/linkedin/android/litr/transcoder/VideoTrackTranscoder.java
+++ b/litr/src/main/java/com/linkedin/android/litr/transcoder/VideoTrackTranscoder.java
@@ -226,18 +226,16 @@ public class VideoTrackTranscoder extends TrackTranscoder {
                 throw new TrackTranscoderException(TrackTranscoderException.Error.NO_FRAME_AVAILABLE);
             }
 
-            if (frame.bufferInfo.size > 0
+            if ((frame.bufferInfo.flags & MediaCodec.BUFFER_FLAG_END_OF_STREAM) != 0) {
+                Log.d(TAG, "Encoder produced EoS, we are done");
+                progress = 1.0f;
+                encodeFrameResult = RESULT_EOS_REACHED;
+            } else if (frame.bufferInfo.size > 0
                 && (frame.bufferInfo.flags & MediaCodec.BUFFER_FLAG_CODEC_CONFIG) == 0) {
                 mediaMuxer.writeSampleData(targetTrack, frame.buffer, frame.bufferInfo);
                 if (duration > 0) {
                     progress = ((float) frame.bufferInfo.presentationTimeUs) / duration;
                 }
-            }
-
-            if ((frame.bufferInfo.flags & MediaCodec.BUFFER_FLAG_END_OF_STREAM) != 0) {
-                Log.d(TAG, "Encoder produced EoS, we are done");
-                progress = 1.0f;
-                encodeFrameResult = RESULT_EOS_REACHED;
             }
 
             encoder.releaseOutputFrame(index);

--- a/litr/src/test/java/com/linkedin/android/litr/transcoder/AudioTrackTranscoderShould.java
+++ b/litr/src/test/java/com/linkedin/android/litr/transcoder/AudioTrackTranscoderShould.java
@@ -437,31 +437,6 @@ public class AudioTrackTranscoderShould {
     }
 
     @Test
-    public void notWriteWhenEncodedFrameHasIllegalPresentationTime() throws Exception {
-        audioTrackTranscoder.lastExtractFrameResult = TrackTranscoder.RESULT_EOS_REACHED;
-        audioTrackTranscoder.lastDecodeFrameResult = TrackTranscoder.RESULT_EOS_REACHED;
-        audioTrackTranscoder.lastEncodeFrameResult = TrackTranscoder.RESULT_FRAME_PROCESSED;
-        audioTrackTranscoder.targetTrack = AUDIO_TRACK;
-        audioTrackTranscoder.duration = DURATION;
-
-        MediaCodec.BufferInfo bufferInfo = new MediaCodec.BufferInfo();
-        bufferInfo.flags = 0;
-        bufferInfo.size = BUFFER_SIZE;
-        bufferInfo.presentationTimeUs = -1;
-        Frame frame = new Frame(BUFFER_INDEX, ByteBuffer.allocate(BUFFER_SIZE), bufferInfo);
-
-        doReturn(BUFFER_INDEX).when(encoder).dequeueOutputFrame(anyLong());
-        doReturn(frame).when(encoder).getOutputFrame(anyInt());
-
-        int result = audioTrackTranscoder.processNextFrame();
-
-        verify(mediaTarget, never()).writeSampleData(anyInt(), any(ByteBuffer.class), any(MediaCodec.BufferInfo.class));
-
-        verify(encoder).releaseOutputFrame(eq(BUFFER_INDEX));
-        assertThat(result, is(TrackTranscoder.RESULT_FRAME_PROCESSED));
-    }
-
-    @Test
     public void finishWhenEosReceived() throws Exception {
         audioTrackTranscoder.lastExtractFrameResult = TrackTranscoder.RESULT_EOS_REACHED;
         audioTrackTranscoder.lastDecodeFrameResult = TrackTranscoder.RESULT_EOS_REACHED;


### PR DESCRIPTION
Last audio frame (with EOS flag) has a presentation time of -1, which causes an `IllegalArgumentException` on `MediaMuxer` when we try to write it. This was not happening on newer devices, because buffer size was zero, which prevents `AudioTrackTranscoder` from writing. But on some older devices (such as Samsung Galaxy S5) buffer size would be non-zero, which would make transcoding fail. 
To fix that, we reverse the check - we check if audio frame is EOS before doing any other checks, and not write EOS frame at all.