### PR TITLE
Simpler input buffer into output buffer copy in AudioRenderer

### DIFF
--- a/litr/src/main/java/com/linkedin/android/litr/render/AudioRenderer.kt
+++ b/litr/src/main/java/com/linkedin/android/litr/render/AudioRenderer.kt
@@ -118,13 +118,9 @@ class AudioRenderer(private val encoder: Encoder) : Renderer {
                         outputFrame.bufferInfo.flags = outputFrame.bufferInfo.flags and MediaCodec.BUFFER_FLAG_END_OF_STREAM.inv()
                     }
 
-                    outputFrame.buffer.put(
-                        inputFrame.buffer.array(),
-                        inputFrame.buffer.position(),
-                        outputFrame.bufferInfo.size)
-
-                    // advance input buffer position by number of bytes copied
-                    inputFrame.buffer.position(inputFrame.buffer.position() + outputFrame.bufferInfo.size)
+                    repeat(outputFrame.bufferInfo.size) {
+                        outputFrame.buffer.put(inputFrame.buffer.get())
+                    }
 
                     encoder.queueInputFrame(outputFrame)
                 }


### PR DESCRIPTION
There is an easier way to copy input audio buffer to output one. Instead of a using `array` to do a bulk copy, we simply use `get` and `put` methods in a loop. This reduces lines of code and has an additional benefit of supporting direct buffers, which may return `null`. We will need this support in upcoming resampling support.