### PR TITLE
Ensure non-started jobs are removed from jobs map when stopping

### DIFF
--- a/litr/src/main/java/com/linkedin/android/litr/frameextract/FrameExtractJob.kt
+++ b/litr/src/main/java/com/linkedin/android/litr/frameextract/FrameExtractJob.kt
@@ -24,6 +24,10 @@ internal class FrameExtractJob constructor(
     private val behavior: FrameExtractBehavior,
     private val listener: FrameExtractListener?
 ) : Runnable {
+
+    var isStarted: Boolean = false
+        private set
+
     private val behaviorFrameListener = object: FrameExtractBehaviorFrameListener {
         override fun onFrameExtracted(bitmap: Bitmap) {
             val renderedBitmap = renderExtractedFrame(bitmap)
@@ -41,6 +45,7 @@ internal class FrameExtractJob constructor(
     }
 
     override fun run() {
+        isStarted = true
         try {
             extract()
         } catch (e: RuntimeException) {

--- a/litr/src/main/java/com/linkedin/android/litr/frameextract/queue/ComparableFutureTask.kt
+++ b/litr/src/main/java/com/linkedin/android/litr/frameextract/queue/ComparableFutureTask.kt
@@ -7,6 +7,8 @@
  */
 package com.linkedin.android.litr.frameextract.queue
 
+import com.linkedin.android.litr.ExperimentalFrameExtractorApi
+import com.linkedin.android.litr.frameextract.FrameExtractJob
 import java.util.concurrent.*
 import java.util.concurrent.atomic.AtomicLong
 
@@ -15,9 +17,13 @@ import java.util.concurrent.atomic.AtomicLong
  *
  * This task maintains a FIFO order for priority.
  */
-internal class ComparableFutureTask<T>(runnable: Runnable?, result: T, private var priority: Long) : FutureTask<T>(runnable, result),
+@ExperimentalFrameExtractorApi
+internal class ComparableFutureTask<T>(private val job: FrameExtractJob?, result: T, private var priority: Long) : FutureTask<T>(job, result),
     Comparable<ComparableFutureTask<T>> {
     private val sequenceNumber = sharedSequence.getAndIncrement()
+
+    val isStarted: Boolean
+        get() = job?.isStarted ?: false
 
     override fun compareTo(other: ComparableFutureTask<T>): Int {
         var res = priority.compareTo(other.priority)


### PR DESCRIPTION
### The problem

Whenever a frame extraction gets cancelled by its request id, there were some cases when a subsequent extract call for the same request id was not reporting any result/error/cancellation.

### The cause

The initial cancellation call was fired when the extraction job hadn't started yet, this was causing the job never being interrupted and never getting into a point of triggering a cancellation listener. The cancellation listener is the one in charge of removing the job from the `activeJobMap`, so since it was never removed, subsequent calls with the same request id were immediately discarded because the job still was in the `activeJobMap`.

### The solution

Add a `isStarted` property to the `FrameExtractJob`, which gets set to `true` right at the beginning of the `run` method of the `Runnable`. This property is exposed to `ComparableFutureTask`, which at the same time can be read from the `ActiveExtractJob` in order to determine when the job is being cancelled but hasn't started yet.

### Visuals

Here's an example of this behavior, modifying a bit the `litr-demo` we can observe the issue and after the fix.
- Caching was removed for better visualization
- A request id is not random but is uniquely mapped to each frame (based on the timestamp)

| Before | After |
|----|----|
| ![before](https://user-images.githubusercontent.com/5265397/156828940-240a374b-12a7-4a78-af2f-49fd9f00e4e6.gif) | ![after](https://user-images.githubusercontent.com/5265397/156828937-ed09693c-82bb-4173-a252-16a79fa7f6fd.gif) |
