### PR TITLE
Implementation of MockVideoMediaSource and PassthroughDecoder

### DIFF
--- a/litr-demo/src/main/java/com/linkedin/android/litr/demo/DemoCase.java
+++ b/litr-demo/src/main/java/com/linkedin/android/litr/demo/DemoCase.java
@@ -16,6 +16,7 @@ public enum DemoCase {
     VIDEO_OVERLAY_GL(R.string.demo_case_free_transform_video_gl, "FreeTransformVideoGl", new FreeTransformVideoGlFragment()),
     SQUARE_CENTER_CROP(R.string.demo_case_square_center_crop, "SquareCenterCrop", new SquareCenterCropFragment()),
     VIDEO_WATERMARK(R.string.demo_case_video_watermark, "VideoWatermark", new VideoWatermarkFragment()),
+    EMPTY_VIDEO(R.string.demo_case_empty_video, "EmptyVideo", new EmptyVideoFragment()),
     VIDEO_FILTERS(R.string.demo_case_video_filters, "VideoFilters", new VideoFiltersFragment()),
     VIDEO_FILTERS_PREVIEW(R.string.demo_case_video_filters_preview, "VideoFiltersPreview", new VideoFilterPreviewFragment()),
     TRANSCODE_VIDEO_MOCK(R.string.demo_case_mock_transcode_video, "TranscodeVideoMock", new MockTranscodeFragment());

--- a/litr-demo/src/main/java/com/linkedin/android/litr/demo/EmptyVideoFragment.kt
+++ b/litr-demo/src/main/java/com/linkedin/android/litr/demo/EmptyVideoFragment.kt
@@ -1,0 +1,76 @@
+package com.linkedin.android.litr.demo
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import com.linkedin.android.litr.MediaTransformer
+import com.linkedin.android.litr.demo.data.SourceMedia
+import com.linkedin.android.litr.demo.data.TargetMedia
+import com.linkedin.android.litr.demo.data.TransformationPresenter
+import com.linkedin.android.litr.demo.data.TransformationState
+import com.linkedin.android.litr.demo.data.VideoTrackFormat
+import com.linkedin.android.litr.demo.databinding.FragmentEmptyVideoBinding
+import com.linkedin.android.litr.utils.TransformationUtil
+import java.io.File
+
+private const val DURATION = 5_000_000L
+
+class EmptyVideoFragment : BaseTransformationFragment() {
+
+    private lateinit var binding: FragmentEmptyVideoBinding
+
+    private lateinit var mediaTransformer: MediaTransformer
+    private var targetMedia: TargetMedia = TargetMedia()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        mediaTransformer = MediaTransformer(context!!.applicationContext)
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        mediaTransformer.release()
+    }
+
+    override fun onCreateView(inflater: LayoutInflater,
+                              container: ViewGroup?, savedInstanceState: Bundle?): View {
+        binding = FragmentEmptyVideoBinding.inflate(inflater, container, false)
+
+        // mimic portrait 720p video with no audio
+        val sourceMedia = SourceMedia()
+        sourceMedia.duration = DURATION.toFloat()
+        val trackFormat = VideoTrackFormat(0, "video/avc")
+        trackFormat.width = 1280
+        trackFormat.height = 720
+        trackFormat.rotation = 90
+        trackFormat.frameRate = 30
+        trackFormat.bitrate = 5_000_000
+        trackFormat.keyFrameInterval = 3
+        trackFormat.duration = DURATION
+        sourceMedia.tracks.add(trackFormat)
+
+        binding.sourceMedia = sourceMedia
+        binding.buttonPickBackground.setOnClickListener {
+            pickBackground { uri ->
+                targetMedia.backgroundImageUri = uri
+            }
+        }
+        binding.buttonPickVideoOverlay.setOnClickListener {
+            pickOverlay { uri ->
+                targetMedia.setOverlayImageUri(uri)
+            }
+        }
+        binding.transformationState = TransformationState()
+        binding.transformationPresenter = TransformationPresenter(context!!, mediaTransformer)
+
+        val targetFile = File(TransformationUtil.getTargetFileDirectory(), "empty_video.mp4")
+        targetMedia.setTargetFile(targetFile)
+        targetMedia.setTracks(sourceMedia.tracks)
+
+        binding.targetMedia = targetMedia
+
+        return binding.root
+    }
+}

--- a/litr-demo/src/main/res/layout/fragment_empty_video.xml
+++ b/litr-demo/src/main/res/layout/fragment_empty_video.xml
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2019 LinkedIn Corporation -->
+<!-- All Rights Reserved. -->
+<!-- -->
+<!-- Licensed under the BSD 2-Clause License (the "License").  See License in the project root -->
+<!-- for license information. -->
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <data>
+        <import type="android.view.View"/>
+
+        <variable
+            name="sourceMedia"
+            type="com.linkedin.android.litr.demo.data.SourceMedia" />
+
+        <variable
+            name="targetMedia"
+            type="com.linkedin.android.litr.demo.data.TargetMedia" />
+
+        <variable
+            name="transformationState"
+            type="com.linkedin.android.litr.demo.data.TransformationState" />
+
+        <variable
+            name="transformationPresenter"
+            type="com.linkedin.android.litr.demo.data.TransformationPresenter" />
+
+    </data>
+
+    <androidx.core.widget.NestedScrollView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <LinearLayout
+            android:orientation="vertical"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+
+            <Button
+                android:id="@+id/button_pick_background"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/pick_background"
+                android:enabled="@{sourceMedia != null &amp;&amp; (transformationState.state != transformationState.STATE_RUNNING)}"
+                android:padding="@dimen/cell_padding"/>
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal">
+
+                <Button
+                    android:id="@+id/button_pick_video_overlay"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:gravity="center"
+                    android:enabled="@{sourceMedia != null &amp;&amp; (transformationState.state != transformationState.STATE_RUNNING)}"
+                    android:text="@string/pick_video_overlay"/>
+
+                <ImageView
+                    android:layout_width="75dp"
+                    android:layout_height="75dp"
+                    android:scaleType="centerCrop"
+                    android:visibility="@{targetMedia.getVideoOverlay() == null ? View.GONE : View.VISIBLE}"
+                    app:overlayThumbnail="@{targetMedia.getVideoOverlay() != null ? targetMedia.getVideoOverlay().toString() : null}"/>
+
+            </LinearLayout>
+
+            <Button
+                android:id="@+id/button_transcode"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/transcode"
+                android:enabled="@{sourceMedia != null &amp;&amp; targetMedia != null &amp;&amp; targetMedia.getIncludedTrackCount() > 0 &amp;&amp; (transformationState.state != transformationState.STATE_RUNNING)}"
+                android:padding="@dimen/cell_padding"
+                android:onClick="@{() -> transformationPresenter.createEmptyVideo(sourceMedia, targetMedia, transformationState)}"/>
+
+            <include layout="@layout/section_transformation_progress"
+                android:id="@+id/section_transformation_progress"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:visibility="@{transformationState.state == transformationState.STATE_IDLE ? View.GONE : View.VISIBLE}"
+                app:transformationState="@{transformationState}"
+                app:presenter="@{transformationPresenter}"/>
+
+            <Button
+                android:id="@+id/button_play"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/play"
+                android:enabled="@{transformationState.state == transformationState.STATE_COMPLETED}"
+                android:padding="@dimen/cell_padding"
+                android:onClick="@{() -> transformationPresenter.play(targetMedia.targetFile)}"/>
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:padding="@dimen/cell_padding"
+                android:text="@{transformationState.stats}"
+                android:visibility="@{transformationState.state == transformationState.STATE_RUNNING || transformationState.stats == null ? View.GONE : View.VISIBLE}"/>
+
+        </LinearLayout>
+
+    </androidx.core.widget.NestedScrollView>
+
+</layout>

--- a/litr-demo/src/main/res/values/strings.xml
+++ b/litr-demo/src/main/res/values/strings.xml
@@ -10,6 +10,7 @@
     <string name="demo_case_free_transform_video_gl">Free Transform Video (GL Renderer)</string>
     <string name="demo_case_square_center_crop">Square Center Crop</string>
     <string name="demo_case_video_watermark">Video Watermark</string>
+    <string name="demo_case_empty_video">Empty Video</string>
     <string name="demo_case_video_filters">Video Filters</string>
     <string name="demo_case_video_filters_preview">Video Filters Preview</string>
     <string name="demo_case_mock_transcode_video">Mock Transcode Video</string>

--- a/litr/src/main/java/com/linkedin/android/litr/codec/PassthroughDecoder.kt
+++ b/litr/src/main/java/com/linkedin/android/litr/codec/PassthroughDecoder.kt
@@ -1,3 +1,10 @@
+/*
+ * Copyright 2021 LinkedIn Corporation
+ * All Rights Reserved.
+ *
+ * Licensed under the BSD 2-Clause License (the "License").  See License in the project root for
+ * license information.
+ */
 package com.linkedin.android.litr.codec
 
 import android.media.MediaCodec

--- a/litr/src/main/java/com/linkedin/android/litr/codec/PassthroughDecoder.kt
+++ b/litr/src/main/java/com/linkedin/android/litr/codec/PassthroughDecoder.kt
@@ -1,0 +1,103 @@
+package com.linkedin.android.litr.codec
+
+import android.media.MediaCodec
+import android.media.MediaFormat
+import android.view.Surface
+import java.nio.ByteBuffer
+
+private const val DEFAULT_BUFFER_POOL_SIZE = 2
+
+/**
+ * Implementation of [Decoder] that produces frames identical to ones it consumes, preserving the order.
+ * If running in hardware accelerated mode, with non-null [Surface], triggers a GL draw call.
+ */
+class PassthroughDecoder(
+    inputBufferCapacity: Int
+) : Decoder {
+
+    // pool of unused frames
+    private val availableFrames = mutableSetOf<Frame>()
+    // pool of frames a client dequeued to populate with encoded input data
+    private val dequeuedInputFrames = mutableMapOf<Int, Frame>()
+    // queue of frames being decoded
+    private val decodeQueue = mutableListOf<Int>()
+    // pool of decoded frames
+    private val decodedFrames = mutableMapOf<Int, Frame>()
+
+    private lateinit var mediaFormat: MediaFormat
+    private var surface: Surface? = null
+
+    private var isRunning = false
+
+    init {
+        for (tag in 0 until DEFAULT_BUFFER_POOL_SIZE) {
+            availableFrames.add(Frame(tag, ByteBuffer.allocate(inputBufferCapacity), MediaCodec.BufferInfo()))
+        }
+    }
+
+    override fun init(mediaFormat: MediaFormat, surface: Surface?) {
+        this.mediaFormat = mediaFormat
+        this.surface = surface
+    }
+
+    override fun start() {
+        isRunning = true
+    }
+
+    override fun isRunning(): Boolean {
+        return isRunning
+    }
+
+    override fun dequeueInputFrame(timeout: Long): Int {
+        return availableFrames.firstOrNull()?.let { availableFrame ->
+            availableFrames.remove(availableFrame)
+            dequeuedInputFrames[availableFrame.tag] = availableFrame
+            availableFrame.tag
+        } ?: MediaCodec.INFO_TRY_AGAIN_LATER
+    }
+
+    override fun getInputFrame(tag: Int): Frame? {
+        return dequeuedInputFrames[tag]
+    }
+
+    override fun queueInputFrame(frame: Frame) {
+        dequeuedInputFrames.remove(frame.tag)
+        decodeQueue.add(frame.tag)
+        decodedFrames[frame.tag] = frame
+    }
+
+    override fun dequeueOutputFrame(timeout: Long): Int {
+        return if (decodeQueue.isNotEmpty()) decodeQueue.removeAt(0) else MediaCodec.INFO_TRY_AGAIN_LATER
+    }
+
+    override fun getOutputFrame(tag: Int): Frame? {
+        return decodedFrames[tag]
+    }
+
+    override fun releaseOutputFrame(tag: Int, render: Boolean) {
+        surface?.let { surface ->
+            if (render) {
+                val canvas = surface.lockCanvas(null)
+                surface.unlockCanvasAndPost(canvas)
+            }
+        }
+        decodedFrames.remove(tag)?.let {
+            availableFrames.add(it)
+        }
+    }
+
+    override fun getOutputFormat(): MediaFormat {
+        return mediaFormat
+    }
+
+    override fun stop() {
+        isRunning = false
+    }
+
+    override fun release() {
+    }
+
+    override fun getName(): String {
+        return "PassthroughDecoder"
+    }
+}

--- a/litr/src/main/java/com/linkedin/android/litr/io/MockVideoMediaSource.kt
+++ b/litr/src/main/java/com/linkedin/android/litr/io/MockVideoMediaSource.kt
@@ -1,0 +1,85 @@
+package com.linkedin.android.litr.io
+
+import android.media.MediaCodec
+import android.media.MediaFormat
+import android.os.Build
+import com.linkedin.android.litr.transcoder.TrackTranscoder
+import java.nio.ByteBuffer
+
+/**
+ * Implementation of [MediaSource] which emulates single video track media with empty frames.
+ * @param trackFormat an instance of [MediaFormat] which describes video track.
+ * Must contain [MediaFormat.KEY_DURATION], [MediaFormat.KEY_FRAME_RATE] defined.
+ * If target video is rotated, must also contain [MediaFormat.KEY_ROTATION] defined, otherwise 0 value will be used.
+ */
+class MockVideoMediaSource(
+    private val trackFormat: MediaFormat
+) : MediaSource {
+
+    private val trackDuration: Long
+    private val frameDuration: Long
+    private val orientationHint: Int
+
+    private var selectedTrack: Int = TrackTranscoder.NO_SELECTED_TRACK
+    private var currentPosition = 0L
+
+    init {
+        assert(trackFormat.containsKey(MediaFormat.KEY_DURATION))
+        trackDuration = trackFormat.getLong(MediaFormat.KEY_DURATION)
+
+        assert(trackFormat.containsKey(MediaFormat.KEY_FRAME_RATE))
+        frameDuration = 1_000_000L / trackFormat.getInteger(MediaFormat.KEY_FRAME_RATE)
+
+        val keyRotation =
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) MediaFormat.KEY_ROTATION else "rotation-degrees"
+        orientationHint = if (trackFormat.containsKey(keyRotation)) trackFormat.getInteger(keyRotation) else 0
+    }
+
+    override fun getOrientationHint(): Int {
+        return orientationHint
+    }
+
+    override fun getTrackCount(): Int {
+        return 1
+    }
+
+    override fun getTrackFormat(track: Int): MediaFormat {
+        return trackFormat
+    }
+
+    override fun selectTrack(track: Int) {
+        selectedTrack = track
+    }
+
+    override fun seekTo(position: Long, mode: Int) {
+        currentPosition = position
+    }
+
+    override fun getSampleTrackIndex(): Int {
+        return selectedTrack
+    }
+
+    override fun readSampleData(buffer: ByteBuffer, offset: Int): Int {
+        // pretend that we read a single byte of data
+        return 1
+    }
+
+    override fun getSampleTime(): Long {
+        return currentPosition
+    }
+
+    override fun getSampleFlags(): Int {
+        return if (currentPosition < trackDuration) 0 else MediaCodec.BUFFER_FLAG_END_OF_STREAM
+    }
+
+    override fun advance() {
+        currentPosition += frameDuration
+    }
+
+    override fun release() {
+    }
+
+    override fun getSize(): Long {
+        return -1
+    }
+}

--- a/litr/src/main/java/com/linkedin/android/litr/io/MockVideoMediaSource.kt
+++ b/litr/src/main/java/com/linkedin/android/litr/io/MockVideoMediaSource.kt
@@ -1,3 +1,10 @@
+/*
+ * Copyright 2021 LinkedIn Corporation
+ * All Rights Reserved.
+ *
+ * Licensed under the BSD 2-Clause License (the "License").  See License in the project root for
+ * license information.
+ */
 package com.linkedin.android.litr.io
 
 import android.media.MediaCodec

--- a/litr/src/test/java/com/linkedin/android/litr/codec/PassthroughDecoderShould.kt
+++ b/litr/src/test/java/com/linkedin/android/litr/codec/PassthroughDecoderShould.kt
@@ -1,0 +1,177 @@
+package com.linkedin.android.litr.codec
+
+import android.media.MediaCodec
+import android.media.MediaFormat
+import android.view.Surface
+import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.CoreMatchers.sameInstance
+import org.hamcrest.MatcherAssert.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.Mockito.any
+import org.mockito.Mockito.never
+import org.mockito.Mockito.verify
+import org.mockito.MockitoAnnotations
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+private const val BUFFER_CAPACITY = 5
+
+class PassthroughDecoderShould {
+
+    @Mock private lateinit var surface: Surface
+
+    private lateinit var mediaFormat: MediaFormat
+
+    private lateinit var passthroughDecoder: PassthroughDecoder
+
+    @Before
+    fun setup() {
+        MockitoAnnotations.initMocks(this)
+
+        mediaFormat = MediaFormat()
+        mediaFormat.setString(MediaFormat.KEY_MIME, "video/avc")
+        mediaFormat.setInteger(MediaFormat.KEY_WIDTH, 1280)
+        mediaFormat.setInteger(MediaFormat.KEY_HEIGHT, 720)
+        mediaFormat.setLong(MediaFormat.KEY_DURATION, 5_000_000L)
+        mediaFormat.setInteger(MediaFormat.KEY_BIT_RATE, 3_300_000)
+
+        passthroughDecoder = PassthroughDecoder(BUFFER_CAPACITY)
+    }
+
+    @Test
+    fun start() {
+        assertFalse(passthroughDecoder.isRunning)
+
+        passthroughDecoder.start()
+
+        assertTrue(passthroughDecoder.isRunning)
+    }
+
+    @Test
+    fun stop() {
+        passthroughDecoder.start()
+
+        passthroughDecoder.stop()
+
+        assertFalse(passthroughDecoder.isRunning)
+    }
+
+    @Test
+    fun `dequeue input frame`() {
+        val tag = passthroughDecoder.dequeueInputFrame(0)
+
+        assertThat(tag, equalTo(0))
+    }
+
+    @Test
+    fun `return try later when frame pool is depleted`() {
+        val tag1 = passthroughDecoder.dequeueInputFrame(0)
+        val tag2 = passthroughDecoder.dequeueInputFrame(0)
+        val tag3 = passthroughDecoder.dequeueInputFrame(0)
+
+        assertThat(tag1, equalTo(0))
+        assertThat(tag2, equalTo(1))
+        assertThat(tag3, equalTo(MediaCodec.INFO_TRY_AGAIN_LATER))
+    }
+
+    @Test
+    fun `return try later when no decoded frames are available`() {
+        val tag = passthroughDecoder.dequeueOutputFrame(0)
+
+        assertThat(tag, equalTo(MediaCodec.INFO_TRY_AGAIN_LATER))
+    }
+
+    @Test
+    fun `passthrough decode an encoded frame`() {
+        val inputTag = passthroughDecoder.dequeueInputFrame(0)
+        val inputFrame = passthroughDecoder.getInputFrame(inputTag)
+        assertNotNull(inputFrame)
+        passthroughDecoder.queueInputFrame(inputFrame)
+
+        val outputTag = passthroughDecoder.dequeueOutputFrame(0)
+        val outputFrame = passthroughDecoder.getOutputFrame(outputTag)
+
+        assertThat(outputTag, equalTo(inputTag))
+        assertThat(outputFrame, equalTo(inputFrame))
+    }
+
+    @Test
+    fun `maintain frame ordering when decoding`() {
+        val inputTag1 = passthroughDecoder.dequeueInputFrame(0)
+        val inputTag2 = passthroughDecoder.dequeueInputFrame(0)
+        val inputFrame1 = passthroughDecoder.getInputFrame(inputTag1)
+        assertNotNull(inputFrame1)
+        val inputFrame2 = passthroughDecoder.getInputFrame(inputTag2)
+        assertNotNull(inputFrame2)
+        passthroughDecoder.queueInputFrame(inputFrame1)
+        passthroughDecoder.queueInputFrame(inputFrame2)
+
+        val outputTag1 = passthroughDecoder.dequeueOutputFrame(0)
+        val outputFrame1 = passthroughDecoder.getOutputFrame(outputTag1)
+        val outputTag2 = passthroughDecoder.dequeueOutputFrame(0)
+        val outputFrame2 = passthroughDecoder.getOutputFrame(outputTag2)
+
+        assertThat(outputTag1, equalTo(inputTag1))
+        assertThat(outputTag2, equalTo(inputTag2))
+        assertThat(outputFrame1, equalTo(inputFrame1))
+        assertThat(outputFrame2, equalTo(inputFrame2))
+    }
+
+    @Test
+    fun `make output frame available when it is released`() {
+        val inputTag1 = passthroughDecoder.dequeueInputFrame(0)
+        val inputTag2 = passthroughDecoder.dequeueInputFrame(0)
+        val inputFrame1 = passthroughDecoder.getInputFrame(inputTag1)
+        assertNotNull(inputFrame1)
+        val inputFrame2 = passthroughDecoder.getInputFrame(inputTag2)
+        assertNotNull(inputFrame2)
+        passthroughDecoder.queueInputFrame(inputFrame1)
+        passthroughDecoder.queueInputFrame(inputFrame2)
+
+        val outputTag1 = passthroughDecoder.dequeueOutputFrame(0)
+        val outputFrame1 = passthroughDecoder.getOutputFrame(outputTag1)
+        val outputTag2 = passthroughDecoder.dequeueOutputFrame(0)
+        val outputFrame2 = passthroughDecoder.getOutputFrame(outputTag2)
+
+        // no available input frames yet
+        assertThat(passthroughDecoder.dequeueInputFrame(0), equalTo(MediaCodec.INFO_TRY_AGAIN_LATER))
+
+        passthroughDecoder.releaseOutputFrame(outputTag1, true)
+
+        // now frame becomes available after it is released
+        assertThat(passthroughDecoder.dequeueInputFrame(0), equalTo(inputTag1))
+    }
+
+    @Test
+    fun `invoke GL render call when output frame is released and render is requested`() {
+        passthroughDecoder.init(mediaFormat, surface)
+
+        passthroughDecoder.releaseOutputFrame(0, true)
+
+        verify(surface).lockCanvas(any())
+        verify(surface).unlockCanvasAndPost(any())
+    }
+
+    @Test
+    fun `not invoke GL render call when output frame is released and render is not requested`() {
+        passthroughDecoder.init(mediaFormat, surface)
+
+        passthroughDecoder.releaseOutputFrame(0, false)
+
+        verify(surface, never()).lockCanvas(any())
+        verify(surface, never()).unlockCanvasAndPost(any())
+    }
+
+    @Test
+    fun `not invoke GL render call when running in software rendering mode`() {
+        passthroughDecoder.init(mediaFormat, null)
+
+        passthroughDecoder.releaseOutputFrame(0, true)
+
+        verify(surface, never()).lockCanvas(any())
+        verify(surface, never()).unlockCanvasAndPost(any())
+    }
+}

--- a/litr/src/test/java/com/linkedin/android/litr/codec/PassthroughDecoderShould.kt
+++ b/litr/src/test/java/com/linkedin/android/litr/codec/PassthroughDecoderShould.kt
@@ -1,10 +1,16 @@
+/*
+ * Copyright 2021 LinkedIn Corporation
+ * All Rights Reserved.
+ *
+ * Licensed under the BSD 2-Clause License (the "License").  See License in the project root for
+ * license information.
+ */
 package com.linkedin.android.litr.codec
 
 import android.media.MediaCodec
 import android.media.MediaFormat
 import android.view.Surface
 import org.hamcrest.CoreMatchers.equalTo
-import org.hamcrest.CoreMatchers.sameInstance
 import org.hamcrest.MatcherAssert.assertThat
 import org.junit.Before
 import org.junit.Test


### PR DESCRIPTION
Adding two new classes that will let us do some powerful media transformations:
 - `MockVideoMediaSource` is an implementation of `MediaSource` that acts as a source with a single video track of a certain duration. Client defines properties of this track by passing in a `MediaFormat` with necessary metadata values. 
 - `PassthroughDecoder` is an implementation of `Decoder` which simply outputs input frames in the order it received them. If running in hardware accelerated mode, it also triggers a GL draw call when output frame is released with a request to render a frame.

We use these two new classes in a new demo case to create a 5 second "empty" video. Optionally we can use a still background image, turning that into a video.