### PR TITLE
Audio resampling

### DIFF
--- a/litr-demo/src/main/java/com/linkedin/android/litr/demo/data/TransformationPresenter.java
+++ b/litr-demo/src/main/java/com/linkedin/android/litr/demo/data/TransformationPresenter.java
@@ -23,7 +23,6 @@ import androidx.annotation.Nullable;
 
 import com.linkedin.android.litr.MediaTransformer;
 import com.linkedin.android.litr.TrackTransform;
-import com.linkedin.android.litr.TransformationListener;
 import com.linkedin.android.litr.TransformationOptions;
 import com.linkedin.android.litr.codec.MediaCodecDecoder;
 import com.linkedin.android.litr.codec.MediaCodecEncoder;
@@ -568,7 +567,7 @@ public class TransformationPresenter {
                 AudioTrackFormat trackFormat = (AudioTrackFormat) targetTrack.format;
                 mediaFormat = MediaFormat.createAudioFormat(
                         "audio/mp4a-latm",
-                        trackFormat.samplingRate,
+                        trackFormat.samplingRate / 2,
                         trackFormat.channelCount);
                 mediaFormat.setInteger(MediaFormat.KEY_BIT_RATE, trackFormat.bitrate / 2);
                 mediaFormat.setLong(MediaFormat.KEY_DURATION, trackFormat.duration);

--- a/litr-demo/src/main/java/com/linkedin/android/litr/demo/data/TransformationPresenter.java
+++ b/litr-demo/src/main/java/com/linkedin/android/litr/demo/data/TransformationPresenter.java
@@ -560,7 +560,6 @@ public class TransformationPresenter {
 
         try {
             MediaSource mediaSource = new MediaExtractorMediaSource(context, sourceMedia.uri, mediaRange);
-            //MediaTarget mediaTarget = new WavMediaTarget(targetMedia.targetFile.getPath() + ".wav");
             MediaTarget mediaTarget = new MediaMuxerMediaTarget(targetMedia.targetFile.getPath(),
                     1,
                     0,

--- a/litr/build.gradle
+++ b/litr/build.gradle
@@ -31,6 +31,13 @@ android {
         checkTestSources true
         checkReleaseBuilds false
     }
+
+    externalNativeBuild {
+        cmake {
+            path file('src/main/cpp/CMakeLists.txt')
+            version '3.10.2'
+        }
+    }
 }
 
 dependencies {

--- a/litr/src/main/cpp/CMakeLists.txt
+++ b/litr/src/main/cpp/CMakeLists.txt
@@ -1,0 +1,16 @@
+
+
+cmake_minimum_required(VERSION 3.10.2)
+
+project("LiTrNative")
+
+add_library(litr-jni SHARED
+        audio-resampler.cpp)
+
+add_subdirectory(oboe_resampler)
+
+find_library(log-lib log)
+
+target_link_libraries(litr-jni
+        ${log-lib}
+        oboe-resampler)

--- a/litr/src/main/cpp/audio-resampler.cpp
+++ b/litr/src/main/cpp/audio-resampler.cpp
@@ -35,9 +35,10 @@ Java_com_linkedin_android_litr_render_AudioRenderer_resample(
         auto inputBuffer = new float[sampleCount * channel_count];
         auto outputBuffer = new float[channel_count];
 
+        // bytes contained in audio buffer produced by MediaCodec contains make up big endian shorts
+        // first we recreate short values, then simply cast them to floats, expected by Oboe resampler
         for (int index = 0; index < sampleCount * channel_count; index++) {
-            short value = (sourceBuffer[index * 2] << 8) | sourceBuffer[index * 2 + 1];
-            inputBuffer[index] = ((float) value);
+            inputBuffer[index] = (float) ((short) ((sourceBuffer[index * 2] << 8) | sourceBuffer[index * 2 + 1]));
         }
 
         int framesProcessed = 0;

--- a/litr/src/main/cpp/audio-resampler.cpp
+++ b/litr/src/main/cpp/audio-resampler.cpp
@@ -41,8 +41,8 @@ Java_com_linkedin_android_litr_render_AudioRenderer_resample(
 
         while (inputFramesLeft > 0) {
             if (audio_resampler->isWriteNeeded()) {
-                // bytes contained in audio buffer produced by MediaCodec contains make up little endian shorts
-                // first we recreate short values, then simply cast them to floats, expected by Oboe resampler
+                // bytes contained in audio buffer produced by MediaCodec make up little endian shorts
+                // first we recreate short values, then cast them to floats, expected by Oboe resampler
                 for (int channel = 0; channel < channel_count; channel++) {
                     int index = (sampleCount - inputFramesLeft) * channel_count + channel;
                     inputBuffer[channel] = (float) ((short) (((sourceBuffer[index * 2 + 1] & 0xFF) << 8) | sourceBuffer[index * 2] & 0xFF));

--- a/litr/src/main/cpp/audio-resampler.cpp
+++ b/litr/src/main/cpp/audio-resampler.cpp
@@ -34,7 +34,7 @@ Java_com_linkedin_android_litr_render_AudioRenderer_resample(
         jshort* targetBuffer = env->GetShortArrayElements(jtargetBuffer, JNI_FALSE);
 
         auto inputBuffer = new float[sourceBufferSize];
-        auto outputBuffer = new float[targetBufferSize];
+        auto outputBuffer = new float[channel_count];
 
         for (int index = 0; index < sourceBufferSize; index++) {
             inputBuffer[index] = ((float) sourceBuffer[index]);
@@ -50,12 +50,9 @@ Java_com_linkedin_android_litr_render_AudioRenderer_resample(
                 inputFramesLeft--;
             } else {
                 audio_resampler->readNextFrame(outputBuffer);
-
                 for (int channel = 0; channel < channel_count; channel++) {
                     targetBuffer[framesProcessed * channel_count + channel] = (short) *(outputBuffer + channel);
                 }
-
-                outputBuffer += channel_count;
                 framesProcessed++;
             }
         }

--- a/litr/src/main/cpp/audio-resampler.cpp
+++ b/litr/src/main/cpp/audio-resampler.cpp
@@ -26,21 +26,21 @@ Java_com_linkedin_android_litr_render_AudioRenderer_resample(
         JNIEnv* env,
         jobject,
         jshortArray jsourceBuffer,
-        jint sourceBufferSize,
+        jint sampleCount,
         jshortArray jtargetBuffer) {
     if (audio_resampler != nullptr && channel_count > 0) {
         jshort* sourceBuffer = env->GetShortArrayElements(jsourceBuffer, JNI_FALSE);
         jshort* targetBuffer = env->GetShortArrayElements(jtargetBuffer, JNI_FALSE);
 
-        auto inputBuffer = new float[sourceBufferSize];
+        auto inputBuffer = new float[sampleCount * channel_count];
         auto outputBuffer = new float[channel_count];
 
-        for (int index = 0; index < sourceBufferSize; index++) {
+        for (int index = 0; index < sampleCount * channel_count; index++) {
             inputBuffer[index] = ((float) sourceBuffer[index]);
         }
 
         int framesProcessed = 0;
-        int inputFramesLeft = sourceBufferSize / channel_count;
+        int inputFramesLeft = sampleCount;
 
         while (inputFramesLeft > 0) {
             if (audio_resampler->isWriteNeeded()) {

--- a/litr/src/main/cpp/audio-resampler.cpp
+++ b/litr/src/main/cpp/audio-resampler.cpp
@@ -38,7 +38,7 @@ Java_com_linkedin_android_litr_render_AudioRenderer_resample(
         // bytes contained in audio buffer produced by MediaCodec contains make up big endian shorts
         // first we recreate short values, then simply cast them to floats, expected by Oboe resampler
         for (int index = 0; index < sampleCount * channel_count; index++) {
-            inputBuffer[index] = (float) ((short) ((sourceBuffer[index * 2] << 8) | sourceBuffer[index * 2 + 1]));
+            inputBuffer[index] = (float) ((short) ((sourceBuffer[index * 2] & 0xFF << 8) | sourceBuffer[index * 2 + 1] & 0xFF));
         }
 
         int framesProcessed = 0;

--- a/litr/src/main/cpp/audio-resampler.cpp
+++ b/litr/src/main/cpp/audio-resampler.cpp
@@ -1,5 +1,4 @@
 #include <jni.h>
-#include <android/log.h>
 #include "oboe_resampler/MultiChannelResampler.h"
 
 using namespace resampler;

--- a/litr/src/main/cpp/audio-resampler.cpp
+++ b/litr/src/main/cpp/audio-resampler.cpp
@@ -27,8 +27,7 @@ Java_com_linkedin_android_litr_render_AudioRenderer_resample(
         jobject,
         jshortArray jsourceBuffer,
         jint sourceBufferSize,
-        jshortArray jtargetBuffer,
-        jint targetBufferSize) {
+        jshortArray jtargetBuffer) {
     if (audio_resampler != nullptr && channel_count > 0) {
         jshort* sourceBuffer = env->GetShortArrayElements(jsourceBuffer, JNI_FALSE);
         jshort* targetBuffer = env->GetShortArrayElements(jtargetBuffer, JNI_FALSE);

--- a/litr/src/main/cpp/audio-resampler.cpp
+++ b/litr/src/main/cpp/audio-resampler.cpp
@@ -30,8 +30,8 @@ Java_com_linkedin_android_litr_render_AudioRenderer_resample(
         jshortArray jtargetBuffer,
         jint targetBufferSize) {
     if (audio_resampler != nullptr && channel_count > 0) {
-        jshort* sourceBuffer = env->GetShortArrayElements(jsourceBuffer, nullptr);
-        jshort* targetBuffer = env->GetShortArrayElements(jtargetBuffer, nullptr);
+        jshort* sourceBuffer = env->GetShortArrayElements(jsourceBuffer, JNI_FALSE);
+        jshort* targetBuffer = env->GetShortArrayElements(jtargetBuffer, JNI_FALSE);
 
         auto inputBuffer = new float[sourceBufferSize];
         auto outputBuffer = new float[targetBufferSize];

--- a/litr/src/main/cpp/audio-resampler.cpp
+++ b/litr/src/main/cpp/audio-resampler.cpp
@@ -1,5 +1,11 @@
 #include <jni.h>
+#include <android/log.h>
 #include "oboe_resampler/MultiChannelResampler.h"
+
+using namespace resampler;
+
+MultiChannelResampler* audio_resampler = nullptr;
+int channel_count = -1;
 
 extern "C" JNIEXPORT void JNICALL
 Java_com_linkedin_android_litr_render_AudioRenderer_initAudioResampler(
@@ -8,34 +14,101 @@ Java_com_linkedin_android_litr_render_AudioRenderer_initAudioResampler(
         jint channelCount,
         jint sourceSampleRate,
         jint targetSampleRate) {
-    // TODO implement
+    audio_resampler = MultiChannelResampler::make(
+            channelCount,
+            sourceSampleRate,
+            targetSampleRate,
+            MultiChannelResampler::Quality::Fastest);
+    channel_count = channelCount;
 }
 
-extern "C" JNIEXPORT jboolean JNICALL
-Java_com_linkedin_android_litr_render_AudioRenderer_isWriteNeeded(
+extern "C" JNIEXPORT int JNICALL
+Java_com_linkedin_android_litr_render_AudioRenderer_resample(
         JNIEnv* env,
-        jobject /* this */) {
-    // TODO implement
-}
+        jobject,
+        jshortArray jsourceBuffer,
+        jint sourceBufferSize,
+        jshortArray jtargetBuffer,
+        jint targetBufferSize) {
+    if (audio_resampler != nullptr && channel_count > 0) {
+        jshort* sourceBuffer = env->GetShortArrayElements(jsourceBuffer, nullptr);
+        jshort* targetBuffer = env->GetShortArrayElements(jtargetBuffer, nullptr);
 
-extern "C" JNIEXPORT void JNICALL
-Java_com_linkedin_android_litr_render_AudioRenderer_writeNextAudioFrame(
-        JNIEnv* env,
-        jobject /* this */,
-        jfloatArray frame) {
-    // TODO implement
-}
+        auto inputBuffer = new float[sourceBufferSize];
+        auto outputBuffer = new float[targetBufferSize];
 
-extern "C" JNIEXPORT jfloatArray JNICALL
-Java_com_linkedin_android_litr_render_AudioRenderer_readNextAudioFrame(
-        JNIEnv* env,
-        jobject /* this */) {
-    // TODO implement
+        float maxSource = -1;
+        for (int index = 0; index < sourceBufferSize; index++) {
+            inputBuffer[index] = (float) sourceBuffer[index];
+            if (maxSource < inputBuffer[index]) {
+                maxSource = inputBuffer[index];
+            }
+        }
+
+        int sourceBufferPos = 0;
+        int targetBufferPos = 0;
+
+        int framesProcessed = 0;
+        int inputFramesLeft = sourceBufferSize / channel_count;
+
+        while (inputFramesLeft > 0) {
+            if (audio_resampler->isWriteNeeded()) {
+//                for (int channel = 0; channel < channel_count; channel++) {
+//                    inputBuffer[channel] = (float) sourceBuffer[sourceBufferPos + channel];
+//                }
+                audio_resampler->writeNextFrame(inputBuffer);
+                inputBuffer += channel_count;
+                inputFramesLeft--;
+            } else {
+                audio_resampler->readNextFrame(outputBuffer);
+//                for (int channel = 0; channel < channel_count; channel++) {
+//                    targetBuffer[targetBufferPos + channel] = (short) outputBuffer[channel];
+//                }
+                outputBuffer += channel_count;
+                framesProcessed++;
+            }
+        }
+
+        float maxOutput = -1;
+        for (int index = 0; index < framesProcessed; index++) {
+            for (int channel = 0; channel < channel_count; channel++) {
+                if (maxOutput < outputBuffer[index * channel_count + channel]) {
+                    maxOutput = outputBuffer[index * channel_count + channel];
+                }
+                targetBuffer[index * channel_count + channel] = (short) (outputBuffer[index * channel_count + channel]);
+            }
+        }
+
+        char* log = new char[100];
+        snprintf(log, 100, "Max source %f, max output %f", maxSource, maxOutput);
+        __android_log_write(ANDROID_LOG_DEBUG, "AudioRenderer", log);
+
+//        int factor = 2;
+//        int framesProcessed = sourceBufferSize / (factor * channel_count);
+//        for (int i = 0; i < framesProcessed; i++) {
+//            for (int c = 0; c < channel_count; c++) {
+//                targetBuffer[i * channel_count + c] = sourceBuffer[i * factor * channel_count + c];
+//            }
+//        }
+
+        env->ReleaseShortArrayElements(jsourceBuffer, sourceBuffer, 0);
+        env->ReleaseShortArrayElements(jtargetBuffer, targetBuffer, 0);
+
+//        delete[] inputBuffer;
+//        delete[] outputBuffer;
+
+        return framesProcessed;
+    }
+    return 0;
 }
 
 extern "C" JNIEXPORT void JNICALL
 Java_com_linkedin_android_litr_render_AudioRenderer_releaseAudioResampler(
         JNIEnv* env,
         jobject /* this */) {
-    // TODO implement
+    if (audio_resampler != nullptr) {
+        delete audio_resampler;
+        audio_resampler = nullptr;
+        channel_count = -1;
+    }
 }

--- a/litr/src/main/cpp/audio-resampler.cpp
+++ b/litr/src/main/cpp/audio-resampler.cpp
@@ -25,18 +25,19 @@ extern "C" JNIEXPORT int JNICALL
 Java_com_linkedin_android_litr_render_AudioRenderer_resample(
         JNIEnv* env,
         jobject,
-        jshortArray jsourceBuffer,
+        jobject jsourceBuffer,
         jint sampleCount,
         jshortArray jtargetBuffer) {
     if (audio_resampler != nullptr && channel_count > 0) {
-        jshort* sourceBuffer = env->GetShortArrayElements(jsourceBuffer, JNI_FALSE);
+        auto sourceBuffer = (jbyte *) env->GetDirectBufferAddress(jsourceBuffer);
         jshort* targetBuffer = env->GetShortArrayElements(jtargetBuffer, JNI_FALSE);
 
         auto inputBuffer = new float[sampleCount * channel_count];
         auto outputBuffer = new float[channel_count];
 
         for (int index = 0; index < sampleCount * channel_count; index++) {
-            inputBuffer[index] = ((float) sourceBuffer[index]);
+            short value = (sourceBuffer[index * 2] << 8) | sourceBuffer[index * 2 + 1];
+            inputBuffer[index] = ((float) value);
         }
 
         int framesProcessed = 0;
@@ -56,7 +57,6 @@ Java_com_linkedin_android_litr_render_AudioRenderer_resample(
             }
         }
 
-        env->ReleaseShortArrayElements(jsourceBuffer, sourceBuffer, 0);
         env->ReleaseShortArrayElements(jtargetBuffer, targetBuffer, 0);
 
         return framesProcessed;

--- a/litr/src/main/cpp/audio-resampler.cpp
+++ b/litr/src/main/cpp/audio-resampler.cpp
@@ -1,5 +1,4 @@
 #include <jni.h>
-#include <android/log.h>
 #include "oboe_resampler/MultiChannelResampler.h"
 
 using namespace resampler;
@@ -37,65 +36,32 @@ Java_com_linkedin_android_litr_render_AudioRenderer_resample(
         auto inputBuffer = new float[sourceBufferSize];
         auto outputBuffer = new float[targetBufferSize];
 
-        float maxSource = -1;
         for (int index = 0; index < sourceBufferSize; index++) {
-            inputBuffer[index] = (float) sourceBuffer[index];
-            if (maxSource < inputBuffer[index]) {
-                maxSource = inputBuffer[index];
-            }
+            inputBuffer[index] = ((float) sourceBuffer[index]);
         }
-
-        int sourceBufferPos = 0;
-        int targetBufferPos = 0;
 
         int framesProcessed = 0;
         int inputFramesLeft = sourceBufferSize / channel_count;
 
         while (inputFramesLeft > 0) {
             if (audio_resampler->isWriteNeeded()) {
-//                for (int channel = 0; channel < channel_count; channel++) {
-//                    inputBuffer[channel] = (float) sourceBuffer[sourceBufferPos + channel];
-//                }
                 audio_resampler->writeNextFrame(inputBuffer);
                 inputBuffer += channel_count;
                 inputFramesLeft--;
             } else {
                 audio_resampler->readNextFrame(outputBuffer);
-//                for (int channel = 0; channel < channel_count; channel++) {
-//                    targetBuffer[targetBufferPos + channel] = (short) outputBuffer[channel];
-//                }
+
+                for (int channel = 0; channel < channel_count; channel++) {
+                    targetBuffer[framesProcessed * channel_count + channel] = (short) *(outputBuffer + channel);
+                }
+
                 outputBuffer += channel_count;
                 framesProcessed++;
             }
         }
 
-        float maxOutput = -1;
-        for (int index = 0; index < framesProcessed; index++) {
-            for (int channel = 0; channel < channel_count; channel++) {
-                if (maxOutput < outputBuffer[index * channel_count + channel]) {
-                    maxOutput = outputBuffer[index * channel_count + channel];
-                }
-                targetBuffer[index * channel_count + channel] = (short) (outputBuffer[index * channel_count + channel]);
-            }
-        }
-
-        char* log = new char[100];
-        snprintf(log, 100, "Max source %f, max output %f", maxSource, maxOutput);
-        __android_log_write(ANDROID_LOG_DEBUG, "AudioRenderer", log);
-
-//        int factor = 2;
-//        int framesProcessed = sourceBufferSize / (factor * channel_count);
-//        for (int i = 0; i < framesProcessed; i++) {
-//            for (int c = 0; c < channel_count; c++) {
-//                targetBuffer[i * channel_count + c] = sourceBuffer[i * factor * channel_count + c];
-//            }
-//        }
-
         env->ReleaseShortArrayElements(jsourceBuffer, sourceBuffer, 0);
         env->ReleaseShortArrayElements(jtargetBuffer, targetBuffer, 0);
-
-//        delete[] inputBuffer;
-//        delete[] outputBuffer;
 
         return framesProcessed;
     }

--- a/litr/src/main/cpp/audio-resampler.cpp
+++ b/litr/src/main/cpp/audio-resampler.cpp
@@ -52,7 +52,13 @@ Java_com_linkedin_android_litr_render_AudioRenderer_resample(
             } else {
                 audio_resampler->readNextFrame(outputBuffer);
                 for (int channel = 0; channel < channel_count; channel++) {
-                    targetBuffer[framesProcessed * channel_count + channel] = (short) *(outputBuffer + channel);
+                    float value = *(outputBuffer + channel);
+                    if (value < -32768) {
+                        value = -32768;
+                    } else if (value > 32767) {
+                        value = 32767;
+                    }
+                    targetBuffer[framesProcessed * channel_count + channel] = (short) value;
                 }
                 framesProcessed++;
             }

--- a/litr/src/main/cpp/audio-resampler.cpp
+++ b/litr/src/main/cpp/audio-resampler.cpp
@@ -1,0 +1,41 @@
+#include <jni.h>
+#include "oboe_resampler/MultiChannelResampler.h"
+
+extern "C" JNIEXPORT void JNICALL
+Java_com_linkedin_android_litr_render_AudioRenderer_initAudioResampler(
+        JNIEnv* env,
+        jobject /* this */,
+        jint channelCount,
+        jint sourceSampleRate,
+        jint targetSampleRate) {
+    // TODO implement
+}
+
+extern "C" JNIEXPORT jboolean JNICALL
+Java_com_linkedin_android_litr_render_AudioRenderer_isWriteNeeded(
+        JNIEnv* env,
+        jobject /* this */) {
+    // TODO implement
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_com_linkedin_android_litr_render_AudioRenderer_writeNextAudioFrame(
+        JNIEnv* env,
+        jobject /* this */,
+        jfloatArray frame) {
+    // TODO implement
+}
+
+extern "C" JNIEXPORT jfloatArray JNICALL
+Java_com_linkedin_android_litr_render_AudioRenderer_readNextAudioFrame(
+        JNIEnv* env,
+        jobject /* this */) {
+    // TODO implement
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_com_linkedin_android_litr_render_AudioRenderer_releaseAudioResampler(
+        JNIEnv* env,
+        jobject /* this */) {
+    // TODO implement
+}

--- a/litr/src/main/cpp/oboe_resampler/CMakeLists.txt
+++ b/litr/src/main/cpp/oboe_resampler/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.10.2)
+
+project("OboeResampler")
+
+add_library(oboe-resampler STATIC
+        IntegerRatio.cpp
+        LinearResampler.cpp
+        MultiChannelResampler.cpp
+        PolyphaseResampler.cpp
+        PolyphaseResamplerMono.cpp
+        PolyphaseResamplerStereo.cpp
+        SincResampler.cpp
+        SincResamplerStereo.cpp
+)

--- a/litr/src/main/cpp/oboe_resampler/HyperbolicCosineWindow.h
+++ b/litr/src/main/cpp/oboe_resampler/HyperbolicCosineWindow.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef RESAMPLER_HYPERBOLIC_COSINE_WINDOW_H
+#define RESAMPLER_HYPERBOLIC_COSINE_WINDOW_H
+
+#include <math.h>
+
+namespace resampler {
+
+/**
+ * Calculate a HyperbolicCosineWindow window centered at 0.
+ * This can be used in place of a Kaiser window.
+ *
+ * The code is based on an anonymous contribution by "a concerned citizen":
+ * https://dsp.stackexchange.com/questions/37714/kaiser-window-approximation
+ */
+class HyperbolicCosineWindow {
+public:
+    HyperbolicCosineWindow() {
+        setStopBandAttenuation(60);
+    }
+
+    /**
+     * @param attenuation typical values range from 30 to 90 dB
+     * @return beta
+     */
+    double setStopBandAttenuation(double attenuation) {
+        double alpha = ((-325.1e-6 * attenuation + 0.1677) * attenuation) - 3.149;
+        setAlpha(alpha);
+        return alpha;
+    }
+
+    void setAlpha(double alpha) {
+        mAlpha = alpha;
+        mInverseCoshAlpha = 1.0 / cosh(alpha);
+    }
+
+    /**
+     * @param x ranges from -1.0 to +1.0
+     */
+    double operator()(double x) {
+        double x2 = x * x;
+        if (x2 >= 1.0) return 0.0;
+        double w = mAlpha * sqrt(1.0 - x2);
+        return cosh(w) * mInverseCoshAlpha;
+    }
+
+private:
+    double mAlpha = 0.0;
+    double mInverseCoshAlpha = 1.0;
+};
+
+} // namespace resampler
+#endif //RESAMPLER_HYPERBOLIC_COSINE_WINDOW_H

--- a/litr/src/main/cpp/oboe_resampler/IntegerRatio.cpp
+++ b/litr/src/main/cpp/oboe_resampler/IntegerRatio.cpp
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "IntegerRatio.h"
+
+using namespace resampler;
+
+// Enough primes to cover the common sample rates.
+static const int kPrimes[] = {
+        2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41,
+        43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97,
+        101, 103, 107, 109, 113, 127, 131, 137, 139, 149,
+        151, 157, 163, 167, 173, 179, 181, 191, 193, 197, 199};
+
+void IntegerRatio::reduce() {
+    for (int prime : kPrimes) {
+        if (mNumerator < prime || mDenominator < prime) {
+            break;
+        }
+
+        // Find biggest prime factor for numerator.
+        while (true) {
+            int top = mNumerator / prime;
+            int bottom = mDenominator / prime;
+            if ((top >= 1)
+                && (bottom >= 1)
+                && (top * prime == mNumerator) // divided evenly?
+                && (bottom * prime == mDenominator)) {
+                mNumerator = top;
+                mDenominator = bottom;
+            } else {
+                break;
+            }
+        }
+
+    }
+}

--- a/litr/src/main/cpp/oboe_resampler/IntegerRatio.h
+++ b/litr/src/main/cpp/oboe_resampler/IntegerRatio.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef OBOE_INTEGER_RATIO_H
+#define OBOE_INTEGER_RATIO_H
+
+#include <sys/types.h>
+
+namespace resampler {
+
+/**
+ * Represent the ratio of two integers.
+ */
+class IntegerRatio {
+public:
+    IntegerRatio(int32_t numerator, int32_t denominator)
+            : mNumerator(numerator), mDenominator(denominator) {}
+
+    /**
+     * Reduce by removing common prime factors.
+     */
+    void reduce();
+
+    int32_t getNumerator() {
+        return mNumerator;
+    }
+
+    int32_t getDenominator() {
+        return mDenominator;
+    }
+
+private:
+    int32_t mNumerator;
+    int32_t mDenominator;
+};
+
+}
+
+#endif //OBOE_INTEGER_RATIO_H

--- a/litr/src/main/cpp/oboe_resampler/KaiserWindow.h
+++ b/litr/src/main/cpp/oboe_resampler/KaiserWindow.h
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef RESAMPLER_KAISER_WINDOW_H
+#define RESAMPLER_KAISER_WINDOW_H
+
+#include <math.h>
+
+namespace resampler {
+
+/**
+ * Calculate a Kaiser window centered at 0.
+ */
+class KaiserWindow {
+public:
+    KaiserWindow() {
+        setStopBandAttenuation(60);
+    }
+
+    /**
+     * @param attenuation typical values range from 30 to 90 dB
+     * @return beta
+     */
+    double setStopBandAttenuation(double attenuation) {
+        double beta = 0.0;
+        if (attenuation > 50) {
+            beta = 0.1102 * (attenuation - 8.7);
+        } else if (attenuation >= 21) {
+            double a21 = attenuation - 21;
+            beta = 0.5842 * pow(a21, 0.4) + (0.07886 * a21);
+        }
+        setBeta(beta);
+        return beta;
+    }
+
+    void setBeta(double beta) {
+        mBeta = beta;
+        mInverseBesselBeta = 1.0 / bessel(beta);
+    }
+
+    /**
+     * @param x ranges from -1.0 to +1.0
+     */
+    double operator()(double x) {
+        double x2 = x * x;
+        if (x2 >= 1.0) return 0.0;
+        double w = mBeta * sqrt(1.0 - x2);
+        return bessel(w) * mInverseBesselBeta;
+    }
+
+    // Approximation of a
+    // modified zero order Bessel function of the first kind.
+    // Based on a discussion at:
+    // https://dsp.stackexchange.com/questions/37714/kaiser-window-approximation
+    static double bessel(double x) {
+        double y = cosh(0.970941817426052 * x);
+        y += cosh(0.8854560256532099 * x);
+        y += cosh(0.7485107481711011 * x);
+        y += cosh(0.5680647467311558 * x);
+        y += cosh(0.3546048870425356 * x);
+        y += cosh(0.120536680255323 * x);
+        y *= 2;
+        y += cosh(x);
+        y /= 13;
+        return y;
+    }
+
+private:
+    double mBeta = 0.0;
+    double mInverseBesselBeta = 1.0;
+};
+
+} // namespace resampler
+#endif //RESAMPLER_KAISER_WINDOW_H

--- a/litr/src/main/cpp/oboe_resampler/LinearResampler.cpp
+++ b/litr/src/main/cpp/oboe_resampler/LinearResampler.cpp
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "LinearResampler.h"
+
+using namespace resampler;
+
+LinearResampler::LinearResampler(const MultiChannelResampler::Builder &builder)
+        : MultiChannelResampler(builder) {
+    mPreviousFrame = std::make_unique<float[]>(getChannelCount());
+    mCurrentFrame = std::make_unique<float[]>(getChannelCount());
+}
+
+void LinearResampler::writeFrame(const float *frame) {
+    memcpy(mPreviousFrame.get(), mCurrentFrame.get(), sizeof(float) * getChannelCount());
+    memcpy(mCurrentFrame.get(), frame, sizeof(float) * getChannelCount());
+}
+
+void LinearResampler::readFrame(float *frame) {
+    float *previous = mPreviousFrame.get();
+    float *current = mCurrentFrame.get();
+    float phase = (float) getIntegerPhase() / mDenominator;
+    // iterate across samples in the frame
+    for (int channel = 0; channel < getChannelCount(); channel++) {
+        float f0 = *previous++;
+        float f1 = *current++;
+        *frame++ = f0 + (phase * (f1 - f0));
+    }
+}

--- a/litr/src/main/cpp/oboe_resampler/LinearResampler.h
+++ b/litr/src/main/cpp/oboe_resampler/LinearResampler.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef OBOE_LINEAR_RESAMPLER_H
+#define OBOE_LINEAR_RESAMPLER_H
+
+#include <memory>
+#include <sys/types.h>
+#include <unistd.h>
+#include "MultiChannelResampler.h"
+
+namespace resampler {
+
+/**
+ * Simple resampler that uses bi-linear interpolation.
+ */
+class LinearResampler : public MultiChannelResampler {
+public:
+    LinearResampler(const MultiChannelResampler::Builder &builder);
+
+    void writeFrame(const float *frame) override;
+
+    void readFrame(float *frame) override;
+
+private:
+    std::unique_ptr<float[]> mPreviousFrame;
+    std::unique_ptr<float[]> mCurrentFrame;
+};
+
+} // namespace resampler
+#endif //OBOE_LINEAR_RESAMPLER_H

--- a/litr/src/main/cpp/oboe_resampler/MultiChannelResampler.cpp
+++ b/litr/src/main/cpp/oboe_resampler/MultiChannelResampler.cpp
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <math.h>
+
+#include "IntegerRatio.h"
+#include "LinearResampler.h"
+#include "MultiChannelResampler.h"
+#include "PolyphaseResampler.h"
+#include "PolyphaseResamplerMono.h"
+#include "PolyphaseResamplerStereo.h"
+#include "SincResampler.h"
+#include "SincResamplerStereo.h"
+
+using namespace resampler;
+
+MultiChannelResampler::MultiChannelResampler(const MultiChannelResampler::Builder &builder)
+        : mNumTaps(builder.getNumTaps())
+        , mX(builder.getChannelCount() * builder.getNumTaps() * 2)
+        , mSingleFrame(builder.getChannelCount())
+        , mChannelCount(builder.getChannelCount())
+        {
+    // Reduce sample rates to the smallest ratio.
+    // For example 44100/48000 would become 147/160.
+    IntegerRatio ratio(builder.getInputRate(), builder.getOutputRate());
+    ratio.reduce();
+    mNumerator = ratio.getNumerator();
+    mDenominator = ratio.getDenominator();
+    mIntegerPhase = mDenominator;
+}
+
+// static factory method
+MultiChannelResampler *MultiChannelResampler::make(int32_t channelCount,
+                                                   int32_t inputRate,
+                                                   int32_t outputRate,
+                                                   Quality quality) {
+    Builder builder;
+    builder.setInputRate(inputRate);
+    builder.setOutputRate(outputRate);
+    builder.setChannelCount(channelCount);
+
+    switch (quality) {
+        case Quality::Fastest:
+            builder.setNumTaps(2);
+            break;
+        case Quality::Low:
+            builder.setNumTaps(4);
+            break;
+        case Quality::Medium:
+        default:
+            builder.setNumTaps(8);
+            break;
+        case Quality::High:
+            builder.setNumTaps(16);
+            break;
+        case Quality::Best:
+            builder.setNumTaps(32);
+            break;
+    }
+
+    // Set the cutoff frequency so that we do not get aliasing when down-sampling.
+    if (inputRate > outputRate) {
+        builder.setNormalizedCutoff(kDefaultNormalizedCutoff);
+    }
+    return builder.build();
+}
+
+MultiChannelResampler *MultiChannelResampler::Builder::build() {
+    if (getNumTaps() == 2) {
+        // Note that this does not do low pass filteringh.
+        return new LinearResampler(*this);
+    }
+    IntegerRatio ratio(getInputRate(), getOutputRate());
+    ratio.reduce();
+    bool usePolyphase = (getNumTaps() * ratio.getDenominator()) <= kMaxCoefficients;
+    if (usePolyphase) {
+        if (getChannelCount() == 1) {
+            return new PolyphaseResamplerMono(*this);
+        } else if (getChannelCount() == 2) {
+            return new PolyphaseResamplerStereo(*this);
+        } else {
+            return new PolyphaseResampler(*this);
+        }
+    } else {
+        // Use less optimized resampler that uses a float phaseIncrement.
+        // TODO mono resampler
+        if (getChannelCount() == 2) {
+            return new SincResamplerStereo(*this);
+        } else {
+            return new SincResampler(*this);
+        }
+    }
+}
+
+void MultiChannelResampler::writeFrame(const float *frame) {
+    // Move cursor before write so that cursor points to last written frame in read.
+    if (--mCursor < 0) {
+        mCursor = getNumTaps() - 1;
+    }
+    float *dest = &mX[mCursor * getChannelCount()];
+    int offset = getNumTaps() * getChannelCount();
+    for (int channel = 0; channel < getChannelCount(); channel++) {
+        // Write twice so we avoid having to wrap when reading.
+        dest[channel] = dest[channel + offset] = frame[channel];
+    }
+}
+
+float MultiChannelResampler::sinc(float radians) {
+    if (abs(radians) < 1.0e-9) return 1.0f;   // avoid divide by zero
+    return sinf(radians) / radians;   // Sinc function
+}
+
+// Generate coefficients in the order they will be used by readFrame().
+// This is more complicated but readFrame() is called repeatedly and should be optimized.
+void MultiChannelResampler::generateCoefficients(int32_t inputRate,
+                                              int32_t outputRate,
+                                              int32_t numRows,
+                                              double phaseIncrement,
+                                              float normalizedCutoff) {
+    mCoefficients.resize(getNumTaps() * numRows);
+    int coefficientIndex = 0;
+    double phase = 0.0; // ranges from 0.0 to 1.0, fraction between samples
+    // Stretch the sinc function for low pass filtering.
+    const float cutoffScaler = normalizedCutoff *
+            ((outputRate < inputRate)
+             ? ((float)outputRate / inputRate)
+             : ((float)inputRate / outputRate));
+    const int numTapsHalf = getNumTaps() / 2; // numTaps must be even.
+    const float numTapsHalfInverse = 1.0f / numTapsHalf;
+    for (int i = 0; i < numRows; i++) {
+        float tapPhase = phase - numTapsHalf;
+        float gain = 0.0; // sum of raw coefficients
+        int gainCursor = coefficientIndex;
+        for (int tap = 0; tap < getNumTaps(); tap++) {
+            float radians = tapPhase * M_PI;
+
+#if MCR_USE_KAISER
+            float window = mKaiserWindow(tapPhase * numTapsHalfInverse);
+#else
+            float window = mCoshWindow(tapPhase * numTapsHalfInverse);
+#endif
+            float coefficient = sinc(radians * cutoffScaler) * window;
+            mCoefficients.at(coefficientIndex++) = coefficient;
+            gain += coefficient;
+            tapPhase += 1.0;
+        }
+        phase += phaseIncrement;
+        while (phase >= 1.0) {
+            phase -= 1.0;
+        }
+
+        // Correct for gain variations.
+        float gainCorrection = 1.0 / gain; // normalize the gain
+        for (int tap = 0; tap < getNumTaps(); tap++) {
+            mCoefficients.at(gainCursor + tap) *= gainCorrection;
+        }
+    }
+}

--- a/litr/src/main/cpp/oboe_resampler/MultiChannelResampler.h
+++ b/litr/src/main/cpp/oboe_resampler/MultiChannelResampler.h
@@ -1,0 +1,271 @@
+/*
+ * Copyright 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef OBOE_MULTICHANNEL_RESAMPLER_H
+#define OBOE_MULTICHANNEL_RESAMPLER_H
+
+#include <memory>
+#include <vector>
+#include <sys/types.h>
+#include <unistd.h>
+
+#ifndef MCR_USE_KAISER
+// It appears from the spectrogram that the HyperbolicCosine window leads to fewer artifacts.
+// And it is faster to calculate.
+#define MCR_USE_KAISER 0
+#endif
+
+#if MCR_USE_KAISER
+#include "KaiserWindow.h"
+#else
+#include "HyperbolicCosineWindow.h"
+#endif
+
+namespace resampler {
+
+class MultiChannelResampler {
+
+public:
+
+    enum class Quality : int32_t {
+        Fastest,
+        Low,
+        Medium,
+        High,
+        Best,
+    };
+
+    class Builder {
+    public:
+        /**
+         * Construct an optimal resampler based on the specified parameters.
+         * @return address of a resampler
+         */
+        MultiChannelResampler *build();
+
+        /**
+         * The number of taps in the resampling filter.
+         * More taps gives better quality but uses more CPU time.
+         * This typically ranges from 4 to 64. Default is 16.
+         *
+         * For polyphase filters, numTaps must be a multiple of four for loop unrolling.
+         * @param numTaps number of taps for the filter
+         * @return address of this builder for chaining calls
+         */
+        Builder *setNumTaps(int32_t numTaps) {
+            mNumTaps = numTaps;
+            return this;
+        }
+
+        /**
+         * Use 1 for mono, 2 for stereo, etc. Default is 1.
+         *
+         * @param channelCount number of channels
+         * @return address of this builder for chaining calls
+         */
+        Builder *setChannelCount(int32_t channelCount) {
+            mChannelCount = channelCount;
+            return this;
+        }
+
+        /**
+         * Default is 48000.
+         *
+         * @param inputRate sample rate of the input stream
+         * @return address of this builder for chaining calls
+         */
+        Builder *setInputRate(int32_t inputRate) {
+            mInputRate = inputRate;
+            return this;
+        }
+
+        /**
+         * Default is 48000.
+         *
+         * @param outputRate sample rate of the output stream
+         * @return address of this builder for chaining calls
+         */
+        Builder *setOutputRate(int32_t outputRate) {
+            mOutputRate = outputRate;
+            return this;
+        }
+
+        /**
+         * Set cutoff frequency relative to the Nyquist rate of the output sample rate.
+         * Set to 1.0 to match the Nyquist frequency.
+         * Set lower to reduce aliasing.
+         * Default is 0.70.
+         *
+         * @param normalizedCutoff anti-aliasing filter cutoff
+         * @return address of this builder for chaining calls
+         */
+        Builder *setNormalizedCutoff(float normalizedCutoff) {
+            mNormalizedCutoff = normalizedCutoff;
+            return this;
+        }
+
+        int32_t getNumTaps() const {
+            return mNumTaps;
+        }
+
+        int32_t getChannelCount() const {
+            return mChannelCount;
+        }
+
+        int32_t getInputRate() const {
+            return mInputRate;
+        }
+
+        int32_t getOutputRate() const {
+            return mOutputRate;
+        }
+
+        float getNormalizedCutoff() const {
+            return mNormalizedCutoff;
+        }
+
+    protected:
+        int32_t mChannelCount = 1;
+        int32_t mNumTaps = 16;
+        int32_t mInputRate = 48000;
+        int32_t mOutputRate = 48000;
+        float   mNormalizedCutoff = kDefaultNormalizedCutoff;
+    };
+
+    virtual ~MultiChannelResampler() = default;
+
+    /**
+     * Factory method for making a resampler that is optimal for the given inputs.
+     *
+     * @param channelCount number of channels, 2 for stereo
+     * @param inputRate sample rate of the input stream
+     * @param outputRate  sample rate of the output stream
+     * @param quality higher quality sounds better but uses more CPU
+     * @return an optimal resampler
+     */
+    static MultiChannelResampler *make(int32_t channelCount,
+                                       int32_t inputRate,
+                                       int32_t outputRate,
+                                       Quality quality);
+
+    bool isWriteNeeded() const {
+        return mIntegerPhase >= mDenominator;
+    }
+
+    /**
+     * Write a frame containing N samples.
+     *
+     * @param frame pointer to the first sample in a frame
+     */
+    void writeNextFrame(const float *frame) {
+        writeFrame(frame);
+        advanceWrite();
+    }
+
+    /**
+     * Read a frame containing N samples.
+     *
+     * @param frame pointer to the first sample in a frame
+     */
+    void readNextFrame(float *frame) {
+        readFrame(frame);
+        advanceRead();
+    }
+
+    int getNumTaps() const {
+        return mNumTaps;
+    }
+
+    int getChannelCount() const {
+        return mChannelCount;
+    }
+
+    static float hammingWindow(float radians, float spread);
+
+    static float sinc(float radians);
+
+protected:
+
+    explicit MultiChannelResampler(const MultiChannelResampler::Builder &builder);
+
+    /**
+     * Write a frame containing N samples.
+     * Call advanceWrite() after calling this.
+     * @param frame pointer to the first sample in a frame
+     */
+    virtual void writeFrame(const float *frame);
+
+    /**
+     * Read a frame containing N samples using interpolation.
+     * Call advanceRead() after calling this.
+     * @param frame pointer to the first sample in a frame
+     */
+    virtual void readFrame(float *frame) = 0;
+
+    void advanceWrite() {
+        mIntegerPhase -= mDenominator;
+    }
+
+    void advanceRead() {
+        mIntegerPhase += mNumerator;
+    }
+
+    /**
+     * Generate the filter coefficients in optimal order.
+     * @param inputRate sample rate of the input stream
+     * @param outputRate  sample rate of the output stream
+     * @param numRows number of rows in the array that contain a set of tap coefficients
+     * @param phaseIncrement how much to increment the phase between rows
+     * @param normalizedCutoff filter cutoff frequency normalized to Nyquist rate of output
+     */
+    void generateCoefficients(int32_t inputRate,
+                              int32_t outputRate,
+                              int32_t numRows,
+                              double phaseIncrement,
+                              float normalizedCutoff);
+
+
+    int32_t getIntegerPhase() {
+        return mIntegerPhase;
+    }
+
+    static constexpr int kMaxCoefficients = 8 * 1024;
+    std::vector<float>   mCoefficients;
+
+    const int            mNumTaps;
+    int                  mCursor = 0;
+    std::vector<float>   mX;           // delayed input values for the FIR
+    std::vector<float>   mSingleFrame; // one frame for temporary use
+    int32_t              mIntegerPhase = 0;
+    int32_t              mNumerator = 0;
+    int32_t              mDenominator = 0;
+
+
+private:
+
+#if MCR_USE_KAISER
+    KaiserWindow           mKaiserWindow;
+#else
+    HyperbolicCosineWindow mCoshWindow;
+#endif
+
+    static constexpr float kDefaultNormalizedCutoff = 0.70f;
+
+    const int              mChannelCount;
+};
+
+}
+#endif //OBOE_MULTICHANNEL_RESAMPLER_H

--- a/litr/src/main/cpp/oboe_resampler/PolyphaseResampler.cpp
+++ b/litr/src/main/cpp/oboe_resampler/PolyphaseResampler.cpp
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cassert>
+#include <math.h>
+#include "IntegerRatio.h"
+#include "PolyphaseResampler.h"
+
+using namespace resampler;
+
+PolyphaseResampler::PolyphaseResampler(const MultiChannelResampler::Builder &builder)
+        : MultiChannelResampler(builder)
+        {
+    assert((getNumTaps() % 4) == 0); // Required for loop unrolling.
+
+    int32_t inputRate = builder.getInputRate();
+    int32_t outputRate = builder.getOutputRate();
+
+    int32_t numRows = mDenominator;
+    double phaseIncrement = (double) inputRate / (double) outputRate;
+    generateCoefficients(inputRate, outputRate,
+                         numRows, phaseIncrement,
+                         builder.getNormalizedCutoff());
+}
+
+void PolyphaseResampler::readFrame(float *frame) {
+    // Clear accumulator for mixing.
+    std::fill(mSingleFrame.begin(), mSingleFrame.end(), 0.0);
+
+    // Multiply input times windowed sinc function.
+    float *coefficients = &mCoefficients[mCoefficientCursor];
+    float *xFrame = &mX[mCursor * getChannelCount()];
+    for (int i = 0; i < mNumTaps; i++) {
+        float coefficient = *coefficients++;
+        for (int channel = 0; channel < getChannelCount(); channel++) {
+            mSingleFrame[channel] += *xFrame++ * coefficient;
+        }
+    }
+
+    // Advance and wrap through coefficients.
+    mCoefficientCursor = (mCoefficientCursor + mNumTaps) % mCoefficients.size();
+
+    // Copy accumulator to output.
+    for (int channel = 0; channel < getChannelCount(); channel++) {
+        frame[channel] = mSingleFrame[channel];
+    }
+}

--- a/litr/src/main/cpp/oboe_resampler/PolyphaseResampler.h
+++ b/litr/src/main/cpp/oboe_resampler/PolyphaseResampler.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef OBOE_POLYPHASE_RESAMPLER_H
+#define OBOE_POLYPHASE_RESAMPLER_H
+
+#include <memory>
+#include <vector>
+#include <sys/types.h>
+#include <unistd.h>
+#include "MultiChannelResampler.h"
+
+namespace resampler {
+/**
+ * Resampler that is optimized for a reduced ratio of sample rates.
+ * All of the coefficients for each possible phase value are pre-calculated.
+ */
+class PolyphaseResampler : public MultiChannelResampler {
+public:
+    /**
+     *
+     * @param builder containing lots of parameters
+     */
+    explicit PolyphaseResampler(const MultiChannelResampler::Builder &builder);
+
+    virtual ~PolyphaseResampler() = default;
+
+    void readFrame(float *frame) override;
+
+protected:
+
+    int32_t                mCoefficientCursor = 0;
+
+};
+
+}
+
+#endif //OBOE_POLYPHASE_RESAMPLER_H

--- a/litr/src/main/cpp/oboe_resampler/PolyphaseResamplerMono.cpp
+++ b/litr/src/main/cpp/oboe_resampler/PolyphaseResamplerMono.cpp
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cassert>
+#include "PolyphaseResamplerMono.h"
+
+using namespace resampler;
+
+#define MONO  1
+
+PolyphaseResamplerMono::PolyphaseResamplerMono(const MultiChannelResampler::Builder &builder)
+        : PolyphaseResampler(builder) {
+    assert(builder.getChannelCount() == MONO);
+}
+
+void PolyphaseResamplerMono::writeFrame(const float *frame) {
+    // Move cursor before write so that cursor points to last written frame in read.
+    if (--mCursor < 0) {
+        mCursor = getNumTaps() - 1;
+    }
+    float *dest = &mX[mCursor * MONO];
+    const int offset = mNumTaps * MONO;
+    // Write each channel twice so we avoid having to wrap when running the FIR.
+    const float sample =  frame[0];
+    // Put ordered writes together.
+    dest[0] = sample;
+    dest[offset] = sample;
+}
+
+void PolyphaseResamplerMono::readFrame(float *frame) {
+    // Clear accumulator.
+    float sum = 0.0;
+
+    // Multiply input times precomputed windowed sinc function.
+    const float *coefficients = &mCoefficients[mCoefficientCursor];
+    float *xFrame = &mX[mCursor * MONO];
+    const int numLoops = mNumTaps >> 2; // n/4
+    for (int i = 0; i < numLoops; i++) {
+        // Manual loop unrolling, might get converted to SIMD.
+        sum += *xFrame++ * *coefficients++;
+        sum += *xFrame++ * *coefficients++;
+        sum += *xFrame++ * *coefficients++;
+        sum += *xFrame++ * *coefficients++;
+    }
+
+    mCoefficientCursor = (mCoefficientCursor + mNumTaps) % mCoefficients.size();
+
+    // Copy accumulator to output.
+    frame[0] = sum;
+}

--- a/litr/src/main/cpp/oboe_resampler/PolyphaseResamplerMono.h
+++ b/litr/src/main/cpp/oboe_resampler/PolyphaseResamplerMono.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef OBOE_POLYPHASE_RESAMPLER_MONO_H
+#define OBOE_POLYPHASE_RESAMPLER_MONO_H
+
+#include <sys/types.h>
+#include <unistd.h>
+#include "PolyphaseResampler.h"
+
+namespace resampler {
+
+class PolyphaseResamplerMono : public PolyphaseResampler {
+public:
+    explicit PolyphaseResamplerMono(const MultiChannelResampler::Builder &builder);
+
+    virtual ~PolyphaseResamplerMono() = default;
+
+    void writeFrame(const float *frame) override;
+
+    void readFrame(float *frame) override;
+};
+
+}
+
+#endif //OBOE_POLYPHASE_RESAMPLER_MONO_H

--- a/litr/src/main/cpp/oboe_resampler/PolyphaseResamplerStereo.cpp
+++ b/litr/src/main/cpp/oboe_resampler/PolyphaseResamplerStereo.cpp
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cassert>
+#include "PolyphaseResamplerStereo.h"
+
+using namespace resampler;
+
+#define STEREO  2
+
+PolyphaseResamplerStereo::PolyphaseResamplerStereo(const MultiChannelResampler::Builder &builder)
+        : PolyphaseResampler(builder) {
+    assert(builder.getChannelCount() == STEREO);
+}
+
+void PolyphaseResamplerStereo::writeFrame(const float *frame) {
+    // Move cursor before write so that cursor points to last written frame in read.
+    if (--mCursor < 0) {
+        mCursor = getNumTaps() - 1;
+    }
+    float *dest = &mX[mCursor * STEREO];
+    const int offset = mNumTaps * STEREO;
+    // Write each channel twice so we avoid having to wrap when running the FIR.
+    const float left =  frame[0];
+    const float right = frame[1];
+    // Put ordered writes together.
+    dest[0] = left;
+    dest[1] = right;
+    dest[offset] = left;
+    dest[1 + offset] = right;
+}
+
+void PolyphaseResamplerStereo::readFrame(float *frame) {
+    // Clear accumulators.
+    float left = 0.0;
+    float right = 0.0;
+
+    // Multiply input times precomputed windowed sinc function.
+    const float *coefficients = &mCoefficients[mCoefficientCursor];
+    float *xFrame = &mX[mCursor * STEREO];
+    const int numLoops = mNumTaps >> 2; // n/4
+    for (int i = 0; i < numLoops; i++) {
+        // Manual loop unrolling, might get converted to SIMD.
+        float coefficient = *coefficients++;
+        left += *xFrame++ * coefficient;
+        right += *xFrame++ * coefficient;
+
+        coefficient = *coefficients++; // next tap
+        left += *xFrame++ * coefficient;
+        right += *xFrame++ * coefficient;
+
+        coefficient = *coefficients++;  // next tap
+        left += *xFrame++ * coefficient;
+        right += *xFrame++ * coefficient;
+
+        coefficient = *coefficients++;  // next tap
+        left += *xFrame++ * coefficient;
+        right += *xFrame++ * coefficient;
+    }
+
+    mCoefficientCursor = (mCoefficientCursor + mNumTaps) % mCoefficients.size();
+
+    // Copy accumulators to output.
+    frame[0] = left;
+    frame[1] = right;
+}

--- a/litr/src/main/cpp/oboe_resampler/PolyphaseResamplerStereo.h
+++ b/litr/src/main/cpp/oboe_resampler/PolyphaseResamplerStereo.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef OBOE_POLYPHASE_RESAMPLER_STEREO_H
+#define OBOE_POLYPHASE_RESAMPLER_STEREO_H
+
+#include <sys/types.h>
+#include <unistd.h>
+#include "PolyphaseResampler.h"
+
+namespace resampler {
+
+class PolyphaseResamplerStereo : public PolyphaseResampler {
+public:
+    explicit PolyphaseResamplerStereo(const MultiChannelResampler::Builder &builder);
+
+    virtual ~PolyphaseResamplerStereo() = default;
+
+    void writeFrame(const float *frame) override;
+
+    void readFrame(float *frame) override;
+};
+
+}
+
+#endif //OBOE_POLYPHASE_RESAMPLER_STEREO_H

--- a/litr/src/main/cpp/oboe_resampler/README.md
+++ b/litr/src/main/cpp/oboe_resampler/README.md
@@ -1,0 +1,101 @@
+# Sample Rate Converter
+
+This folder contains a sample rate converter, or "resampler".
+
+The converter is based on a sinc function that has been windowed by a hyperbolic cosine.
+We found this had fewer artifacts than the more traditional Kaiser window.
+
+## Building the Resampler
+
+It is part of [Oboe](https://github.com/google/oboe) but has no dependencies on Oboe.
+So the contents of this folder can be used outside of Oboe.
+
+To build it for use outside of Oboe:
+
+1. Copy the "resampler" folder to a folder in your project that is in the include path.
+2. Add all of the \*.cpp files in the resampler folder to your project IDE or Makefile.
+
+## Creating a Resampler
+
+Include the [main header](MultiChannelResampler.h) for the resampler.
+
+    #include "resampler/MultiChannelResampler.h"
+
+Here is an example of creating a stereo resampler that will convert from 44100 to 48000 Hz.
+Only do this once, when you open your stream. Then use the sample resampler to process multiple buffers.
+
+    MultiChannelResampler *resampler = MultiChannelResampler::make(
+            2, // channel count
+            44100, // input sampleRate
+            48000, // output sampleRate
+            MultiChannelResampler::Quality::Medium); // conversion quality
+
+Possible values for quality include { Fastest, Low, Medium, High, Best }.
+Higher quality levels will sound better but consume more CPU because they have more taps in the filter.
+
+## Fractional Frame Counts
+
+Note that the number of output frames generated for a given number of input frames can vary.
+
+For example, suppose you are converting from 44100 Hz to 48000 Hz and using an input buffer with 960 frames. If you calculate the number of output frames you get:
+
+    960 * 48000 * 44100 = 1044.897959...
+
+You cannot generate a fractional number of frames. So the resampler will sometimes generate 1044 frames and sometimes 1045 frames. On average it will generate 1044.897959 frames. The resampler stores the fraction internally and keeps track of when to consume or generate a frame.
+
+You can either use a fixed number of input frames or a fixed number of output frames. The other frame count will vary.
+
+## Calling the Resampler with a fixed number of OUTPUT frames
+
+In this example, suppose we have a fixed number of output frames and a variable number of input frames.
+
+Assume you start with these variables and a method that returns the next input frame:
+
+    float *outputBuffer;     // multi-channel buffer to be filled
+    int    numOutputFrames;  // number of frames of output
+    
+The resampler has a method isWriteNeeded() that tells you whether to write to or read from the resampler.
+
+    int outputFramesLeft = numOutputFrames;
+    while (outputFramesLeft > 0) {
+        if(resampler->isWriteNeeded()) {
+            const float *frame = getNextInputFrame(); // you provide this
+            resampler->writeNextFrame(frame);
+        } else {
+            resampler->readNextFrame(outputBuffer);
+            outputBuffer += channelCount;
+            outputFramesLeft--;
+        }
+    }
+
+## Calling the Resampler with a fixed number of INPUT frames
+
+In this example, suppose we have a fixed number of input frames and a variable number of output frames.
+
+Assume you start with these variables:
+
+    float *inputBuffer;     // multi-channel buffer to be consumed
+    float *outputBuffer;    // multi-channel buffer to be filled
+    int    numInputFrames;  // number of frames of input
+    int    numOutputFrames = 0;
+    int    channelCount;    // 1 for mono, 2 for stereo
+
+    int inputFramesLeft = numInputFrames;
+    while (inputFramesLeft > 0) {
+        if(resampler->isWriteNeeded()) {
+            resampler->writeNextFrame(inputBuffer);
+            inputBuffer += channelCount;
+            inputFramesLeft--;
+        } else {
+            resampler->readNextFrame(outputBuffer);
+            outputBuffer += channelCount;
+            numOutputFrames++;
+        }
+    }
+
+## Deleting the Resampler
+
+When you are done, you should delete the Resampler to avoid a memory leak.
+
+    delete resampler;
+    

--- a/litr/src/main/cpp/oboe_resampler/SincResampler.cpp
+++ b/litr/src/main/cpp/oboe_resampler/SincResampler.cpp
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cassert>
+#include <math.h>
+#include "SincResampler.h"
+
+using namespace resampler;
+
+SincResampler::SincResampler(const MultiChannelResampler::Builder &builder)
+        : MultiChannelResampler(builder)
+        , mSingleFrame2(builder.getChannelCount()) {
+    assert((getNumTaps() % 4) == 0); // Required for loop unrolling.
+    mNumRows = kMaxCoefficients / getNumTaps(); // no guard row needed
+    mPhaseScaler = (double) mNumRows / mDenominator;
+    double phaseIncrement = 1.0 / mNumRows;
+    generateCoefficients(builder.getInputRate(),
+                         builder.getOutputRate(),
+                         mNumRows,
+                         phaseIncrement,
+                         builder.getNormalizedCutoff());
+}
+
+void SincResampler::readFrame(float *frame) {
+    // Clear accumulator for mixing.
+    std::fill(mSingleFrame.begin(), mSingleFrame.end(), 0.0);
+    std::fill(mSingleFrame2.begin(), mSingleFrame2.end(), 0.0);
+
+    // Determine indices into coefficients table.
+    double tablePhase = getIntegerPhase() * mPhaseScaler;
+    int index1 = static_cast<int>(floor(tablePhase));
+    if (index1 >= mNumRows) { // no guard row needed because we wrap the indices
+        tablePhase -= mNumRows;
+        index1 -= mNumRows;
+    }
+
+    int index2 = index1 + 1;
+    if (index2 >= mNumRows) { // no guard row needed because we wrap the indices
+        index2 -= mNumRows;
+    }
+
+    float *coefficients1 = &mCoefficients[index1 * getNumTaps()];
+    float *coefficients2 = &mCoefficients[index2 * getNumTaps()];
+
+    float *xFrame = &mX[mCursor * getChannelCount()];
+    for (int i = 0; i < mNumTaps; i++) {
+        float coefficient1 = *coefficients1++;
+        float coefficient2 = *coefficients2++;
+        for (int channel = 0; channel < getChannelCount(); channel++) {
+            float sample = *xFrame++;
+            mSingleFrame[channel] +=  sample * coefficient1;
+            mSingleFrame2[channel] += sample * coefficient2;
+        }
+    }
+
+    // Interpolate and copy to output.
+    float fraction = tablePhase - index1;
+    for (int channel = 0; channel < getChannelCount(); channel++) {
+        float low = mSingleFrame[channel];
+        float high = mSingleFrame2[channel];
+        frame[channel] = low + (fraction * (high - low));
+    }
+}

--- a/litr/src/main/cpp/oboe_resampler/SincResampler.h
+++ b/litr/src/main/cpp/oboe_resampler/SincResampler.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef OBOE_SINC_RESAMPLER_H
+#define OBOE_SINC_RESAMPLER_H
+
+#include <memory>
+#include <sys/types.h>
+#include <unistd.h>
+#include "MultiChannelResampler.h"
+
+namespace resampler {
+
+/**
+ * Resampler that can interpolate between coefficients.
+ * This can be used to support arbitrary ratios.
+ */
+class SincResampler : public MultiChannelResampler {
+public:
+    explicit SincResampler(const MultiChannelResampler::Builder &builder);
+
+    virtual ~SincResampler() = default;
+
+    void readFrame(float *frame) override;
+
+protected:
+
+    std::vector<float> mSingleFrame2; // for interpolation
+    int32_t            mNumRows = 0;
+    double             mPhaseScaler = 1.0;
+};
+
+}
+#endif //OBOE_SINC_RESAMPLER_H

--- a/litr/src/main/cpp/oboe_resampler/SincResamplerStereo.cpp
+++ b/litr/src/main/cpp/oboe_resampler/SincResamplerStereo.cpp
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cassert>
+#include <math.h>
+
+#include "SincResamplerStereo.h"
+
+using namespace resampler;
+
+#define STEREO  2
+
+SincResamplerStereo::SincResamplerStereo(const MultiChannelResampler::Builder &builder)
+        : SincResampler(builder) {
+    assert(builder.getChannelCount() == STEREO);
+}
+
+void SincResamplerStereo::writeFrame(const float *frame) {
+    // Move cursor before write so that cursor points to last written frame in read.
+    if (--mCursor < 0) {
+        mCursor = getNumTaps() - 1;
+    }
+    float *dest = &mX[mCursor * STEREO];
+    const int offset = mNumTaps * STEREO;
+    // Write each channel twice so we avoid having to wrap when running the FIR.
+    const float left =  frame[0];
+    const float right = frame[1];
+    // Put ordered writes together.
+    dest[0] = left;
+    dest[1] = right;
+    dest[offset] = left;
+    dest[1 + offset] = right;
+}
+
+// Multiply input times windowed sinc function.
+void SincResamplerStereo::readFrame(float *frame) {
+    // Clear accumulator for mixing.
+    std::fill(mSingleFrame.begin(), mSingleFrame.end(), 0.0);
+    std::fill(mSingleFrame2.begin(), mSingleFrame2.end(), 0.0);
+
+    // Determine indices into coefficients table.
+    double tablePhase = getIntegerPhase() * mPhaseScaler;
+    int index1 = static_cast<int>(floor(tablePhase));
+    float *coefficients1 = &mCoefficients[index1 * getNumTaps()];
+    int index2 = (index1 + 1);
+    if (index2 >= mNumRows) { // no guard row needed because we wrap the indices
+        index2 = 0;
+    }
+    float *coefficients2 = &mCoefficients[index2 * getNumTaps()];
+    float *xFrame = &mX[mCursor * getChannelCount()];
+    for (int i = 0; i < mNumTaps; i++) {
+        float coefficient1 = *coefficients1++;
+        float coefficient2 = *coefficients2++;
+        for (int channel = 0; channel < getChannelCount(); channel++) {
+            float sample = *xFrame++;
+            mSingleFrame[channel] +=  sample * coefficient1;
+            mSingleFrame2[channel] += sample * coefficient2;
+        }
+    }
+
+    // Interpolate and copy to output.
+    float fraction = tablePhase - index1;
+    for (int channel = 0; channel < getChannelCount(); channel++) {
+        float low = mSingleFrame[channel];
+        float high = mSingleFrame2[channel];
+        frame[channel] = low + (fraction * (high - low));
+    }
+}

--- a/litr/src/main/cpp/oboe_resampler/SincResamplerStereo.h
+++ b/litr/src/main/cpp/oboe_resampler/SincResamplerStereo.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef OBOE_SINC_RESAMPLER_STEREO_H
+#define OBOE_SINC_RESAMPLER_STEREO_H
+
+#include <sys/types.h>
+#include <unistd.h>
+#include "SincResampler.h"
+
+namespace resampler {
+
+class SincResamplerStereo : public SincResampler {
+public:
+    explicit SincResamplerStereo(const MultiChannelResampler::Builder &builder);
+
+    virtual ~SincResamplerStereo() = default;
+
+    void writeFrame(const float *frame) override;
+
+    void readFrame(float *frame) override;
+
+};
+
+}
+#endif //OBOE_SINC_RESAMPLER_STEREO_H

--- a/litr/src/main/java/com/linkedin/android/litr/codec/Encoder.java
+++ b/litr/src/main/java/com/linkedin/android/litr/codec/Encoder.java
@@ -30,7 +30,7 @@ public interface Encoder {
      * Requests a Surface to use as the input to an encoder, in place of input buffers. This may only be called after init() and before start()
      * @return a surface, which will be input to an encoder
      */
-    @NonNull
+    @Nullable
     Surface createInputSurface();
 
     /**

--- a/litr/src/main/java/com/linkedin/android/litr/io/WavMediaTarget.kt
+++ b/litr/src/main/java/com/linkedin/android/litr/io/WavMediaTarget.kt
@@ -1,0 +1,143 @@
+package com.linkedin.android.litr.io
+
+import android.media.MediaCodec
+import android.media.MediaFormat
+import java.io.File
+import java.io.FileOutputStream
+import java.io.IOException
+import java.io.OutputStream
+import java.io.RandomAccessFile
+import java.lang.IllegalStateException
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+
+/**
+ * Implementation of [MediaTarget] that writes a single audio track to WAV file
+ */
+class WavMediaTarget(
+    private val targetPath: String
+) : MediaTarget {
+
+    private val tracks = mutableListOf<MediaFormat>()
+    private val outputStream: OutputStream
+
+    init {
+        outputStream = FileOutputStream(File(targetPath))
+    }
+
+    override fun addTrack(mediaFormat: MediaFormat, targetTrack: Int): Int {
+        if (mediaFormat.containsKey(MediaFormat.KEY_MIME) &&
+            mediaFormat.getString(MediaFormat.KEY_MIME) == "audio/raw" &&
+            mediaFormat.containsKey(MediaFormat.KEY_CHANNEL_COUNT) &&
+            mediaFormat.containsKey(MediaFormat.KEY_SAMPLE_RATE)) {
+            tracks.add(mediaFormat)
+            writeWavHeader(
+                outputStream,
+                mediaFormat.getInteger(MediaFormat.KEY_CHANNEL_COUNT).toShort(),
+                mediaFormat.getInteger(MediaFormat.KEY_SAMPLE_RATE),
+                16
+            )
+        }
+        if (tracks.size > 1){
+            throw IllegalStateException("Cannot add more than one track")
+        }
+        return 0
+    }
+
+    override fun writeSampleData(targetTrack: Int, buffer: ByteBuffer, info: MediaCodec.BufferInfo) {
+//        val writeBuffer: ByteBuffer = ByteBuffer.allocate(buffer.capacity()).order(ByteOrder.LITTLE_ENDIAN)
+//        writeBuffer.asShortBuffer().put(buffer.asShortBuffer())
+        outputStream.write(buffer.array(), info.offset, info.size)
+    }
+
+    override fun release() {
+        outputStream.close()
+        updateWavHeader()
+    }
+
+    override fun getOutputFilePath(): String {
+        return targetPath
+    }
+
+    // https://gist.github.com/kmark/d8b1b01fb0d2febf5770#file-audiorecordactivity-java-L288
+    /**
+     * Writes the proper 44-byte RIFF/WAVE header to/for the given stream
+     * Two size fields are left empty/null since we do not yet know the final stream size
+     *
+     * @param out        The stream to write the header to
+     * @param channels   The number of channels
+     * @param sampleRate The sample rate in hertz
+     * @param bitDepth   The bit depth
+     */
+    private fun writeWavHeader(out: OutputStream, channels: Short, sampleRate: Int, bitDepth: Short) {
+        // Convert the multi-byte integers to raw bytes in little endian format as required by the spec
+        val littleBytes = ByteBuffer
+            .allocate(14)
+            .order(ByteOrder.LITTLE_ENDIAN)
+            .putShort(channels)
+            .putInt(sampleRate)
+            .putInt(sampleRate * channels * (bitDepth / 8))
+            .putShort((channels * (bitDepth / 8)).toShort())
+            .putShort(bitDepth)
+            .array()
+
+        // Not necessarily the best, but it's very easy to visualize this way
+        out.write(byteArrayOf( // RIFF header
+            'R'.toByte(), 'I'.toByte(), 'F'.toByte(), 'F'.toByte(),  // ChunkID
+            0, 0, 0, 0,  // ChunkSize (must be updated later)
+            'W'.toByte(), 'A'.toByte(), 'V'.toByte(), 'E'.toByte(),  // Format
+            // fmt subchunk
+            'f'.toByte(), 'm'.toByte(), 't'.toByte(), ' '.toByte(),  // Subchunk1ID
+            16, 0, 0, 0,  // Subchunk1 Size
+            1, 0,  // AudioFormat
+            littleBytes[0], littleBytes[1],  // NumChannels
+            littleBytes[2], littleBytes[3], littleBytes[4], littleBytes[5],  // SampleRate
+            littleBytes[6], littleBytes[7], littleBytes[8], littleBytes[9],  // ByteRate
+            littleBytes[10], littleBytes[11],  // BlockAlign
+            littleBytes[12], littleBytes[13],  // BitsPerSample
+            // data subchunk
+            'd'.toByte(), 'a'.toByte(), 't'.toByte(), 'a'.toByte(),  // Subchunk2 ID
+            0, 0, 0, 0))
+    }
+
+    /**
+     * Updates the given wav file's header to include the final chunk sizes
+     *
+     * @param wav The wav file to update
+     * @throws IOException
+     */
+    private fun updateWavHeader() {
+        val wav = File(targetPath)
+        val sizes = ByteBuffer
+            .allocate(8)
+            .order(ByteOrder.LITTLE_ENDIAN) // There are probably a bunch of different/better ways to calculate
+            // these two given your circumstances. Cast should be safe since if the WAV is
+            // > 4 GB we've already made a terrible mistake.
+            .putInt((wav.length() - 8).toInt()) // ChunkSize
+            .putInt((wav.length() - 44).toInt()) // Subchunk2Size
+            .array()
+        var accessWave: RandomAccessFile? = null
+        try {
+            accessWave = RandomAccessFile(wav, "rw")
+            // ChunkSize
+            accessWave.seek(4)
+            accessWave.write(sizes, 0, 4)
+
+            // Subchunk2Size
+            accessWave.seek(40)
+            accessWave.write(sizes, 4, 4)
+        } catch (ex: IOException) {
+            // Rethrow but we still close accessWave in our finally
+            throw ex
+        } finally {
+            if (accessWave != null) {
+                try {
+                    accessWave.close()
+                } catch (ex: IOException) {
+                    //
+                }
+            }
+        }
+    }
+
+}

--- a/litr/src/main/java/com/linkedin/android/litr/render/AudioRenderer.kt
+++ b/litr/src/main/java/com/linkedin/android/litr/render/AudioRenderer.kt
@@ -90,6 +90,10 @@ class AudioRenderer(private val encoder: Encoder) : Renderer {
                 val targetBufferSize = targetSampleCount * BYTES_PER_SAMPLE * channelCount
                 targetBuffer.limit(targetBufferSize)
 
+                val buffer = ByteBuffer.allocate(targetBufferSize)
+                buffer.put(targetBuffer)
+                buffer.flip()
+
                 bufferInfo.size = targetBufferSize
                 bufferInfo.offset = 0
                 bufferInfo.presentationTimeUs = this.presentationTimeNs
@@ -97,7 +101,7 @@ class AudioRenderer(private val encoder: Encoder) : Renderer {
 
                 this.presentationTimeNs += (targetSampleCount * sampleDurationUs).toLong()
 
-                renderQueue.add(Frame(inputFrame.tag, targetBuffer, bufferInfo))
+                renderQueue.add(Frame(inputFrame.tag, buffer, bufferInfo))
             } else {
                 val buffer = ByteBuffer.allocate(inputFrame.buffer.limit())
                 buffer.put(inputFrame.buffer)

--- a/litr/src/main/java/com/linkedin/android/litr/render/AudioRenderer.kt
+++ b/litr/src/main/java/com/linkedin/android/litr/render/AudioRenderer.kt
@@ -94,7 +94,7 @@ class AudioRenderer(private val encoder: Encoder) : Renderer {
                 }
                 val targetBuffer = ShortArray(numSamples * channelCount)
 
-                val resampledNumSamples = resample(sourceBuffer, sourceBuffer.size, targetBuffer)
+                val resampledNumSamples = resample(sourceBuffer, numSamples, targetBuffer)
 
                 val newSize = resampledNumSamples * BYTES_PER_SAMPLE * channelCount
 
@@ -183,7 +183,7 @@ class AudioRenderer(private val encoder: Encoder) : Renderer {
 
     private external fun initAudioResampler(channelCount: Int, sourceSampleRate: Int, targetSampleRate: Int)
 
-    private external fun resample(sourceBuffer: ShortArray, sourceBufferSize: Int, targetBuffer: ShortArray): Int
+    private external fun resample(sourceBuffer: ShortArray, sampleCount: Int, targetBuffer: ShortArray): Int
 
     private external fun releaseAudioResampler()
 

--- a/litr/src/main/java/com/linkedin/android/litr/render/AudioRenderer.kt
+++ b/litr/src/main/java/com/linkedin/android/litr/render/AudioRenderer.kt
@@ -92,29 +92,9 @@ class AudioRenderer(private val encoder: Encoder) : Renderer {
                 repeat(numSamples * channelCount) { index ->
                     sourceBuffer[index] = inputBuffer.get(index)
                 }
-
                 val targetBuffer = ShortArray(numSamples * channelCount)
 
-                // resample in Java
-//                val factor = 2
-//                val resampledNumSamples = numSamples / factor
-//
-//
-//                for (index in 0 until resampledNumSamples) {
-//                    for (channel in 0 until channelCount) {
-//                        targetBuffer[index * channelCount + channel] = sourceBuffer[index * factor * channelCount + channel]
-//                    }
-//                }
-
-                // resample in JNI
                 val resampledNumSamples = resample(sourceBuffer, sourceBuffer.size, targetBuffer)
-
-//                val newBuffer = ShortArray(resampledNumSamples * channelCount)
-//                for (index in 0 until resampledNumSamples * channelCount) {
-//                    newBuffer[index] = targetBuffer[index].toInt().toShort()
-//                }
-
-                //Log.d(TAG, "Max source ${sourceBuffer.maxOrNull()} target ${targetBuffer.maxOrNull()}")
 
                 val newSize = resampledNumSamples * BYTES_PER_SAMPLE * channelCount
 
@@ -127,8 +107,6 @@ class AudioRenderer(private val encoder: Encoder) : Renderer {
                 bufferInfo.flags = inputFrame.bufferInfo.flags
 
                 this.presentationTimeNs += (resampledNumSamples * sampleDurationUs).toLong()
-
-                //Log.d(TAG, "Resampled $numSamples to $resampledNumSamples")
 
                 renderQueue.add(Frame(inputFrame.tag, outByteBuffer, bufferInfo))
             } else {

--- a/litr/src/main/java/com/linkedin/android/litr/render/AudioRenderer.kt
+++ b/litr/src/main/java/com/linkedin/android/litr/render/AudioRenderer.kt
@@ -107,7 +107,7 @@ class AudioRenderer(private val encoder: Encoder) : Renderer {
 //                }
 
                 // resample in JNI
-                val resampledNumSamples = resample(sourceBuffer, sourceBuffer.size, targetBuffer, targetBuffer.size)
+                val resampledNumSamples = resample(sourceBuffer, sourceBuffer.size, targetBuffer)
 
 //                val newBuffer = ShortArray(resampledNumSamples * channelCount)
 //                for (index in 0 until resampledNumSamples * channelCount) {
@@ -205,7 +205,7 @@ class AudioRenderer(private val encoder: Encoder) : Renderer {
 
     private external fun initAudioResampler(channelCount: Int, sourceSampleRate: Int, targetSampleRate: Int)
 
-    private external fun resample(sourceBuffer: ShortArray, sourceBufferSize: Int, targetBuffer: ShortArray, targetBufferSize: Int): Int
+    private external fun resample(sourceBuffer: ShortArray, sourceBufferSize: Int, targetBuffer: ShortArray): Int
 
     private external fun releaseAudioResampler()
 

--- a/litr/src/main/java/com/linkedin/android/litr/transcoder/TrackTranscoderFactory.java
+++ b/litr/src/main/java/com/linkedin/android/litr/transcoder/TrackTranscoderFactory.java
@@ -20,7 +20,7 @@ import com.linkedin.android.litr.codec.Encoder;
 import com.linkedin.android.litr.exception.TrackTranscoderException;
 import com.linkedin.android.litr.io.MediaSource;
 import com.linkedin.android.litr.io.MediaTarget;
-import com.linkedin.android.litr.render.PassthroughSoftwareRenderer;
+import com.linkedin.android.litr.render.AudioRenderer;
 import com.linkedin.android.litr.render.Renderer;
 
 @RestrictTo(RestrictTo.Scope.LIBRARY)
@@ -85,7 +85,7 @@ public class TrackTranscoderFactory {
                                             encoder);
         } else if (trackMimeType.startsWith("audio")) {
             Renderer audioRenderer = renderer == null
-                    ? new PassthroughSoftwareRenderer(encoder)
+                    ? new AudioRenderer(encoder)
                     : renderer;
 
             return new AudioTrackTranscoder(mediaSource,


### PR DESCRIPTION
Using Oboe to resample audio track:
 - Oboe resampler (https://github.com/google/oboe/tree/master/src/flowgraph/resampler) is copied and used via JNI
 - `AudioRenderer` is modified to send a source buffer to Oboe, receive a resized buffer and queue it to be encoded.