### PR TITLE
Fix GlVideoRenderer.hasFilters() logic

### DIFF
--- a/litr/src/main/java/com/linkedin/android/litr/render/GlVideoRenderer.java
+++ b/litr/src/main/java/com/linkedin/android/litr/render/GlVideoRenderer.java
@@ -47,6 +47,8 @@ public class GlVideoRenderer implements Renderer {
                                                  ? MediaFormat.KEY_ROTATION
                                                  : "rotation-degrees";
 
+    private final boolean hasFilters;
+
     private VideoRenderInputSurface inputSurface;
     private VideoRenderOutputSurface outputSurface;
     private List<GlFilter> filters;
@@ -63,6 +65,8 @@ public class GlVideoRenderer implements Renderer {
      */
     public GlVideoRenderer(@Nullable List<GlFilter> filters) {
         this.filters = new ArrayList<>();
+        hasFilters = filters != null && !filters.isEmpty();
+
         if (filters == null) {
             this.filters.add(new DefaultVideoFrameRenderFilter());
             return;
@@ -146,7 +150,7 @@ public class GlVideoRenderer implements Renderer {
 
     @Override
     public boolean hasFilters() {
-        return filters != null && !filters.isEmpty();
+        return hasFilters;
     }
 
     /**

--- a/litr/src/main/java/com/linkedin/android/litr/render/Renderer.java
+++ b/litr/src/main/java/com/linkedin/android/litr/render/Renderer.java
@@ -10,7 +10,9 @@ package com.linkedin.android.litr.render;
 import android.media.MediaCodec;
 import android.media.MediaFormat;
 import android.view.Surface;
+
 import androidx.annotation.Nullable;
+
 import com.linkedin.android.litr.codec.Frame;
 
 /**
@@ -53,7 +55,7 @@ public interface Renderer {
     void release();
 
     /**
-     * Check if renderer has filters
+     * Check if renderer has user provided filters
      * @return true if has, false otherwise
      */
     boolean hasFilters();


### PR DESCRIPTION
`GlVideoRenderer.hasFilters()` always returned true, since it always had a `DefaultFrameRendererFilter` 
Intended behavior of `hasFilters()` method is to see if renderer has user provided filters, which would mean that user is modifying video frames, which in turn means that we cannot use a `PassthroughTrackTranscoder`. Fixing this now.