### PR TITLE
Store videos locally for transcoding, create MediaStore entries when transcoded successfully

### DIFF
--- a/litr-demo/src/main/java/com/linkedin/android/litr/demo/EmptyVideoFragment.kt
+++ b/litr-demo/src/main/java/com/linkedin/android/litr/demo/EmptyVideoFragment.kt
@@ -65,7 +65,7 @@ class EmptyVideoFragment : BaseTransformationFragment() {
         binding.transformationState = TransformationState()
         binding.transformationPresenter = TransformationPresenter(context!!, mediaTransformer)
 
-        val targetFile = File(TransformationUtil.getTargetFileDirectory(), "empty_video.mp4")
+        val targetFile = File(TransformationUtil.getTargetFileDirectory(requireContext().applicationContext), "empty_video.mp4")
         targetMedia.setTargetFile(targetFile)
         targetMedia.setTracks(sourceMedia.tracks)
 

--- a/litr-demo/src/main/java/com/linkedin/android/litr/demo/FreeTransformVideoGlFragment.java
+++ b/litr-demo/src/main/java/com/linkedin/android/litr/demo/FreeTransformVideoGlFragment.java
@@ -90,7 +90,7 @@ public class FreeTransformVideoGlFragment extends BaseTransformationFragment imp
     public void onMediaPicked(@NonNull Uri uri) {
         SourceMedia sourceMedia = binding.getSourceMedia();
         updateSourceMedia(sourceMedia, uri);
-        File targetFile = new File(TransformationUtil.getTargetFileDirectory(),
+        File targetFile = new File(TransformationUtil.getTargetFileDirectory(requireContext().getApplicationContext()),
                               "transcoded_" + TransformationUtil.getDisplayName(getContext(), sourceMedia.uri));
         binding.getTargetMedia().setTargetFile(targetFile);
         binding.getTargetMedia().setTracks(sourceMedia.tracks);

--- a/litr-demo/src/main/java/com/linkedin/android/litr/demo/MockTranscodeFragment.java
+++ b/litr-demo/src/main/java/com/linkedin/android/litr/demo/MockTranscodeFragment.java
@@ -84,7 +84,7 @@ public class MockTranscodeFragment extends BaseTransformationFragment {
 
         TargetMedia targetMedia = new TargetMedia();
         targetMedia.setTracks(sourceMedia.tracks);
-        File targetFile = new File(TransformationUtil.getTargetFileDirectory(), "transcoded_mock.mp4");
+        File targetFile = new File(TransformationUtil.getTargetFileDirectory(requireContext().getApplicationContext()), "transcoded_mock.mp4");
         targetMedia.setTargetFile(targetFile);
 
         TranscodingConfigPresenter transcodingConfigPresenter = new TranscodingConfigPresenter(this, targetMedia);
@@ -99,7 +99,8 @@ public class MockTranscodeFragment extends BaseTransformationFragment {
 
         final MediaTransformationListener mediaTransformationListener = new MediaTransformationListener(getContext(),
                                                                                                         transformationState.requestId,
-                                                                                                        transformationState);
+                                                                                                        transformationState,
+                                                                                                        targetMedia);
 
         binding.buttonTranscode.setOnClickListener(new View.OnClickListener() {
             @Override

--- a/litr-demo/src/main/java/com/linkedin/android/litr/demo/MuxVideoAndAudioFragment.kt
+++ b/litr-demo/src/main/java/com/linkedin/android/litr/demo/MuxVideoAndAudioFragment.kt
@@ -61,7 +61,7 @@ class MuxVideoAndAudioFragment : BaseTransformationFragment() {
                 when {
                     mimeType.startsWith("video") -> {
                         updateSourceMedia(binding.sourceVideo!!, uri)
-                        val targetFile = File(TransformationUtil.getTargetFileDirectory(),
+                        val targetFile = File(TransformationUtil.getTargetFileDirectory(requireContext().applicationContext),
                             "transcoded_" + TransformationUtil.getDisplayName(context!!, uri))
                         binding.targetMedia?.setTargetFile(targetFile)
                     }

--- a/litr-demo/src/main/java/com/linkedin/android/litr/demo/SquareCenterCropFragment.java
+++ b/litr-demo/src/main/java/com/linkedin/android/litr/demo/SquareCenterCropFragment.java
@@ -86,7 +86,7 @@ public class SquareCenterCropFragment extends BaseTransformationFragment impleme
     public void onMediaPicked(@NonNull Uri uri) {
         SourceMedia sourceMedia = binding.getSourceMedia();
         updateSourceMedia(sourceMedia, uri);
-        File targetFile = new File(TransformationUtil.getTargetFileDirectory(),
+        File targetFile = new File(TransformationUtil.getTargetFileDirectory(requireContext().getApplicationContext()),
                               "transcoded_" + TransformationUtil.getDisplayName(getContext(), sourceMedia.uri));
         binding.getTargetMedia().setTargetFile(targetFile);
         binding.getTargetMedia().setTracks(sourceMedia.tracks);

--- a/litr-demo/src/main/java/com/linkedin/android/litr/demo/TranscodeVideoGlFragment.java
+++ b/litr-demo/src/main/java/com/linkedin/android/litr/demo/TranscodeVideoGlFragment.java
@@ -81,7 +81,7 @@ public class TranscodeVideoGlFragment extends BaseTransformationFragment impleme
         SourceMedia sourceMedia = binding.getSourceMedia();
         updateSourceMedia(sourceMedia, uri);
         updateTrimConfig(binding.getTrimConfig(), sourceMedia);
-        File targetFile = new File(TransformationUtil.getTargetFileDirectory(),
+        File targetFile = new File(TransformationUtil.getTargetFileDirectory(requireContext().getApplicationContext()),
                               "transcoded_" + TransformationUtil.getDisplayName(getContext(), sourceMedia.uri));
         binding.getTargetMedia().setTargetFile(targetFile);
         binding.getTargetMedia().setTracks(sourceMedia.tracks);

--- a/litr-demo/src/main/java/com/linkedin/android/litr/demo/VideoFiltersFragment.java
+++ b/litr-demo/src/main/java/com/linkedin/android/litr/demo/VideoFiltersFragment.java
@@ -94,7 +94,7 @@ public class VideoFiltersFragment extends BaseTransformationFragment implements 
     public void onMediaPicked(@NonNull Uri uri) {
         SourceMedia sourceMedia = binding.getSourceMedia();
         updateSourceMedia(sourceMedia, uri);
-        File targetFile = new File(TransformationUtil.getTargetFileDirectory(),
+        File targetFile = new File(TransformationUtil.getTargetFileDirectory(requireContext().getApplicationContext()),
                               "transcoded_" + TransformationUtil.getDisplayName(getContext(), sourceMedia.uri));
         binding.getTargetMedia().setTargetFile(targetFile);
         binding.getTargetMedia().setTracks(sourceMedia.tracks);

--- a/litr-demo/src/main/java/com/linkedin/android/litr/demo/VideoWatermarkFragment.java
+++ b/litr-demo/src/main/java/com/linkedin/android/litr/demo/VideoWatermarkFragment.java
@@ -90,7 +90,7 @@ public class VideoWatermarkFragment extends BaseTransformationFragment implement
         SourceMedia sourceMedia = binding.getSourceMedia();
         updateSourceMedia(sourceMedia, uri);
         updateTrimConfig(binding.getTrimConfig(), sourceMedia);
-        File targetFile = new File(TransformationUtil.getTargetFileDirectory(),
+        File targetFile = new File(TransformationUtil.getTargetFileDirectory(requireContext().getApplicationContext()),
                               "transcoded_" + TransformationUtil.getDisplayName(getContext(), sourceMedia.uri));
         binding.getTargetMedia().setTargetFile(targetFile);
         binding.getTargetMedia().setTracks(sourceMedia.tracks);

--- a/litr-demo/src/main/java/com/linkedin/android/litr/demo/data/MediaTransformationListener.java
+++ b/litr-demo/src/main/java/com/linkedin/android/litr/demo/data/MediaTransformationListener.java
@@ -11,6 +11,8 @@ import android.content.Context;
 import android.text.TextUtils;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
+
 import com.linkedin.android.litr.TransformationListener;
 import com.linkedin.android.litr.analytics.TrackTransformationInfo;
 import com.linkedin.android.litr.utils.TrackMetadataUtil;
@@ -22,13 +24,27 @@ public class MediaTransformationListener implements TransformationListener {
     private final Context context;
     private final String requestId;
     private final TransformationState transformationState;
+    private final SharedMediaStoragePublisher publisher;
+    private final TargetMedia targetMedia;
 
     public MediaTransformationListener(@NonNull Context context,
                                        @NonNull String requestId,
-                                       @NonNull TransformationState transformationState) {
+                                       @NonNull TransformationState transformationState,
+                                       @NonNull TargetMedia targetMedia) {
+        this(context, requestId, transformationState, targetMedia, new SharedMediaStoragePublisher(context));
+    }
+
+    @VisibleForTesting
+    MediaTransformationListener(@NonNull Context context,
+                                       @NonNull String requestId,
+                                       @NonNull TransformationState transformationState,
+                                       @NonNull TargetMedia targetMedia,
+                                       @NonNull SharedMediaStoragePublisher publisher) {
         this.context = context;
         this.requestId = requestId;
         this.transformationState = transformationState;
+        this.targetMedia = targetMedia;
+        this.publisher = publisher;
     }
 
     @Override
@@ -51,6 +67,7 @@ public class MediaTransformationListener implements TransformationListener {
             transformationState.setState(TransformationState.STATE_COMPLETED);
             transformationState.setProgress(TransformationState.MAX_PROGRESS);
             transformationState.setStats(TrackMetadataUtil.printTransformationStats(context, trackTransformationInfos));
+            publisher.publish(targetMedia.targetFile, false, (file, contentUri) -> targetMedia.setContentUri(contentUri));
         }
     }
 

--- a/litr-demo/src/main/java/com/linkedin/android/litr/demo/data/SharedMediaStoragePublisher.kt
+++ b/litr-demo/src/main/java/com/linkedin/android/litr/demo/data/SharedMediaStoragePublisher.kt
@@ -1,0 +1,130 @@
+package com.linkedin.android.litr.demo.data
+
+import android.content.ContentResolver
+import android.content.ContentValues
+import android.content.Context
+import android.net.Uri
+import android.os.Build
+import android.os.Environment
+import android.os.Handler
+import android.os.Looper
+import android.provider.MediaStore
+import android.util.Log
+import androidx.annotation.ChecksSdkIntAtLeast
+import androidx.annotation.WorkerThread
+import java.io.File
+import java.io.FileInputStream
+import java.io.IOException
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+
+/**
+ * Provides interaction between locally-stored media files and the [MediaStore].
+ * Copies video file and creates necessary entries to make video discoverable by the user, surviving application re-installs.
+ *
+ * @param context The context, used to obtain a [ContentResolver]
+ * @param executor The [ExecutorService] to use for fire-and-forget IO
+ * @param handler The handler to which [MediaPublishedListener] events are posted
+ */
+class SharedMediaStoragePublisher @JvmOverloads constructor(
+    private val context: Context,
+    private val executor: ExecutorService = Executors.newSingleThreadExecutor(),
+    private val handler: Handler = Handler(Looper.getMainLooper())
+) {
+
+    private val resolver: ContentResolver
+        get() = context.contentResolver
+
+    fun publish(file: File, keepOriginal: Boolean, listener: MediaPublishedListener) {
+        executor.execute {
+            val contentUri = storeVideoInternal(file, keepOriginal)
+            handler.post {
+                listener.onPublished(file, contentUri)
+            }
+        }
+    }
+
+    @WorkerThread
+    private fun storeVideoInternal(file: File, keepOriginal: Boolean): Uri? {
+        if (!file.exists()) return null
+
+        val newFileName = file.name
+
+        val values = ContentValues().apply {
+            put(MediaStore.Video.Media.MIME_TYPE, MIME_TYPE_MPEG_4)
+            put(MediaStore.Video.Media.TITLE, newFileName)
+            put(MediaStore.Video.Media.DISPLAY_NAME, newFileName)
+            put(MediaStore.Video.Media.DATE_TAKEN, System.currentTimeMillis())
+            if (isAndroidQ) {
+                put(MediaStore.Video.Media.RELATIVE_PATH, relativePathMovies)
+                put(MediaStore.Video.Media.IS_PENDING, 1)
+            }
+        }
+
+
+        val collectionUrl = if (isAndroidQ) {
+            MediaStore.Video.Media.getContentUri(MediaStore.VOLUME_EXTERNAL_PRIMARY)
+        } else {
+            MediaStore.Video.Media.EXTERNAL_CONTENT_URI
+        }
+
+        var contentUri: Uri? = null
+
+        runCatching {
+            resolver.insert(collectionUrl, values)?.also { insertedUri ->
+                contentUri = insertedUri
+                resolver.openOutputStream(insertedUri)?.use { output ->
+                    FileInputStream(file).use { input ->
+                        input.copyTo(output)
+                    }
+                } ?: throw IOException("Failed to copy video to output stream")
+            } ?: throw IOException("Failed to insert video to MediaStore")
+
+        }.onFailure {
+            Log.e(TAG, "Error copying file to MediaStore", it)
+            contentUri?.let { copyFailedUri ->
+                resolver.delete(copyFailedUri, null, null)
+            }
+        }
+
+        if (!keepOriginal) {
+            runCatching { file.delete() }.onFailure {
+                Log.e(TAG, "Unable to delete original video file $file from system", it)
+            }
+        }
+
+        if (isAndroidQ) {
+            contentUri?.let {
+                // Since we're done writing to the Uri, this tells MediaStore that other apps can use the content now.
+                values.clear()
+                values.put(MediaStore.Video.Media.IS_PENDING, 0)
+                runCatching {
+                    resolver.update(it, values, null, null)
+                }.onFailure {
+                    Log.e(TAG, "Could not update MediaStore for $file", it)
+                }
+            }
+        }
+
+        return contentUri
+    }
+
+    interface MediaPublishedListener {
+        fun onPublished(file: File, contentUri: Uri?)
+    }
+
+    companion object {
+        private val TAG = SharedMediaStoragePublisher::class.qualifiedName
+        private const val MIME_TYPE_MPEG_4 = "video/mp4"
+
+        private val isAndroidQ
+            @ChecksSdkIntAtLeast(api = Build.VERSION_CODES.Q)
+            get() = Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q
+
+
+        private val moviesDirectory = Environment.DIRECTORY_MOVIES
+        private val litrDirectory = "LiTr"
+        private val relativePathMovies = "${moviesDirectory}/${litrDirectory}"
+
+    }
+}

--- a/litr-demo/src/main/java/com/linkedin/android/litr/demo/data/TargetMedia.java
+++ b/litr-demo/src/main/java/com/linkedin/android/litr/demo/data/TargetMedia.java
@@ -28,6 +28,8 @@ public class TargetMedia extends BaseObservable {
     public static final int DEFAULT_AUDIO_BITRATE = 128000;
 
     public File targetFile;
+    @Nullable
+    private Uri contentUri;
     public List<TargetTrack> tracks = new ArrayList<>();
     public Uri backgroundImageUri;
     public GlFilter filter;
@@ -96,6 +98,16 @@ public class TargetMedia extends BaseObservable {
             }
         }
         return null;
+    }
+
+    @Nullable
+    public Uri getContentUri() {
+        return contentUri;
+    }
+
+    public void setContentUri(@Nullable Uri storedContentUri) {
+        this.contentUri = storedContentUri;
+        notifyChange();
     }
 
 }

--- a/litr-demo/src/main/java/com/linkedin/android/litr/demo/data/TransformationPresenter.java
+++ b/litr-demo/src/main/java/com/linkedin/android/litr/demo/data/TransformationPresenter.java
@@ -20,10 +20,10 @@ import android.util.Log;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.core.content.FileProvider;
 
 import com.linkedin.android.litr.MediaTransformer;
 import com.linkedin.android.litr.TrackTransform;
+import com.linkedin.android.litr.TransformationListener;
 import com.linkedin.android.litr.TransformationOptions;
 import com.linkedin.android.litr.codec.MediaCodecDecoder;
 import com.linkedin.android.litr.codec.MediaCodecEncoder;
@@ -42,7 +42,6 @@ import com.linkedin.android.litr.io.MockVideoMediaSource;
 import com.linkedin.android.litr.render.GlVideoRenderer;
 import com.linkedin.android.litr.utils.TransformationUtil;
 
-import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -82,7 +81,8 @@ public class TransformationPresenter {
         transformationState.requestId = UUID.randomUUID().toString();
         MediaTransformationListener transformationListener = new MediaTransformationListener(context,
                                                                                              transformationState.requestId,
-                                                                                             transformationState);
+                                                                                             transformationState,
+                                                                                             targetMedia);
 
         try {
             int videoRotation = 0;
@@ -153,7 +153,8 @@ public class TransformationPresenter {
         transformationState.requestId = UUID.randomUUID().toString();
         MediaTransformationListener transformationListener = new MediaTransformationListener(context,
                 transformationState.requestId,
-                transformationState);
+                transformationState,
+                targetMedia);
 
         try {
             MediaTarget mediaTarget = new MediaMuxerMediaTarget(targetMedia.targetFile.getPath(),
@@ -224,7 +225,8 @@ public class TransformationPresenter {
         transformationState.requestId = UUID.randomUUID().toString();
         MediaTransformationListener transformationListener = new MediaTransformationListener(context,
                 transformationState.requestId,
-                transformationState);
+                transformationState,
+                targetMedia);
 
         try {
             int videoRotation = 0;
@@ -311,7 +313,8 @@ public class TransformationPresenter {
         transformationState.requestId = UUID.randomUUID().toString();
         MediaTransformationListener transformationListener = new MediaTransformationListener(context,
                 transformationState.requestId,
-                transformationState);
+                transformationState,
+                targetMedia);
 
         List<GlFilter> watermarkImageFilter = null;
         for (TargetTrack targetTrack : targetMedia.tracks) {
@@ -357,7 +360,8 @@ public class TransformationPresenter {
         transformationState.requestId = UUID.randomUUID().toString();
         MediaTransformationListener transformationListener = new MediaTransformationListener(context,
                 transformationState.requestId,
-                transformationState);
+                transformationState,
+                targetMedia);
 
         TransformationOptions transformationOptions = new TransformationOptions.Builder()
                 .setGranularity(MediaTransformer.GRANULARITY_DEFAULT)
@@ -384,7 +388,8 @@ public class TransformationPresenter {
         transformationState.requestId = UUID.randomUUID().toString();
         MediaTransformationListener transformationListener = new MediaTransformationListener(context,
                 transformationState.requestId,
-                transformationState);
+                transformationState,
+                targetMedia);
 
         try {
             int videoRotation = 0;
@@ -467,7 +472,8 @@ public class TransformationPresenter {
         transformationState.requestId = UUID.randomUUID().toString();
         MediaTransformationListener transformationListener = new MediaTransformationListener(context,
                 transformationState.requestId,
-                transformationState);
+                transformationState,
+                targetMedia);
 
         try {
             int videoRotation = 0;
@@ -535,13 +541,10 @@ public class TransformationPresenter {
         mediaTransformer.cancel(requestId);
     }
 
-    public void play(@Nullable File targetFile) {
-        if (targetFile != null && targetFile.exists()) {
+    public void play(@Nullable Uri contentUri) {
+        if (contentUri != null) {
             Intent playIntent = new Intent(Intent.ACTION_VIEW);
-            Uri videoUri = FileProvider.getUriForFile(context,
-                                                      context.getPackageName() + ".provider",
-                                                      targetFile);
-            playIntent.setDataAndType(videoUri, "video/*");
+            playIntent.setDataAndType(contentUri, "video/*");
             playIntent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
 
             context.startActivity(playIntent);

--- a/litr-demo/src/main/java/com/linkedin/android/litr/utils/TransformationUtil.java
+++ b/litr-demo/src/main/java/com/linkedin/android/litr/utils/TransformationUtil.java
@@ -13,7 +13,7 @@ import android.database.Cursor;
 import android.graphics.Bitmap;
 import android.graphics.PointF;
 import android.net.Uri;
-import android.os.Environment;
+import android.os.Build;
 import android.os.SystemClock;
 import android.provider.MediaStore;
 import android.text.TextUtils;
@@ -95,15 +95,12 @@ public class TransformationUtil {
     }
 
     @NonNull
-    public static File getTargetFileDirectory() {
-        File targetDirectory = new File(Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_MOVIES)
-                                            + File.separator
-                                            + "LiTr");
-        if (!targetDirectory.exists()) {
-            targetDirectory.mkdirs();
+    public static File getTargetFileDirectory(Context context) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            return context.getNoBackupFilesDir();
+        } else {
+            return context.getFilesDir();
         }
-
-        return targetDirectory;
     }
 
     @NonNull

--- a/litr-demo/src/main/res/layout/fragment_empty_video.xml
+++ b/litr-demo/src/main/res/layout/fragment_empty_video.xml
@@ -92,7 +92,7 @@
                 android:text="@string/play"
                 android:enabled="@{transformationState.state == transformationState.STATE_COMPLETED}"
                 android:padding="@dimen/cell_padding"
-                android:onClick="@{() -> transformationPresenter.play(targetMedia.targetFile)}"/>
+                android:onClick="@{() -> transformationPresenter.play(targetMedia.contentUri)}"/>
 
             <TextView
                 android:layout_width="match_parent"

--- a/litr-demo/src/main/res/layout/fragment_mux_video_audio.xml
+++ b/litr-demo/src/main/res/layout/fragment_mux_video_audio.xml
@@ -81,7 +81,7 @@
                 android:text="@string/play"
                 android:enabled="@{transformationState.state == transformationState.STATE_COMPLETED}"
                 android:padding="@dimen/cell_padding"
-                android:onClick="@{() -> transformationPresenter.play(targetMedia.targetFile)}"/>
+                android:onClick="@{() -> transformationPresenter.play(targetMedia.contentUri)}"/>
 
             <TextView
                 android:layout_width="match_parent"

--- a/litr-demo/src/main/res/layout/fragment_square_center_crop.xml
+++ b/litr-demo/src/main/res/layout/fragment_square_center_crop.xml
@@ -75,7 +75,7 @@
                 android:text="@string/play"
                 android:enabled="@{transformationState.state == transformationState.STATE_COMPLETED}"
                 android:padding="@dimen/cell_padding"
-                android:onClick="@{() -> transformationPresenter.play(targetMedia.targetFile)}"/>
+                android:onClick="@{() -> transformationPresenter.play(targetMedia.contentUri)}"/>
 
             <TextView
                 android:layout_width="match_parent"

--- a/litr-demo/src/main/res/layout/fragment_transcode_video_gl.xml
+++ b/litr-demo/src/main/res/layout/fragment_transcode_video_gl.xml
@@ -89,7 +89,7 @@
                 android:text="@string/play"
                 android:enabled="@{transformationState.state == transformationState.STATE_COMPLETED}"
                 android:padding="@dimen/cell_padding"
-                android:onClick="@{() -> transformationPresenter.play(targetMedia.targetFile)}"/>
+                android:onClick="@{() -> transformationPresenter.play(targetMedia.contentUri)}"/>
 
             <TextView
                 android:layout_width="match_parent"

--- a/litr-demo/src/main/res/layout/fragment_video_filters.xml
+++ b/litr-demo/src/main/res/layout/fragment_video_filters.xml
@@ -78,7 +78,7 @@
                 android:text="@string/play"
                 android:enabled="@{transformationState.state == transformationState.STATE_COMPLETED}"
                 android:padding="@dimen/cell_padding"
-                android:onClick="@{() -> transformationPresenter.play(targetMedia.targetFile)}"/>
+                android:onClick="@{() -> transformationPresenter.play(targetMedia.contentUri)}"/>
 
             <TextView
                 android:layout_width="match_parent"

--- a/litr-demo/src/main/res/layout/fragment_video_overlay_gl.xml
+++ b/litr-demo/src/main/res/layout/fragment_video_overlay_gl.xml
@@ -87,7 +87,7 @@
                 android:text="@string/play"
                 android:enabled="@{transformationState.state == transformationState.STATE_COMPLETED}"
                 android:padding="@dimen/cell_padding"
-                android:onClick="@{() -> transformationPresenter.play(targetMedia.targetFile)}"/>
+                android:onClick="@{() -> transformationPresenter.play(targetMedia.contentUri)}"/>
 
             <TextView
                 android:layout_width="match_parent"

--- a/litr-demo/src/main/res/layout/fragment_video_watermark.xml
+++ b/litr-demo/src/main/res/layout/fragment_video_watermark.xml
@@ -105,7 +105,7 @@
                 android:text="@string/play"
                 android:enabled="@{transformationState.state == transformationState.STATE_COMPLETED}"
                 android:padding="@dimen/cell_padding"
-                android:onClick="@{() -> transformationPresenter.play(targetMedia.targetFile)}"/>
+                android:onClick="@{() -> transformationPresenter.play(targetMedia.contentUri)}"/>
 
             <TextView
                 android:layout_width="match_parent"


### PR DESCRIPTION
With Android Q+, we should no longer use `Environment.getExternalStoragePublicDirectory`, because it is deprecated and will throw when attempting IO with files in that directory.

The approach here is:
1. Write all video files to the files dir owned by demo app.
2. When transcoding is done, create a MediaStore entry and copy finished video to the content URI, deleting original file.

This keeps changes localized to the demo app.

We can also consider adding UI (checkbox or button) to explicitly specify if step #2 should happen, because it has potential to pollute the user's device with a lot of transcoded videos.
