### PR TITLE
Fix renderFrame logic in PassthroughSoftwareRenderer

### DIFF
--- a/litr/src/main/java/com/linkedin/android/litr/TransformationJob.java
+++ b/litr/src/main/java/com/linkedin/android/litr/TransformationJob.java
@@ -245,10 +245,20 @@ class TransformationJob implements Runnable {
             mediaTargets.add(trackTransform.getMediaTarget());
         }
         for (MediaSource mediaSource : mediaSources) {
-            mediaSource.release();
+            try {
+                // Sometimes this method will throw an exception, so we just need to catch it.
+                mediaSource.release();
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
         }
         for (MediaTarget mediaTarget : mediaTargets) {
-            mediaTarget.release();
+            try {
+                // Sometimes this method will throw an exception, so we just need to catch it.
+                mediaTarget.release();
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
             if (!success) {
                 deleteOutputFile(mediaTarget.getOutputFilePath());
             }

--- a/litr/src/main/java/com/linkedin/android/litr/TransformationJob.java
+++ b/litr/src/main/java/com/linkedin/android/litr/TransformationJob.java
@@ -245,20 +245,10 @@ class TransformationJob implements Runnable {
             mediaTargets.add(trackTransform.getMediaTarget());
         }
         for (MediaSource mediaSource : mediaSources) {
-            try {
-                // Sometimes this method will throw an exception, so we just need to catch it.
-                mediaSource.release();
-            } catch (Exception e) {
-                e.printStackTrace();
-            }
+            mediaSource.release();
         }
         for (MediaTarget mediaTarget : mediaTargets) {
-            try {
-                // Sometimes this method will throw an exception, so we just need to catch it.
-                mediaTarget.release();
-            } catch (Exception e) {
-                e.printStackTrace();
-            }
+            mediaTarget.release();
             if (!success) {
                 deleteOutputFile(mediaTarget.getOutputFilePath());
             }

--- a/litr/src/main/java/com/linkedin/android/litr/codec/MediaCodecDecoder.java
+++ b/litr/src/main/java/com/linkedin/android/litr/codec/MediaCodecDecoder.java
@@ -105,7 +105,7 @@ public final class MediaCodecDecoder implements Decoder {
 
     @Override
     public int dequeueOutputFrame(long timeout) {
-        return mediaCodec.dequeueOutputBuffer(outputBufferInfo, 0);
+        return mediaCodec.dequeueOutputBuffer(outputBufferInfo, timeout);
     }
 
     @Override

--- a/litr/src/main/java/com/linkedin/android/litr/render/PassthroughSoftwareRenderer.java
+++ b/litr/src/main/java/com/linkedin/android/litr/render/PassthroughSoftwareRenderer.java
@@ -83,11 +83,11 @@ public class PassthroughSoftwareRenderer implements Renderer {
                     outputFrame.buffer.put(inputBuffer);
                 }
 
-                outputFrame.bufferInfo.set(
-                        0,
-                        capacity,
-                        TimeUnit.NANOSECONDS.toMicros(presentationTimeNs),
-                        frame.bufferInfo.flags);
+                MediaCodec.BufferInfo bufferInfo = outputFrame.bufferInfo;
+                bufferInfo.offset = 0;
+                bufferInfo.size = capacity;
+                bufferInfo.presentationTimeUs = TimeUnit.NANOSECONDS.toMicros(presentationTimeNs);
+                bufferInfo.flags = frame.bufferInfo.flags;
                 encoder.queueInputFrame(outputFrame);
 
                 areBytesRemaining = inputBuffer.hasRemaining();

--- a/litr/src/main/java/com/linkedin/android/litr/render/PassthroughSoftwareRenderer.java
+++ b/litr/src/main/java/com/linkedin/android/litr/render/PassthroughSoftwareRenderer.java
@@ -74,10 +74,11 @@ public class PassthroughSoftwareRenderer implements Renderer {
 
                 if (outputFrame.buffer.remaining() < inputBuffer.remaining()) {
                     capacity = outputFrame.buffer.remaining();
-                    inputByteBuffer = new byte[capacity];
+                    if (inputByteBuffer == null || inputByteBuffer.length < capacity) {
+                        inputByteBuffer = new byte[capacity];
+                    }
                     inputBuffer.get(inputByteBuffer, 0, capacity);
-
-                    outputFrame.buffer.put(inputByteBuffer);
+                    outputFrame.buffer.put(inputByteBuffer, 0, capacity);
                 } else {
                     capacity = inputBuffer.remaining();
                     outputFrame.buffer.put(inputBuffer);


### PR DESCRIPTION
1. Fix an issue in renderFrame() method inside PassthroughSoftwareRenderer class, where it throws a BufferOverflowException when the InputBuffer's size is larger than the OutputBuffer's size.
2. Add a try-catch to some release() methods, where it's safe to catch the exception and not throw it, also to not make wrong behavior where the onError method of TransformationListener will not be called.
3. This pull request will fix the opened issue in litr, https://github.com/linkedin/LiTr/issues/102 