### PR TITLE
Allow non-negative reads from source buffer during transcoding

### DIFF
--- a/litr/src/main/java/com/linkedin/android/litr/transcoder/AudioTrackTranscoder.java
+++ b/litr/src/main/java/com/linkedin/android/litr/transcoder/AudioTrackTranscoder.java
@@ -127,7 +127,8 @@ public class AudioTrackTranscoder extends TrackTranscoder {
                 int bytesRead = mediaSource.readSampleData(frame.buffer, 0);
                 long sampleTime = mediaSource.getSampleTime();
                 int sampleFlags = mediaSource.getSampleFlags();
-                if (bytesRead <= 0 || (sampleFlags & MediaCodec.BUFFER_FLAG_END_OF_STREAM) != 0) {
+
+                if (bytesRead < 0 || (sampleFlags & MediaCodec.BUFFER_FLAG_END_OF_STREAM) != 0) {
                     frame.bufferInfo.set(0, 0, -1, MediaCodec.BUFFER_FLAG_END_OF_STREAM);
                     decoder.queueInputFrame(frame);
                     extractFrameResult = RESULT_EOS_REACHED;

--- a/litr/src/main/java/com/linkedin/android/litr/transcoder/PassthroughTranscoder.java
+++ b/litr/src/main/java/com/linkedin/android/litr/transcoder/PassthroughTranscoder.java
@@ -95,7 +95,7 @@ public class PassthroughTranscoder extends TrackTranscoder {
         long sampleTime = mediaSource.getSampleTime();
         int inputFlags = mediaSource.getSampleFlags();
 
-        if (bytesRead <= 0 || (inputFlags & MediaCodec.BUFFER_FLAG_END_OF_STREAM) != 0) {
+        if (bytesRead < 0 || (inputFlags & MediaCodec.BUFFER_FLAG_END_OF_STREAM) != 0) {
             outputBuffer.clear();
             progress = 1.0f;
             lastResult = RESULT_EOS_REACHED;

--- a/litr/src/main/java/com/linkedin/android/litr/transcoder/VideoTrackTranscoder.java
+++ b/litr/src/main/java/com/linkedin/android/litr/transcoder/VideoTrackTranscoder.java
@@ -144,7 +144,8 @@ public class VideoTrackTranscoder extends TrackTranscoder {
                 int bytesRead = mediaSource.readSampleData(frame.buffer, 0);
                 long sampleTime = mediaSource.getSampleTime();
                 int sampleFlags = mediaSource.getSampleFlags();
-                if (bytesRead <= 0 || (sampleFlags & MediaCodec.BUFFER_FLAG_END_OF_STREAM) != 0) {
+
+                if (bytesRead < 0 || (sampleFlags & MediaCodec.BUFFER_FLAG_END_OF_STREAM) != 0) {
                     frame.bufferInfo.set(0, 0, -1, MediaCodec.BUFFER_FLAG_END_OF_STREAM);
                     decoder.queueInputFrame(frame);
                     extractFrameResult = RESULT_EOS_REACHED;

--- a/litr/src/test/java/com/linkedin/android/litr/transcoder/AudioTrackTranscoderShould.java
+++ b/litr/src/test/java/com/linkedin/android/litr/transcoder/AudioTrackTranscoderShould.java
@@ -288,7 +288,7 @@ public class AudioTrackTranscoderShould {
         doReturn(AUDIO_TRACK).when(mediaSource).getSampleTrackIndex();
         doReturn(BUFFER_INDEX).when(decoder).dequeueInputFrame(anyLong());
         doReturn(sampleFrame).when(decoder).getInputFrame(BUFFER_INDEX);
-        doReturn(0).when(mediaSource).readSampleData(any(ByteBuffer.class), anyInt());
+        doReturn(-1).when(mediaSource).readSampleData(any(ByteBuffer.class), anyInt());
 
         int result = audioTrackTranscoder.processNextFrame();
 

--- a/litr/src/test/java/com/linkedin/android/litr/transcoder/PassthroughTranscoderShould.java
+++ b/litr/src/test/java/com/linkedin/android/litr/transcoder/PassthroughTranscoderShould.java
@@ -167,7 +167,7 @@ public class PassthroughTranscoderShould {
         passthroughTranscoder.targetTrackAdded = true;
 
         doReturn(0).when(mediaSource).getSampleTrackIndex();
-        doReturn(0).when(mediaSource).readSampleData(outputBuffer, 0);
+        doReturn(-1).when(mediaSource).readSampleData(outputBuffer, 0);
 
         int result = passthroughTranscoder.processNextFrame();
 

--- a/litr/src/test/java/com/linkedin/android/litr/transcoder/PassthroughTranscoderShould.java
+++ b/litr/src/test/java/com/linkedin/android/litr/transcoder/PassthroughTranscoderShould.java
@@ -160,6 +160,30 @@ public class PassthroughTranscoderShould {
     }
 
     @Test
+    public void writeFrameWhenNoBytesRead() {
+        passthroughTranscoder.sourceTrack = 0;
+        passthroughTranscoder.targetTrack = 0;
+        passthroughTranscoder.duration = DURATION;
+        passthroughTranscoder.targetTrackAdded = true;
+        int outputFlags = 0;
+
+        doReturn(0).when(mediaSource).getSampleTrackIndex();
+        doReturn(0).when(mediaSource).readSampleData(outputBuffer, 0);
+        doReturn(SAMPLE_TIME).when(mediaSource).getSampleTime();
+        doReturn(outputFlags).when(mediaSource).getSampleFlags();
+
+        int result = passthroughTranscoder.processNextFrame();
+
+        verify(outputBufferInfo).set(0, 0, SAMPLE_TIME, outputFlags);
+        verify(mediaSource).advance();
+        verify(mediaTarget).writeSampleData(0, outputBuffer, outputBufferInfo);
+
+        assertThat(passthroughTranscoder.progress, is((float) SAMPLE_TIME / DURATION));
+        assertThat(result, is(TrackTranscoder.RESULT_FRAME_PROCESSED));
+        assertThat(passthroughTranscoder.lastResult, is(TrackTranscoder.RESULT_FRAME_PROCESSED));
+    }
+
+    @Test
     public void finishWritingWhenInputDataIsNotAvailable() {
         passthroughTranscoder.sourceTrack = 0;
         passthroughTranscoder.targetTrack = 0;

--- a/litr/src/test/java/com/linkedin/android/litr/transcoder/VideoTrackTranscoderShould.java
+++ b/litr/src/test/java/com/linkedin/android/litr/transcoder/VideoTrackTranscoderShould.java
@@ -305,7 +305,7 @@ public class VideoTrackTranscoderShould {
         doReturn(VIDEO_TRACK).when(mediaSource).getSampleTrackIndex();
         doReturn(BUFFER_INDEX).when(decoder).dequeueInputFrame(anyLong());
         doReturn(sampleFrame).when(decoder).getInputFrame(BUFFER_INDEX);
-        doReturn(0).when(mediaSource).readSampleData(any(ByteBuffer.class), anyInt());
+        doReturn(-1).when(mediaSource).readSampleData(any(ByteBuffer.class), anyInt());
 
         int result = videoTrackTranscoder.processNextFrame();
 

--- a/litr/src/test/java/com/linkedin/android/litr/transcoder/VideoTrackTranscoderShould.java
+++ b/litr/src/test/java/com/linkedin/android/litr/transcoder/VideoTrackTranscoderShould.java
@@ -297,6 +297,30 @@ public class VideoTrackTranscoderShould {
     }
 
     @Test
+    public void extractAndDecodeFrameWhenNoBytesRead() throws  Exception {
+        videoTrackTranscoder.lastExtractFrameResult = TrackTranscoder.RESULT_FRAME_PROCESSED;
+        videoTrackTranscoder.lastDecodeFrameResult = TrackTranscoder.RESULT_EOS_REACHED;
+        videoTrackTranscoder.lastEncodeFrameResult = TrackTranscoder.RESULT_EOS_REACHED;
+
+        doReturn(VIDEO_TRACK).when(mediaSource).getSampleTrackIndex();
+        doReturn(BUFFER_INDEX).when(decoder).dequeueInputFrame(anyLong());
+        doReturn(sampleFrame).when(decoder).getInputFrame(BUFFER_INDEX);
+        doReturn(0).when(mediaSource).readSampleData(any(ByteBuffer.class), anyInt());
+        doReturn(CURRENT_PRESENTATION_TIME).when(mediaSource).getSampleTime();
+        doReturn(0).when(mediaSource).getSampleFlags();
+
+        int result = videoTrackTranscoder.processNextFrame();
+
+        verify(mediaSource).readSampleData(eq(sampleFrame.buffer), eq(0));
+        verify(decoder).queueInputFrame(sampleFrame);
+        verify(bufferInfo).set(0, 0, CURRENT_PRESENTATION_TIME, 0);
+
+        verify(mediaSource, atLeast(1)).advance();
+
+        assertThat(result, is(TrackTranscoder.RESULT_FRAME_PROCESSED));
+    }
+
+    @Test
     public void signalDecoderWhenEos() throws Exception {
         videoTrackTranscoder.lastExtractFrameResult = TrackTranscoder.RESULT_FRAME_PROCESSED;
         videoTrackTranscoder.lastDecodeFrameResult = TrackTranscoder.RESULT_EOS_REACHED;


### PR DESCRIPTION
Zero bytes can be read from the data source in some valid cases. This change treats 0 bytes read as a valid scenario that does not signal EOS.

Subjectively, the issue appears when transcoding the metadata track of a 60fps mp4 recorded on a Pixel 5: `readSampleData` returns 0 bytes read on every other read. On the other hand, video with a 30fps video stream recorded on the same device didn't present this problem (i.e. sample size was always > 0).

I'm not excluding that the issue might have another underlying cause or solution, but the [readSampleData docs](https://developer.android.com/reference/android/media/MediaExtractor#readSampleData(java.nio.ByteBuffer,%20int)) indicate that the return value is "the sample size, **or** -1 if no more samples are available". Thus, 0 can be considered a valid sample size.


---

Example video that was failing (when metadata transcoding was enabled): https://drive.google.com/file/d/10QFgzRT7PoNStCDRRRZHleHEt7KL61We/view?usp=sharing

<details>
  <summary>Click to view ffprobe</summary>
  
```
ffprobe -show_format -show_streams PXL_20210921_182413576.mp4
ffprobe version 4.4 Copyright (c) 2007-2021 the FFmpeg developers
  built with Apple clang version 12.0.5 (clang-1205.0.22.9)
  configuration: --prefix=/usr/local/Cellar/ffmpeg/4.4_2 --enable-shared --enable-pthreads --enable-version3 --cc=clang --host-cflags= --host-ldflags= --enable-ffplay --enable-gnutls --enable-gpl --enable-libaom --enable-libbluray --enable-libdav1d --enable-libmp3lame --enable-libopus --enable-librav1e --enable-librubberband --enable-libsnappy --enable-libsrt --enable-libtesseract --enable-libtheora --enable-libvidstab --enable-libvorbis --enable-libvpx --enable-libwebp --enable-libx264 --enable-libx265 --enable-libxml2 --enable-libxvid --enable-lzma --enable-libfontconfig --enable-libfreetype --enable-frei0r --enable-libass --enable-libopencore-amrnb --enable-libopencore-amrwb --enable-libopenjpeg --enable-libspeex --enable-libsoxr --enable-libzmq --enable-libzimg --disable-libjack --disable-indev=jack --enable-avresample --enable-videotoolbox
  libavutil      56. 70.100 / 56. 70.100
  libavcodec     58.134.100 / 58.134.100
  libavformat    58. 76.100 / 58. 76.100
  libavdevice    58. 13.100 / 58. 13.100
  libavfilter     7.110.100 /  7.110.100
  libavresample   4.  0.  0 /  4.  0.  0
  libswscale      5.  9.100 /  5.  9.100
  libswresample   3.  9.100 /  3.  9.100
  libpostproc    55.  9.100 / 55.  9.100
Input #0, mov,mp4,m4a,3gp,3g2,mj2, from 'PXL_20210921_182413576.mp4':
  Metadata:
    major_brand     : mp42
    minor_version   : 0
    compatible_brands: isommp42
    creation_time   : 2021-09-21T18:24:31.000000Z
    location        : +40.3492-74.3137/
    location-eng    : +40.3492-74.3137/
    com.android.capture.fps: 30.000000
  Duration: 00:00:16.73, start: 0.000000, bitrate: 30294 kb/s
  Stream #0:0(eng): Data: none (mett / 0x7474656D), 31 kb/s (default)
    Metadata:
      rotate          : 90
      creation_time   : 2021-09-21T18:24:31.000000Z
      handler_name    : MetaHandle
  Stream #0:1(eng): Audio: aac (LC) (mp4a / 0x6134706D), 48000 Hz, stereo, fltp, 191 kb/s (default)
    Metadata:
      rotate          : 90
      creation_time   : 2021-09-21T18:24:31.000000Z
      handler_name    : SoundHandle
      vendor_id       : [0][0][0][0]
  Stream #0:2(eng): Video: h264 (High) (avc1 / 0x31637661), yuvj420p(pc, smpte170m/bt470bg/smpte170m), 1920x1080, 30058 kb/s, SAR 1:1 DAR 16:9, 52.91 fps, 60 tbr, 90k tbn, 180k tbc (default)
    Metadata:
      rotate          : 90
      creation_time   : 2021-09-21T18:24:31.000000Z
      handler_name    : VideoHandle
      vendor_id       : [0][0][0][0]
    Side data:
      displaymatrix: rotation of -90.00 degrees
Unsupported codec with id 0 for input stream 0
[STREAM]
index=0
codec_name=unknown
codec_long_name=unknown
profile=unknown
codec_type=data
codec_tag_string=mett
codec_tag=0x7474656d
id=N/A
r_frame_rate=0/0
avg_frame_rate=0/0
time_base=1/90000
start_pts=0
start_time=0.000000
duration_ts=1505475
duration=16.727500
bit_rate=31826
max_bit_rate=N/A
bits_per_raw_sample=N/A
nb_frames=885
nb_read_frames=N/A
nb_read_packets=N/A
DISPOSITION:default=1
DISPOSITION:dub=0
DISPOSITION:original=0
DISPOSITION:comment=0
DISPOSITION:lyrics=0
DISPOSITION:karaoke=0
DISPOSITION:forced=0
DISPOSITION:hearing_impaired=0
DISPOSITION:visual_impaired=0
DISPOSITION:clean_effects=0
DISPOSITION:attached_pic=0
DISPOSITION:timed_thumbnails=0
TAG:rotate=90
TAG:creation_time=2021-09-21T18:24:31.000000Z
TAG:language=eng
TAG:handler_name=MetaHandle
[/STREAM]
[STREAM]
index=1
codec_name=aac
codec_long_name=AAC (Advanced Audio Coding)
profile=LC
codec_type=audio
codec_tag_string=mp4a
codec_tag=0x6134706d
sample_fmt=fltp
sample_rate=48000
channels=2
channel_layout=stereo
bits_per_sample=0
id=N/A
r_frame_rate=0/0
avg_frame_rate=0/0
time_base=1/48000
start_pts=0
start_time=0.000000
duration_ts=802293
duration=16.714437
bit_rate=191986
max_bit_rate=N/A
bits_per_raw_sample=N/A
nb_frames=783
nb_read_frames=N/A
nb_read_packets=N/A
DISPOSITION:default=1
DISPOSITION:dub=0
DISPOSITION:original=0
DISPOSITION:comment=0
DISPOSITION:lyrics=0
DISPOSITION:karaoke=0
DISPOSITION:forced=0
DISPOSITION:hearing_impaired=0
DISPOSITION:visual_impaired=0
DISPOSITION:clean_effects=0
DISPOSITION:attached_pic=0
DISPOSITION:timed_thumbnails=0
TAG:rotate=90
TAG:creation_time=2021-09-21T18:24:31.000000Z
TAG:language=eng
TAG:handler_name=SoundHandle
TAG:vendor_id=[0][0][0][0]
[/STREAM]
[STREAM]
index=2
codec_name=h264
codec_long_name=H.264 / AVC / MPEG-4 AVC / MPEG-4 part 10
profile=High
codec_type=video
codec_tag_string=avc1
codec_tag=0x31637661
width=1920
height=1080
coded_width=1920
coded_height=1080
closed_captions=0
has_b_frames=0
sample_aspect_ratio=1:1
display_aspect_ratio=16:9
pix_fmt=yuvj420p
level=51
color_range=pc
color_space=smpte170m
color_transfer=smpte170m
color_primaries=bt470bg
chroma_location=left
field_order=unknown
refs=1
is_avc=true
nal_length_size=4
id=N/A
r_frame_rate=60/1
avg_frame_rate=79650000/1505479
time_base=1/90000
start_pts=0
start_time=0.000000
duration_ts=1505479
duration=16.727544
bit_rate=30058964
max_bit_rate=N/A
bits_per_raw_sample=8
nb_frames=885
nb_read_frames=N/A
nb_read_packets=N/A
DISPOSITION:default=1
DISPOSITION:dub=0
DISPOSITION:original=0
DISPOSITION:comment=0
DISPOSITION:lyrics=0
DISPOSITION:karaoke=0
DISPOSITION:forced=0
DISPOSITION:hearing_impaired=0
DISPOSITION:visual_impaired=0
DISPOSITION:clean_effects=0
DISPOSITION:attached_pic=0
DISPOSITION:timed_thumbnails=0
TAG:rotate=90
TAG:creation_time=2021-09-21T18:24:31.000000Z
TAG:language=eng
TAG:handler_name=VideoHandle
TAG:vendor_id=[0][0][0][0]
[SIDE_DATA]
side_data_type=Display Matrix
displaymatrix=
00000000:            0       65536           0
00000001:       -65536           0           0
00000002:            0           0  1073741824

rotation=-90
[/SIDE_DATA]
[/STREAM]
[FORMAT]
filename=PXL_20210921_182413576.mp4
nb_streams=3
nb_programs=0
format_name=mov,mp4,m4a,3gp,3g2,mj2
format_long_name=QuickTime / MOV
start_time=0.000000
duration=16.727500
size=63343611
bit_rate=30294358
probe_score=100
TAG:major_brand=mp42
TAG:minor_version=0
TAG:compatible_brands=isommp42
TAG:creation_time=2021-09-21T18:24:31.000000Z
TAG:location=+40.3492-74.3137/
TAG:location-eng=+40.3492-74.3137/
TAG:com.android.capture.fps=30.000000
[/FORMAT]
```
</details>


<details>
  <summary>Click to view mediainfo</summary>
  
```
General
Complete name                            : PXL_20210921_182413576.mp4
Format                                   : MPEG-4
Format profile                           : Base Media / Version 2
Codec ID                                 : mp42 (isom/mp42)
File size                                : 60.4 MiB
Duration                                 : 16 s 728 ms
Overall bit rate                         : 30.3 Mb/s
Encoded date                             : UTC 2021-09-21 18:24:31
Tagged date                              : UTC 2021-09-21 18:24:31
xyz                                      : +40.3492-74.3137/

Video
ID                                       : 3
Format                                   : AVC
Format/Info                              : Advanced Video Codec
Format profile                           : High@L5.1
Format settings                          : CABAC / 1 Ref Frames
Format settings, CABAC                   : Yes
Format settings, Reference frames        : 1 frame
Format settings, GOP                     : M=1, N=60
Codec ID                                 : avc1
Codec ID/Info                            : Advanced Video Coding
Duration                                 : 16 s 728 ms
Bit rate                                 : 30.1 Mb/s
Width                                    : 1 920 pixels
Height                                   : 1 080 pixels
Display aspect ratio                     : 16:9
Rotation                                 : 90°
Frame rate mode                          : Variable
Frame rate                               : 52.907 FPS
Minimum frame rate                       : 29.970 FPS
Maximum frame rate                       : 62.587 FPS
FrameRate_Real                           : 30.000 FPS
Standard                                 : NTSC
Color space                              : YUV
Chroma subsampling                       : 4:2:0
Bit depth                                : 8 bits
Scan type                                : Progressive
Bits/(Pixel*Frame)                       : 0.274
Stream size                              : 59.9 MiB (99%)
Title                                    : VideoHandle
Language                                 : English
Encoded date                             : UTC 2021-09-21 18:24:31
Tagged date                              : UTC 2021-09-21 18:24:31
Color range                              : Full
Color primaries                          : BT.601 PAL
Transfer characteristics                 : BT.709
transfer_characteristics_Original        : BT.601
Matrix coefficients                      : BT.601
Codec configuration box                  : avcC

Audio
ID                                       : 2
Format                                   : AAC LC
Format/Info                              : Advanced Audio Codec Low Complexity
Codec ID                                 : mp4a-40-2
Duration                                 : 16 s 714 ms
Bit rate mode                            : Constant
Bit rate                                 : 192 kb/s
Channel(s)                               : 2 channels
Channel layout                           : L R
Sampling rate                            : 48.0 kHz
Frame rate                               : 46.875 FPS (1024 SPF)
Compression mode                         : Lossy
Stream size                              : 392 KiB (1%)
Title                                    : SoundHandle
Language                                 : English
Encoded date                             : UTC 2021-09-21 18:24:31
Tagged date                              : UTC 2021-09-21 18:24:31

Other
Type                                     : meta
Duration                                 : 16 s 728 ms
Bit rate mode                            : Variable
```
</details>