### PR TITLE
Fix hasFilters method logic in AudioRenderer

### DIFF
--- a/litr/src/main/java/com/linkedin/android/litr/render/AudioRenderer.kt
+++ b/litr/src/main/java/com/linkedin/android/litr/render/AudioRenderer.kt
@@ -97,7 +97,7 @@ class AudioRenderer @JvmOverloads constructor(
     }
 
     override fun hasFilters(): Boolean {
-        return false
+        return filters.isNotEmpty()
     }
 
     private inner class RenderThread : Thread() {


### PR DESCRIPTION
Initially `AudioRenderer` did not support filters, so `hasFilters` defaulted to returning `false`. Fixing this oversight.