### PR TITLE
Enhance the logic for finding a media codec for a media format

### DIFF
--- a/litr-demo/src/main/java/com/linkedin/android/litr/demo/data/TransformationPresenter.java
+++ b/litr-demo/src/main/java/com/linkedin/android/litr/demo/data/TransformationPresenter.java
@@ -115,8 +115,8 @@ public class TransformationPresenter {
                                                                                           mediaTarget)
                     .setTargetTrack(trackTransforms.size())
                     .setTargetFormat(targetTrack.shouldTranscode ? createMediaFormat(targetTrack) : null)
-                    .setEncoder(new MediaCodecEncoder(true))
-                    .setDecoder(new MediaCodecDecoder(true));
+                    .setEncoder(new MediaCodecEncoder())
+                    .setDecoder(new MediaCodecDecoder());
                 if (targetTrack.format instanceof VideoTrackFormat) {
                     trackTransformBuilder.setRenderer(new GlVideoRenderer(createGlFilters(sourceMedia,
                             (TargetVideoTrack) targetTrack,

--- a/litr/src/main/java/com/linkedin/android/litr/codec/MediaCodecDecoder.java
+++ b/litr/src/main/java/com/linkedin/android/litr/codec/MediaCodecDecoder.java
@@ -24,19 +24,21 @@ import java.nio.ByteBuffer;
 public final class MediaCodecDecoder implements Decoder {
 
     private final boolean fallbackToGetCodecByType;
+    private final boolean filterByTypeAndFormat;
 
     private MediaCodec mediaCodec;
 
     private boolean isRunning;
     private boolean isReleased;
-    private MediaCodec.BufferInfo outputBufferInfo = new MediaCodec.BufferInfo();
+    private final MediaCodec.BufferInfo outputBufferInfo = new MediaCodec.BufferInfo();
 
     public MediaCodecDecoder() {
-        this(true);
+        this(true, true);
     }
 
-    public MediaCodecDecoder(boolean fallbackToGetCodecByType) {
+    public MediaCodecDecoder(boolean fallbackToGetCodecByType, boolean filterByTypeAndFormat) {
         this.fallbackToGetCodecByType = fallbackToGetCodecByType;
+        this.filterByTypeAndFormat = filterByTypeAndFormat;
     }
 
     @Override
@@ -48,7 +50,8 @@ public final class MediaCodecDecoder implements Decoder {
                 TrackTranscoderException.Error.DECODER_NOT_FOUND,
                 TrackTranscoderException.Error.DECODER_FORMAT_NOT_FOUND,
                 TrackTranscoderException.Error.DECODER_CONFIGURATION_ERROR,
-                fallbackToGetCodecByType);
+                fallbackToGetCodecByType,
+                filterByTypeAndFormat);
         isReleased = mediaCodec == null;
     }
 

--- a/litr/src/main/java/com/linkedin/android/litr/codec/MediaCodecDecoder.java
+++ b/litr/src/main/java/com/linkedin/android/litr/codec/MediaCodecDecoder.java
@@ -33,7 +33,11 @@ public final class MediaCodecDecoder implements Decoder {
     private final MediaCodec.BufferInfo outputBufferInfo = new MediaCodec.BufferInfo();
 
     public MediaCodecDecoder() {
-        this(true, true);
+        this(true);
+    }
+
+    public MediaCodecDecoder(boolean fallbackToGetCodecByType) {
+        this(fallbackToGetCodecByType, false);
     }
 
     public MediaCodecDecoder(boolean fallbackToGetCodecByType, boolean filterByTypeAndFormat) {

--- a/litr/src/main/java/com/linkedin/android/litr/codec/MediaCodecEncoder.java
+++ b/litr/src/main/java/com/linkedin/android/litr/codec/MediaCodecEncoder.java
@@ -35,7 +35,11 @@ public class MediaCodecEncoder implements Encoder {
     private final MediaCodec.BufferInfo encoderOutputBufferInfo = new MediaCodec.BufferInfo();
 
     public MediaCodecEncoder() {
-        this(true, true);
+        this(true);
+    }
+
+    public MediaCodecEncoder(boolean fallbackToGetCodecByType) {
+        this(fallbackToGetCodecByType, false);
     }
 
     public MediaCodecEncoder(boolean fallbackToGetCodecByType, boolean filterByTypeAndFormat) {

--- a/litr/src/main/java/com/linkedin/android/litr/codec/MediaCodecEncoder.java
+++ b/litr/src/main/java/com/linkedin/android/litr/codec/MediaCodecEncoder.java
@@ -25,20 +25,22 @@ import java.nio.ByteBuffer;
 public class MediaCodecEncoder implements Encoder {
 
     private final boolean fallbackToGetCodecByType;
+    private final boolean filterByTypeAndFormat;
 
     private MediaCodec mediaCodec;
 
     private boolean isReleased = true;
     private boolean isRunning;
 
-    private MediaCodec.BufferInfo encoderOutputBufferInfo = new MediaCodec.BufferInfo();
+    private final MediaCodec.BufferInfo encoderOutputBufferInfo = new MediaCodec.BufferInfo();
 
     public MediaCodecEncoder() {
-        this(true);
+        this(true, true);
     }
 
-    public MediaCodecEncoder(boolean fallbackToGetCodecByType) {
+    public MediaCodecEncoder(boolean fallbackToGetCodecByType, boolean filterByTypeAndFormat) {
         this.fallbackToGetCodecByType = fallbackToGetCodecByType;
+        this.filterByTypeAndFormat = filterByTypeAndFormat;
     }
 
     @Override
@@ -55,7 +57,8 @@ public class MediaCodecEncoder implements Encoder {
                 TrackTranscoderException.Error.ENCODER_NOT_FOUND,
                 TrackTranscoderException.Error.ENCODER_FORMAT_NOT_FOUND,
                 TrackTranscoderException.Error.ENCODER_CONFIGURATION_ERROR,
-                fallbackToGetCodecByType);
+                fallbackToGetCodecByType,
+                filterByTypeAndFormat);
         isReleased = mediaCodec == null;
     }
 


### PR DESCRIPTION
Enhance the logic for finding a media codec for a media format, where sometimes the findEncoderForFormat/findDeccoderForFormat or createEncoderByType/createDecoderByType methods will return the first MediaCodec in the available media codecs that could support the media type, but this codec may not be able to configure the media format, so the fix here is to get all available codecs that support the mimeType, and iterate over them to check which codec could configure the media format and return it