### PR TITLE
Remove fallback codec lookup configuration flags

### DIFF
--- a/litr/src/main/java/com/linkedin/android/litr/codec/MediaCodecDecoder.java
+++ b/litr/src/main/java/com/linkedin/android/litr/codec/MediaCodecDecoder.java
@@ -23,27 +23,11 @@ import java.nio.ByteBuffer;
 
 public final class MediaCodecDecoder implements Decoder {
 
-    private final boolean fallbackToGetCodecByType;
-    private final boolean filterByTypeAndFormat;
-
     private MediaCodec mediaCodec;
 
     private boolean isRunning;
     private boolean isReleased;
     private final MediaCodec.BufferInfo outputBufferInfo = new MediaCodec.BufferInfo();
-
-    public MediaCodecDecoder() {
-        this(true);
-    }
-
-    public MediaCodecDecoder(boolean fallbackToGetCodecByType) {
-        this(fallbackToGetCodecByType, false);
-    }
-
-    public MediaCodecDecoder(boolean fallbackToGetCodecByType, boolean filterByTypeAndFormat) {
-        this.fallbackToGetCodecByType = fallbackToGetCodecByType;
-        this.filterByTypeAndFormat = filterByTypeAndFormat;
-    }
 
     @Override
     public void init(@NonNull MediaFormat mediaFormat, @Nullable Surface surface) throws TrackTranscoderException {
@@ -53,9 +37,7 @@ public final class MediaCodecDecoder implements Decoder {
                 false,
                 TrackTranscoderException.Error.DECODER_NOT_FOUND,
                 TrackTranscoderException.Error.DECODER_FORMAT_NOT_FOUND,
-                TrackTranscoderException.Error.DECODER_CONFIGURATION_ERROR,
-                fallbackToGetCodecByType,
-                filterByTypeAndFormat);
+                TrackTranscoderException.Error.DECODER_CONFIGURATION_ERROR);
         isReleased = mediaCodec == null;
     }
 

--- a/litr/src/main/java/com/linkedin/android/litr/codec/MediaCodecEncoder.java
+++ b/litr/src/main/java/com/linkedin/android/litr/codec/MediaCodecEncoder.java
@@ -24,28 +24,12 @@ import java.nio.ByteBuffer;
 
 public class MediaCodecEncoder implements Encoder {
 
-    private final boolean fallbackToGetCodecByType;
-    private final boolean filterByTypeAndFormat;
-
     private MediaCodec mediaCodec;
 
     private boolean isReleased = true;
     private boolean isRunning;
 
     private final MediaCodec.BufferInfo encoderOutputBufferInfo = new MediaCodec.BufferInfo();
-
-    public MediaCodecEncoder() {
-        this(true);
-    }
-
-    public MediaCodecEncoder(boolean fallbackToGetCodecByType) {
-        this(fallbackToGetCodecByType, false);
-    }
-
-    public MediaCodecEncoder(boolean fallbackToGetCodecByType, boolean filterByTypeAndFormat) {
-        this.fallbackToGetCodecByType = fallbackToGetCodecByType;
-        this.filterByTypeAndFormat = filterByTypeAndFormat;
-    }
 
     @Override
     public void init(@NonNull MediaFormat targetFormat) throws TrackTranscoderException {
@@ -60,9 +44,7 @@ public class MediaCodecEncoder implements Encoder {
                 true,
                 TrackTranscoderException.Error.ENCODER_NOT_FOUND,
                 TrackTranscoderException.Error.ENCODER_FORMAT_NOT_FOUND,
-                TrackTranscoderException.Error.ENCODER_CONFIGURATION_ERROR,
-                fallbackToGetCodecByType,
-                filterByTypeAndFormat);
+                TrackTranscoderException.Error.ENCODER_CONFIGURATION_ERROR);
         isReleased = mediaCodec == null;
     }
 


### PR DESCRIPTION
With all experimentation done, we can now remove flags for different ways of manually finding compatible codecs. We can also remove supporting logic.