### PR TITLE
Passthrough ByteBuffer encoder

### DIFF
--- a/litr-demo/src/main/java/com/linkedin/android/litr/demo/data/TargetMedia.java
+++ b/litr-demo/src/main/java/com/linkedin/android/litr/demo/data/TargetMedia.java
@@ -33,6 +33,7 @@ public class TargetMedia extends BaseObservable {
     public List<TargetTrack> tracks = new ArrayList<>();
     public Uri backgroundImageUri;
     public GlFilter filter;
+    public boolean writeToWav;
 
     public void setTracks(@NonNull List<MediaTrackFormat> sourceTracks) {
         tracks = new ArrayList<>(sourceTracks.size());

--- a/litr-demo/src/main/res/layout/fragment_transcode_audio.xml
+++ b/litr-demo/src/main/res/layout/fragment_transcode_audio.xml
@@ -65,6 +65,14 @@
                 android:layout_height="wrap_content"
                 android:padding="@dimen/cell_padding"/>
 
+            <CheckBox
+                android:id="@+id/checkbox_write_to_wav"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/write_to_wav"
+                android:checked="@={targetMedia.writeToWav}"
+                android:visibility="@{(sourceMedia != null &amp;&amp; targetMedia.getIncludedTrackCount() > 0) ? View.VISIBLE : View.GONE}"/>
+
             <Button
                 android:id="@+id/button_transcode"
                 android:layout_width="match_parent"

--- a/litr-demo/src/main/res/values/strings.xml
+++ b/litr-demo/src/main/res/values/strings.xml
@@ -24,6 +24,7 @@
     <string name="transcode_video">Transcode Video</string>
     <string name="transcode_audio">Transcode Audio</string>
     <string name="trim">Trim</string>
+    <string name="write_to_wav">Write to WAV file</string>
 
     <string name="pick_video">Pick Video</string>
     <string name="pick_audio">Pick Audio</string>

--- a/litr/src/main/java/com/linkedin/android/litr/codec/Encoder.java
+++ b/litr/src/main/java/com/linkedin/android/litr/codec/Encoder.java
@@ -30,7 +30,7 @@ public interface Encoder {
      * Requests a Surface to use as the input to an encoder, in place of input buffers. This may only be called after init() and before start()
      * @return a surface, which will be input to an encoder
      */
-    @NonNull
+    @Nullable
     Surface createInputSurface();
 
     /**

--- a/litr/src/main/java/com/linkedin/android/litr/codec/PassthroughBufferEncoder.kt
+++ b/litr/src/main/java/com/linkedin/android/litr/codec/PassthroughBufferEncoder.kt
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2022 LinkedIn Corporation
+ * All Rights Reserved.
+ *
+ * Licensed under the BSD 2-Clause License (the "License").  See License in the project root for
+ * license information.
+ */
+package com.linkedin.android.litr.codec
+
+import android.media.MediaCodec
+import android.media.MediaFormat
+import android.view.Surface
+import java.nio.ByteBuffer
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.LinkedBlockingQueue
+
+private const val DEFAULT_BUFFER_POOL_SIZE = 2
+
+/**
+ * Implementation of [Encoder] that passes input frames to output consumer without modifying them.
+ * Works only in ByteBuffer mode.
+ * @param inputBufferCapacity capacity of encoder's input buffers
+ */
+class PassthroughBufferEncoder(
+    inputBufferCapacity: Int
+) : Encoder {
+
+    // pool of unused frames
+    private val availableFrames = LinkedBlockingQueue<Frame>()
+    // pool of frames a client dequeued to populate with raw input data
+    private val dequeuedInputFrames = ConcurrentHashMap<Int, Frame>()
+    // queue of frames being encoded
+    private val encodeQueue = LinkedBlockingQueue<Int>()
+    // pool of encoded frames
+    private val encodedFrames = ConcurrentHashMap<Int, Frame>()
+
+    private lateinit var mediaFormat: MediaFormat
+
+    private var isRunning = false
+    private var mediaFormatChanged = false
+
+    init {
+        for (tag in 0 until DEFAULT_BUFFER_POOL_SIZE) {
+            availableFrames.add(Frame(tag, ByteBuffer.allocate(inputBufferCapacity), MediaCodec.BufferInfo()))
+        }
+    }
+
+    override fun init(targetFormat: MediaFormat) {
+        this.mediaFormat = targetFormat
+    }
+
+    override fun createInputSurface(): Surface? {
+        return null
+    }
+
+    override fun start() {
+        isRunning = true
+    }
+
+    override fun isRunning(): Boolean {
+        return isRunning
+    }
+
+    override fun signalEndOfInputStream() {}
+
+    override fun dequeueInputFrame(timeout: Long): Int {
+        // since this method modifies multiple data structures, we have to make it synchronous
+        synchronized(this) {
+            return availableFrames.firstOrNull()?.let { availableFrame ->
+                availableFrames.remove(availableFrame)
+                dequeuedInputFrames[availableFrame.tag] = availableFrame
+                availableFrame.tag
+            } ?: MediaCodec.INFO_TRY_AGAIN_LATER
+        }
+    }
+
+    override fun getInputFrame(tag: Int): Frame? {
+        return dequeuedInputFrames[tag]
+    }
+
+    override fun queueInputFrame(frame: Frame) {
+        // since this method modifies multiple data structures, we have to make it synchronous
+        synchronized(this) {
+            frame.buffer?.flip()
+            dequeuedInputFrames.remove(frame.tag)
+            encodeQueue.add(frame.tag)
+            encodedFrames[frame.tag] = frame
+        }
+    }
+
+    override fun dequeueOutputFrame(timeout: Long): Int {
+        if (!mediaFormatChanged) {
+            mediaFormatChanged = true
+            return MediaCodec.INFO_OUTPUT_FORMAT_CHANGED
+        }
+        return encodeQueue.poll() ?: MediaCodec.INFO_TRY_AGAIN_LATER
+    }
+
+    override fun getOutputFrame(tag: Int): Frame? {
+        return encodedFrames[tag]
+    }
+
+    override fun releaseOutputFrame(tag: Int) {
+        encodedFrames.remove(tag)?.let {
+            it.buffer?.clear()
+            availableFrames.add(it)
+        }
+    }
+
+    override fun getOutputFormat(): MediaFormat {
+        return mediaFormat
+    }
+
+    override fun stop() {
+        isRunning = false
+    }
+
+    override fun release() {
+        availableFrames.clear()
+        dequeuedInputFrames.clear()
+        encodeQueue.clear()
+        encodedFrames.clear()
+    }
+
+    override fun getName(): String {
+        return "PassthroughEncoder"
+    }
+}

--- a/litr/src/test/java/com/linkedin/android/litr/codec/PassthroughBufferEncoderShould.kt
+++ b/litr/src/test/java/com/linkedin/android/litr/codec/PassthroughBufferEncoderShould.kt
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2022 LinkedIn Corporation
+ * All Rights Reserved.
+ *
+ * Licensed under the BSD 2-Clause License (the "License").  See License in the project root for
+ * license information.
+ */
+package com.linkedin.android.litr.codec
+
+import android.media.MediaCodec
+import android.media.MediaFormat
+import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.MatcherAssert.assertThat
+import org.junit.Before
+import org.junit.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+private const val BUFFER_CAPACITY = 42
+
+class PassthroughBufferEncoderShould {
+
+    private lateinit var encoder: Encoder
+
+    @Before
+    fun setup() {
+        encoder = PassthroughBufferEncoder(BUFFER_CAPACITY)
+
+        // first output frame is always a media format change, so get it out of the way for main tests
+        encoder.dequeueOutputFrame(0)
+    }
+
+    @Test
+    fun start() {
+        assertFalse(encoder.isRunning)
+
+        encoder.start()
+
+        assertTrue(encoder.isRunning)
+    }
+
+    @Test
+    fun stop() {
+        encoder.start()
+
+        encoder.stop()
+
+        assertFalse(encoder.isRunning)
+    }
+
+    @Test
+    fun `dequeue input frame`() {
+        val tag = encoder.dequeueInputFrame(0)
+
+        assertThat(tag, equalTo(0))
+    }
+
+    @Test
+    fun `return try later when frame pool is depleted`() {
+        val tag1 = encoder.dequeueInputFrame(0)
+        val tag2 = encoder.dequeueInputFrame(0)
+        val tag3 = encoder.dequeueInputFrame(0)
+
+        assertThat(tag1, equalTo(0))
+        assertThat(tag2, equalTo(1))
+        assertThat(tag3, equalTo(MediaCodec.INFO_TRY_AGAIN_LATER))
+    }
+
+    @Test
+    fun `return media format change on first output frame request`() {
+        val mediaFormat = MediaFormat()
+        mediaFormat.setString(MediaFormat.KEY_MIME, "audio/raw")
+        mediaFormat.setInteger(MediaFormat.KEY_SAMPLE_RATE, 48000)
+        mediaFormat.setInteger(MediaFormat.KEY_CHANNEL_COUNT, 2)
+
+        val encoder = PassthroughBufferEncoder(BUFFER_CAPACITY)
+        encoder.init(mediaFormat)
+
+        val formatTag = encoder.dequeueOutputFrame(0)
+        assertThat(formatTag, equalTo(MediaCodec.INFO_OUTPUT_FORMAT_CHANGED))
+        assertThat(encoder.outputFormat, equalTo(mediaFormat))
+    }
+
+    @Test
+    fun `return try later when no output frames are available`() {
+        val tag = encoder.dequeueOutputFrame(0)
+
+        assertThat(tag, equalTo(MediaCodec.INFO_TRY_AGAIN_LATER))
+    }
+
+    @Test
+    fun `passthrough encode a frame`() {
+        val inputTag = encoder.dequeueInputFrame(0)
+        val inputFrame = encoder.getInputFrame(inputTag)
+        assertNotNull(inputFrame)
+        encoder.queueInputFrame(inputFrame)
+
+        // subsequent requests will return frame tags, if available
+        val outputTag = encoder.dequeueOutputFrame(0)
+        val outputFrame = encoder.getOutputFrame(outputTag)
+
+        assertThat(outputTag, equalTo(inputTag))
+        assertThat(outputFrame, equalTo(inputFrame))
+    }
+
+    @Test
+    fun `maintain frame ordering when encoding`() {
+        val inputTag1 = encoder.dequeueInputFrame(0)
+        val inputTag2 = encoder.dequeueInputFrame(0)
+        val inputFrame1 = encoder.getInputFrame(inputTag1)
+        assertNotNull(inputFrame1)
+        val inputFrame2 = encoder.getInputFrame(inputTag2)
+        assertNotNull(inputFrame2)
+        encoder.queueInputFrame(inputFrame1)
+        encoder.queueInputFrame(inputFrame2)
+
+        val outputTag1 = encoder.dequeueOutputFrame(0)
+        val outputFrame1 = encoder.getOutputFrame(outputTag1)
+        val outputTag2 = encoder.dequeueOutputFrame(0)
+        val outputFrame2 = encoder.getOutputFrame(outputTag2)
+
+        assertThat(outputTag1, equalTo(inputTag1))
+        assertThat(outputTag2, equalTo(inputTag2))
+        assertThat(outputFrame1, equalTo(inputFrame1))
+        assertThat(outputFrame2, equalTo(inputFrame2))
+    }
+
+    @Test
+    fun `make output frame available when it is released`() {
+        val inputTag1 = encoder.dequeueInputFrame(0)
+        val inputTag2 = encoder.dequeueInputFrame(0)
+        val inputFrame1 = encoder.getInputFrame(inputTag1)
+        assertNotNull(inputFrame1)
+        val inputFrame2 = encoder.getInputFrame(inputTag2)
+        assertNotNull(inputFrame2)
+        encoder.queueInputFrame(inputFrame1)
+        encoder.queueInputFrame(inputFrame2)
+
+        val outputTag1 = encoder.dequeueOutputFrame(0)
+        val outputFrame1 = encoder.getOutputFrame(outputTag1)
+        val outputTag2 = encoder.dequeueOutputFrame(0)
+        val outputFrame2 = encoder.getOutputFrame(outputTag2)
+
+        // no available input frames yet
+        assertThat(encoder.dequeueInputFrame(0), equalTo(MediaCodec.INFO_TRY_AGAIN_LATER))
+
+        encoder.releaseOutputFrame(outputTag1)
+
+        // now frame becomes available after it is released
+        assertThat(encoder.dequeueInputFrame(0), equalTo(inputTag1))
+    }
+}


### PR DESCRIPTION
An implementation of `Encoder` which simply passes input `ByteBuffer`s into output, with no modification. Useful when raw decoded frames are needed - for inspection, or to write audio frames into a WAV file. 

Demo of writing audio into WAV file is included.