### PR TITLE
Handle float frame rate or interval in MediaFormat

### DIFF
--- a/litr-demo/src/main/java/com/linkedin/android/litr/demo/BaseTransformationFragment.java
+++ b/litr-demo/src/main/java/com/linkedin/android/litr/demo/BaseTransformationFragment.java
@@ -24,6 +24,7 @@ import com.linkedin.android.litr.demo.data.GenericTrackFormat;
 import com.linkedin.android.litr.demo.data.SourceMedia;
 import com.linkedin.android.litr.demo.data.TrimConfig;
 import com.linkedin.android.litr.demo.data.VideoTrackFormat;
+import com.linkedin.android.litr.utils.MediaFormatUtils;
 import com.linkedin.android.litr.utils.TranscoderUtils;
 
 import java.io.IOException;
@@ -91,8 +92,8 @@ public class BaseTransformationFragment extends Fragment {
                     videoTrack.width = getInt(mediaFormat, MediaFormat.KEY_WIDTH);
                     videoTrack.height = getInt(mediaFormat, MediaFormat.KEY_HEIGHT);
                     videoTrack.duration = getLong(mediaFormat, MediaFormat.KEY_DURATION);
-                    videoTrack.frameRate = getInt(mediaFormat, MediaFormat.KEY_FRAME_RATE);
-                    videoTrack.keyFrameInterval = getInt(mediaFormat, MediaFormat.KEY_I_FRAME_INTERVAL);
+                    videoTrack.frameRate = MediaFormatUtils.getFrameRate(mediaFormat, -1).intValue();
+                    videoTrack.keyFrameInterval = MediaFormatUtils.getIFrameInterval(mediaFormat, -1).intValue();
                     videoTrack.rotation = getInt(mediaFormat, KEY_ROTATION, 0);
                     videoTrack.bitrate = getInt(mediaFormat, MediaFormat.KEY_BIT_RATE);
                     sourceMedia.tracks.add(videoTrack);

--- a/litr-demo/src/main/java/com/linkedin/android/litr/utils/TrackMetadataUtil.java
+++ b/litr-demo/src/main/java/com/linkedin/android/litr/utils/TrackMetadataUtil.java
@@ -93,10 +93,10 @@ public class TrackMetadataUtil {
             stringBuilder.append(context.getString(R.string.stats_duration, mediaFormat.getLong(MediaFormat.KEY_DURATION)));
         }
         if (mediaFormat.containsKey(MediaFormat.KEY_FRAME_RATE)) {
-            stringBuilder.append(context.getString(R.string.stats_frame_rate, mediaFormat.getInteger(MediaFormat.KEY_FRAME_RATE)));
+            stringBuilder.append(context.getString(R.string.stats_frame_rate, MediaFormatUtils.getFrameRate(mediaFormat, 0).intValue()));
         }
         if (mediaFormat.containsKey(MediaFormat.KEY_I_FRAME_INTERVAL)) {
-            stringBuilder.append(context.getString(R.string.stats_key_frame_interval, mediaFormat.getInteger(MediaFormat.KEY_I_FRAME_INTERVAL)));
+            stringBuilder.append(context.getString(R.string.stats_key_frame_interval, MediaFormatUtils.getIFrameInterval(mediaFormat, 0).intValue()));
         }
         if (mediaFormat.containsKey(KEY_ROTATION)) {
             stringBuilder.append(context.getString(R.string.stats_rotation, mediaFormat.getInteger(KEY_ROTATION)));

--- a/litr/src/main/java/com/linkedin/android/litr/io/MockVideoMediaSource.kt
+++ b/litr/src/main/java/com/linkedin/android/litr/io/MockVideoMediaSource.kt
@@ -11,6 +11,7 @@ import android.media.MediaCodec
 import android.media.MediaFormat
 import android.os.Build
 import com.linkedin.android.litr.transcoder.TrackTranscoder
+import com.linkedin.android.litr.utils.MediaFormatUtils
 import java.nio.ByteBuffer
 
 /**
@@ -35,7 +36,7 @@ class MockVideoMediaSource(
         trackDuration = trackFormat.getLong(MediaFormat.KEY_DURATION)
 
         assert(trackFormat.containsKey(MediaFormat.KEY_FRAME_RATE))
-        frameDuration = 1_000_000L / trackFormat.getInteger(MediaFormat.KEY_FRAME_RATE)
+        frameDuration = 1_000_000L / MediaFormatUtils.getFrameRate(trackFormat, -1).toInt()
 
         val keyRotation =
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) MediaFormat.KEY_ROTATION else "rotation-degrees"

--- a/litr/src/main/java/com/linkedin/android/litr/transcoder/VideoTrackTranscoder.java
+++ b/litr/src/main/java/com/linkedin/android/litr/transcoder/VideoTrackTranscoder.java
@@ -21,6 +21,7 @@ import com.linkedin.android.litr.io.MediaSource;
 import com.linkedin.android.litr.io.MediaTarget;
 import com.linkedin.android.litr.render.GlVideoRenderer;
 import com.linkedin.android.litr.render.Renderer;
+import com.linkedin.android.litr.utils.MediaFormatUtils;
 
 import java.util.concurrent.TimeUnit;
 
@@ -66,9 +67,9 @@ public class VideoTrackTranscoder extends TrackTranscoder {
 
     private void initCodecs() throws TrackTranscoderException {
         sourceVideoFormat = mediaSource.getTrackFormat(sourceTrack);
-        if (sourceVideoFormat.containsKey(MediaFormat.KEY_FRAME_RATE)) {
-            int sourceFrameRate = sourceVideoFormat.getInteger(MediaFormat.KEY_FRAME_RATE);
-            targetVideoFormat.setInteger(MediaFormat.KEY_FRAME_RATE, sourceFrameRate);
+        Number sourceFrameRate = MediaFormatUtils.getNumber(sourceVideoFormat, MediaFormat.KEY_FRAME_RATE);
+        if (sourceFrameRate != null) {
+            targetVideoFormat.setInteger(MediaFormat.KEY_FRAME_RATE, sourceFrameRate.intValue());
         }
 
         encoder.init(targetFormat);

--- a/litr/src/main/java/com/linkedin/android/litr/utils/MediaFormatUtils.kt
+++ b/litr/src/main/java/com/linkedin/android/litr/utils/MediaFormatUtils.kt
@@ -1,0 +1,31 @@
+package com.linkedin.android.litr.utils
+
+import android.media.MediaFormat
+import android.os.Build
+
+class MediaFormatUtils {
+    companion object {
+        @JvmStatic
+        fun getIFrameInterval(format: MediaFormat, defaultValue: Number): Number {
+            return getNumber(format, MediaFormat.KEY_I_FRAME_INTERVAL) ?: return defaultValue
+        }
+
+        @JvmStatic
+        fun getFrameRate(format: MediaFormat, defaultValue: Number): Number {
+            return getNumber(format, MediaFormat.KEY_FRAME_RATE) ?: return defaultValue
+        }
+
+        @JvmStatic
+        fun getNumber(format: MediaFormat, key: String): Number? {
+            return when {
+                !format.containsKey(key) -> null
+                Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q -> format.getNumber(key)
+                else -> runCatching {
+                    format.getInteger(key)
+                }.recoverCatching {
+                    format.getFloat(key)
+                }.getOrNull()
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR provides a safer way to retrieve frame rate and I-Frame interval from MediaFormat, since those values can be stored as either float or int (see [here](https://developer.android.com/reference/android/media/MediaFormat#KEY_FRAME_RATE), [here](https://developer.android.com/reference/android/media/MediaFormat#KEY_I_FRAME_INTERVAL)).

To reduce the scope of changes, this PR doesn't change the type of these values in the lib or the demos -- only provides minor safety for retrieving them. As a result, the way those values are used should remain unchanged (i.e. continue to use int)


When the output format is set (`MediaCodec.INFO_OUTPUT_FORMAT_CHANGED`), we obtain the target format from the encoder. The format can contain either float or int values for the above-keys, so reading as integer afterward is not guaranteed to succeed. So this PR provides a relatively safe way to access those values. Until Android Q, we don't have a good way to either get a type for key, or get a Number, so exceptions are used to test. Maybe there's a better way?