### PR TITLE
Support for channel mixing

### DIFF
--- a/litr/src/main/cpp/audio-resampler.cpp
+++ b/litr/src/main/cpp/audio-resampler.cpp
@@ -29,6 +29,13 @@ Java_com_linkedin_android_litr_render_OboeAudioResampler_initResampler(
             sourceSampleRate,
             targetSampleRate,
             MultiChannelResampler::Quality::High);
+    if (sourceChannelCount > 1 && targetChannelCount > 1 && sourceChannelCount != targetChannelCount) {
+        jclass exClass = env->FindClass("java/lang/IllegalArgumentException");
+        if (exClass != nullptr) {
+            env->ThrowNew(exClass, "Multiple channel to multiple channel mixing is not supported");
+        }
+    }
+
     inputChannelCount = sourceChannelCount;
     outputChannelCount = targetChannelCount;
 }

--- a/litr/src/main/java/com/linkedin/android/litr/render/AudioResamplerFactory.kt
+++ b/litr/src/main/java/com/linkedin/android/litr/render/AudioResamplerFactory.kt
@@ -17,10 +17,12 @@ internal class AudioResamplerFactory {
             sourceMediaFormat.containsKey(MediaFormat.KEY_SAMPLE_RATE) &&
             targetMediaFormat.containsKey(MediaFormat.KEY_SAMPLE_RATE) &&
             sourceMediaFormat.containsKey(MediaFormat.KEY_CHANNEL_COUNT) &&
+            targetMediaFormat.containsKey(MediaFormat.KEY_CHANNEL_COUNT) &&
             sourceMediaFormat.getInteger(MediaFormat.KEY_SAMPLE_RATE) != targetMediaFormat.getInteger(MediaFormat.KEY_SAMPLE_RATE)) {
             OboeAudioResampler(
                 sourceMediaFormat.getInteger(MediaFormat.KEY_CHANNEL_COUNT),
                 sourceMediaFormat.getInteger(MediaFormat.KEY_SAMPLE_RATE),
+                targetMediaFormat.getInteger(MediaFormat.KEY_CHANNEL_COUNT),
                 targetMediaFormat.getInteger(MediaFormat.KEY_SAMPLE_RATE)
             )
         } else {

--- a/litr/src/main/java/com/linkedin/android/litr/render/AudioResamplerFactory.kt
+++ b/litr/src/main/java/com/linkedin/android/litr/render/AudioResamplerFactory.kt
@@ -18,7 +18,8 @@ internal class AudioResamplerFactory {
             targetMediaFormat.containsKey(MediaFormat.KEY_SAMPLE_RATE) &&
             sourceMediaFormat.containsKey(MediaFormat.KEY_CHANNEL_COUNT) &&
             targetMediaFormat.containsKey(MediaFormat.KEY_CHANNEL_COUNT) &&
-            sourceMediaFormat.getInteger(MediaFormat.KEY_SAMPLE_RATE) != targetMediaFormat.getInteger(MediaFormat.KEY_SAMPLE_RATE)) {
+            (sourceMediaFormat.getInteger(MediaFormat.KEY_SAMPLE_RATE) != targetMediaFormat.getInteger(MediaFormat.KEY_SAMPLE_RATE)
+                || sourceMediaFormat.getInteger(MediaFormat.KEY_CHANNEL_COUNT) != targetMediaFormat.getInteger(MediaFormat.KEY_CHANNEL_COUNT))) {
             OboeAudioResampler(
                 sourceMediaFormat.getInteger(MediaFormat.KEY_CHANNEL_COUNT),
                 sourceMediaFormat.getInteger(MediaFormat.KEY_SAMPLE_RATE),


### PR DESCRIPTION
Adding support for channel mixing - mono to stereo and stereo to mono. 
 - Implemented in native layer, as different ways to populate buffer that we send toOboe resampler.
 - No mixing (mono to mono or stereo to stereo) simply copies audio sample bytes, which is current behavior.
 - Mono to stereo replicates mono sample into both stereo channels.
 - Stereo to mono mixes stereo channels by averaging them and puts it into mono channel.
 - Multiple to multiple (e.g. 2 to 4 channels) is not supported.