### PR TITLE
Fix for incorrect size estimation with range

### DIFF
--- a/litr/src/main/java/com/linkedin/android/litr/utils/TranscoderUtils.java
+++ b/litr/src/main/java/com/linkedin/android/litr/utils/TranscoderUtils.java
@@ -216,10 +216,6 @@ public final class TranscoderUtils {
     }
 
     private static long getDuration(final @NonNull TrackTransform trackTransform) {
-        // Get the user specified MediaRange's duration
-        final MediaRange mediaRange = trackTransform.getMediaSource().getSelection();
-        final long trimmedDuration = mediaRange.getEnd() - mediaRange.getStart();
-
         final MediaFormat trackFormat = trackTransform.getMediaSource()
                 .getTrackFormat(trackTransform.getSourceTrack());
 
@@ -227,9 +223,12 @@ public final class TranscoderUtils {
         long trackDuration = -1;
         if (trackFormat.containsKey(MediaFormat.KEY_DURATION)) {
             trackDuration = trackFormat.getLong(MediaFormat.KEY_DURATION);
+
+            // Get the user specified MediaRange's duration
+            final MediaRange mediaRange = trackTransform.getMediaSource().getSelection();
+            trackDuration = Math.min(trackDuration, mediaRange.getEnd()) - Math.max(0, mediaRange.getStart());
         }
 
-        // Trimmed duration could be Long.MAX_VALUE, return the track duration in that case
-        return Math.min(trimmedDuration, trackDuration);
+        return trackDuration;
     }
 }


### PR DESCRIPTION
Duration estimation had a bug, it didn't work when media range started at non-zero and ended at Long.MAX_VALUE