### PR TITLE
Capability to apply filters in AudioRenderer

### DIFF
--- a/litr/src/main/java/com/linkedin/android/litr/filter/BufferFilter.kt
+++ b/litr/src/main/java/com/linkedin/android/litr/filter/BufferFilter.kt
@@ -1,0 +1,17 @@
+package com.linkedin.android.litr.filter
+
+import com.linkedin.android.litr.codec.Frame
+
+/**
+ * A filter used with a renderer operating in buffer mode, like [AudioRenderer]
+ */
+interface BufferFilter {
+
+    /**
+     * Apply a filter to a [Frame]. Frame.bufferInfo will provide necessary metadata.
+     * Frame.buffer is expected to be modified. Buffer contents are in target format.
+     * For example, for audio buffer those will be Short (2 byte LE) values with target
+     * sample rate and channel count.
+     */
+    fun apply(frame: Frame)
+}

--- a/litr/src/main/java/com/linkedin/android/litr/filter/BufferFilter.kt
+++ b/litr/src/main/java/com/linkedin/android/litr/filter/BufferFilter.kt
@@ -1,11 +1,18 @@
 package com.linkedin.android.litr.filter
 
+import android.media.MediaFormat
 import com.linkedin.android.litr.codec.Frame
 
 /**
  * A filter used with a renderer operating in buffer mode, like [AudioRenderer]
  */
 interface BufferFilter {
+
+    /**
+     * Initialize the filter
+     * @param mediaFormat renderer's target [MediaFormat]
+     */
+    fun init(mediaFormat: MediaFormat?)
 
     /**
      * Apply a filter to a [Frame]. Frame.bufferInfo will provide necessary metadata.

--- a/litr/src/main/java/com/linkedin/android/litr/render/AudioRenderer.kt
+++ b/litr/src/main/java/com/linkedin/android/litr/render/AudioRenderer.kt
@@ -48,6 +48,7 @@ class AudioRenderer @JvmOverloads constructor(
         released.set(false)
         renderThread.start()
         audioProcessor = AudioProcessorFactory().createAudioProcessor(sourceMediaFormat, targetMediaFormat)
+        filters.forEach { it.init(targetMediaFormat) }
     }
 
     override fun onMediaFormatChanged(sourceMediaFormat: MediaFormat?, targetMediaFormat: MediaFormat?) {

--- a/litr/src/main/java/com/linkedin/android/litr/render/AudioRenderer.kt
+++ b/litr/src/main/java/com/linkedin/android/litr/render/AudioRenderer.kt
@@ -13,6 +13,7 @@ import android.util.Log
 import android.view.Surface
 import com.linkedin.android.litr.codec.Encoder
 import com.linkedin.android.litr.codec.Frame
+import com.linkedin.android.litr.filter.BufferFilter
 import com.linkedin.android.litr.utils.ByteBufferPool
 import java.util.concurrent.LinkedBlockingDeque
 import java.util.concurrent.atomic.AtomicBoolean
@@ -23,7 +24,10 @@ private const val FRAME_WAIT_TIMEOUT: Long = 0L
 
 private const val TAG = "AudioRenderer"
 
-class AudioRenderer(private val encoder: Encoder) : Renderer {
+class AudioRenderer @JvmOverloads constructor(
+    private val encoder: Encoder,
+    private val filters: MutableList<BufferFilter> = mutableListOf()
+) : Renderer {
 
     private var sourceMediaFormat: MediaFormat? = null
     private var targetMediaFormat: MediaFormat? = null
@@ -79,6 +83,8 @@ class AudioRenderer(private val encoder: Encoder) : Renderer {
             val processedFrame = Frame(inputFrame.tag, targetBuffer, MediaCodec.BufferInfo())
 
             audioProcessor.processFrame(inputFrame, processedFrame)
+            filters.forEach { it.apply(processedFrame) }
+
             renderQueue.add(processedFrame)
         }
     }


### PR DESCRIPTION
Similar to video GL filters, adding support for audio filters:
 - introducing a new `BufferFilter` interface that is called to modify `Frame` contents, meant to be used for any `Renderer` in a buffer mode
 - `AudioRenderer` can now accept a list of filters and apply them in order.
 - No actual filters are yet implemented