### PR TITLE
Add resampling support in AudioRenderer

### DIFF
--- a/litr-demo/src/main/java/com/linkedin/android/litr/demo/data/TransformationPresenter.java
+++ b/litr-demo/src/main/java/com/linkedin/android/litr/demo/data/TransformationPresenter.java
@@ -23,7 +23,6 @@ import androidx.annotation.Nullable;
 
 import com.linkedin.android.litr.MediaTransformer;
 import com.linkedin.android.litr.TrackTransform;
-import com.linkedin.android.litr.TransformationListener;
 import com.linkedin.android.litr.TransformationOptions;
 import com.linkedin.android.litr.codec.MediaCodecDecoder;
 import com.linkedin.android.litr.codec.MediaCodecEncoder;
@@ -568,7 +567,7 @@ public class TransformationPresenter {
                 AudioTrackFormat trackFormat = (AudioTrackFormat) targetTrack.format;
                 mediaFormat = MediaFormat.createAudioFormat(
                         "audio/mp4a-latm",
-                        trackFormat.samplingRate,
+                        trackFormat.samplingRate / 2,
                         trackFormat.channelCount);
                 mediaFormat.setInteger(MediaFormat.KEY_BIT_RATE, trackFormat.bitrate / 2);
                 mediaFormat.setLong(MediaFormat.KEY_DURATION, trackFormat.duration);

--- a/litr/src/main/java/com/linkedin/android/litr/render/AudioResamplerFactory.kt
+++ b/litr/src/main/java/com/linkedin/android/litr/render/AudioResamplerFactory.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2019 LinkedIn Corporation
+ * All Rights Reserved.
+ *
+ * Licensed under the BSD 2-Clause License (the "License").  See License in the project root for
+ * license information.
+ */
+package com.linkedin.android.litr.render
+
+import android.media.MediaFormat
+
+internal class AudioResamplerFactory {
+
+    fun createAudioResampler(sourceMediaFormat: MediaFormat?, targetMediaFormat: MediaFormat?): AudioResampler {
+        return if (sourceMediaFormat != null &&
+            targetMediaFormat != null &&
+            sourceMediaFormat.containsKey(MediaFormat.KEY_SAMPLE_RATE) &&
+            targetMediaFormat.containsKey(MediaFormat.KEY_SAMPLE_RATE) &&
+            sourceMediaFormat.containsKey(MediaFormat.KEY_CHANNEL_COUNT) &&
+            sourceMediaFormat.getInteger(MediaFormat.KEY_SAMPLE_RATE) != targetMediaFormat.getInteger(MediaFormat.KEY_SAMPLE_RATE)) {
+            OboeAudioResampler(
+                sourceMediaFormat.getInteger(MediaFormat.KEY_CHANNEL_COUNT),
+                sourceMediaFormat.getInteger(MediaFormat.KEY_SAMPLE_RATE),
+                targetMediaFormat.getInteger(MediaFormat.KEY_SAMPLE_RATE)
+            )
+        } else {
+            PassthroughResampler()
+        }
+    }
+}

--- a/litr/src/main/java/com/linkedin/android/litr/render/OboeAudioResampler.kt
+++ b/litr/src/main/java/com/linkedin/android/litr/render/OboeAudioResampler.kt
@@ -19,7 +19,7 @@ private const val BYTES_PER_SAMPLE = 2
 /**
  * Implementation of audio resampler that uses Oboe library
  */
-class OboeAudioResampler(
+internal class OboeAudioResampler(
     private val channelCount: Int,
     sourceSampleRate: Int,
     targetSampleRate: Int

--- a/litr/src/main/java/com/linkedin/android/litr/render/PassthroughResampler.kt
+++ b/litr/src/main/java/com/linkedin/android/litr/render/PassthroughResampler.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2019 LinkedIn Corporation
+ * All Rights Reserved.
+ *
+ * Licensed under the BSD 2-Clause License (the "License").  See License in the project root for
+ * license information.
+ */
+package com.linkedin.android.litr.render
+
+import android.media.MediaCodec
+import com.linkedin.android.litr.codec.Frame
+import java.lang.IllegalArgumentException
+import java.nio.ByteBuffer
+
+/**
+ * Simple implementation of [AudioResampler] that doesn't resample.
+ * It simply creates a duplicate of a source [Frame]
+ */
+
+internal class PassthroughResampler : AudioResampler {
+
+    override fun resample(frame: Frame): Frame {
+        return frame.buffer?.let { inputBuffer ->
+            val buffer = ByteBuffer.allocate(inputBuffer.limit())
+            buffer.put(inputBuffer)
+            buffer.flip()
+
+            val bufferInfo = MediaCodec.BufferInfo()
+            bufferInfo.set(
+                0,
+                frame.bufferInfo.size,
+                frame.bufferInfo.presentationTimeUs,
+                frame.bufferInfo.flags
+            )
+
+            Frame(frame.tag, buffer, bufferInfo)
+        } ?: throw IllegalArgumentException("Frame doesn't have a buffer, cannot resize!")
+    }
+
+    override fun release() {}
+}

--- a/litr/src/main/java/com/linkedin/android/litr/transcoder/TrackTranscoderFactory.java
+++ b/litr/src/main/java/com/linkedin/android/litr/transcoder/TrackTranscoderFactory.java
@@ -20,7 +20,7 @@ import com.linkedin.android.litr.codec.Encoder;
 import com.linkedin.android.litr.exception.TrackTranscoderException;
 import com.linkedin.android.litr.io.MediaSource;
 import com.linkedin.android.litr.io.MediaTarget;
-import com.linkedin.android.litr.render.PassthroughSoftwareRenderer;
+import com.linkedin.android.litr.render.AudioRenderer;
 import com.linkedin.android.litr.render.Renderer;
 
 @RestrictTo(RestrictTo.Scope.LIBRARY)
@@ -85,7 +85,7 @@ public class TrackTranscoderFactory {
                                             encoder);
         } else if (trackMimeType.startsWith("audio")) {
             Renderer audioRenderer = renderer == null
-                    ? new PassthroughSoftwareRenderer(encoder)
+                    ? new AudioRenderer(encoder)
                     : renderer;
 
             return new AudioTrackTranscoder(mediaSource,


### PR DESCRIPTION
With `OboeAudioResampler` implemented, we can now add audio resampling support in `AudioRenderer`:
 - current logic of copying source `Frame` into target one is abstracted out into `PassthroughResampler`
 - `AudioResamplerFactory` is added to create correct implementation of `AudioResampler` depending if resampling support is needed
 - `AudioResampler` is now used by default