### PR TITLE
Make the default FRAME_WAIT_TIMEOUT equals to zero

### DIFF
--- a/litr/src/main/java/com/linkedin/android/litr/render/PassthroughSoftwareRenderer.java
+++ b/litr/src/main/java/com/linkedin/android/litr/render/PassthroughSoftwareRenderer.java
@@ -24,16 +24,22 @@ import java.util.concurrent.TimeUnit;
 
 public class PassthroughSoftwareRenderer implements Renderer {
 
-    @VisibleForTesting static final long FRAME_WAIT_TIMEOUT = TimeUnit.SECONDS.toMicros(10);
+    @VisibleForTesting static final long FRAME_WAIT_TIMEOUT = TimeUnit.SECONDS.toMicros(0);
 
     private static final String TAG = "PassthroughSwRenderer";
 
     @NonNull public final Encoder encoder;
+    public final long frameWaitTimeoutUs;
 
     private byte[] inputByteBuffer = null;
 
     public PassthroughSoftwareRenderer(@NonNull Encoder encoder) {
+        this(encoder, FRAME_WAIT_TIMEOUT);
+    }
+
+    public PassthroughSoftwareRenderer(@NonNull Encoder encoder, long frameWaitTimeoutUs) {
         this.encoder = encoder;
+        this.frameWaitTimeoutUs = frameWaitTimeoutUs;
     }
 
     @Override
@@ -58,7 +64,7 @@ public class PassthroughSoftwareRenderer implements Renderer {
         boolean areBytesRemaining;
         do {
             areBytesRemaining = false;
-            int tag = encoder.dequeueInputFrame(FRAME_WAIT_TIMEOUT);
+            int tag = encoder.dequeueInputFrame(frameWaitTimeoutUs);
             if (tag >= 0) {
                 Frame outputFrame = encoder.getInputFrame(tag);
                 if (outputFrame == null) {

--- a/litr/src/test/java/com/linkedin/android/litr/render/PassthroughSoftwareRendererShould.java
+++ b/litr/src/test/java/com/linkedin/android/litr/render/PassthroughSoftwareRendererShould.java
@@ -59,7 +59,7 @@ public class PassthroughSoftwareRendererShould {
                 inputBuffer,
                 bufferInfo);
 
-        renderer = new PassthroughSoftwareRenderer(encoder);
+        renderer = new PassthroughSoftwareRenderer(encoder, FRAME_WAIT_TIMEOUT);
     }
 
     @Test


### PR DESCRIPTION
- Make the default FRAME_WAIT_TIMEOUT equals to zero, because on some device the previous value cause a very very long processing time

- Add the ability to configure the FRAME_WAIT_TIMEOUT in the constructor as a parameter