### PR TITLE
Support for transcoding video to VP8/VP9

### DIFF
--- a/litr-demo/src/main/java/com/linkedin/android/litr/demo/DemoCase.java
+++ b/litr-demo/src/main/java/com/linkedin/android/litr/demo/DemoCase.java
@@ -22,7 +22,8 @@ public enum DemoCase {
     VIDEO_FILTERS_PREVIEW(R.string.demo_case_video_filters_preview, "VideoFiltersPreview", new VideoFilterPreviewFragment()),
     TRANSCODE_VIDEO_MOCK(R.string.demo_case_mock_transcode_video, "TranscodeVideoMock", new MockTranscodeFragment()),
     TRANSCODE_AUDIO(R.string.demo_case_transcode_audio, "TranscodeAudio", new TranscodeAudioFragment()),
-    EXTRACT_FRAMES(R.string.demo_case_extract_frames, "ExtractFramesFragment", new ExtractFramesFragment());
+    EXTRACT_FRAMES(R.string.demo_case_extract_frames, "ExtractFramesFragment", new ExtractFramesFragment()),
+    TRANSCODE_TO_VP9(R.string.demo_case_transcode_to_vp9, "TranscodeToVp9Fragment", new TranscodeToVp9Fragment());
 
     @StringRes int displayName;
     String fragmentTag;

--- a/litr-demo/src/main/java/com/linkedin/android/litr/demo/TranscodeToVp9Fragment.kt
+++ b/litr-demo/src/main/java/com/linkedin/android/litr/demo/TranscodeToVp9Fragment.kt
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2019 LinkedIn Corporation
+ * All Rights Reserved.
+ *
+ * Licensed under the BSD 2-Clause License (the "License").  See License in the project root for
+ * license information.
+ */
+package com.linkedin.android.litr.demo
+
+import android.net.Uri
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import com.linkedin.android.litr.MediaTransformer
+import com.linkedin.android.litr.demo.data.SourceMedia
+import com.linkedin.android.litr.demo.data.TargetMedia
+import com.linkedin.android.litr.demo.data.TranscodingConfigPresenter
+import com.linkedin.android.litr.demo.data.TransformationPresenter
+import com.linkedin.android.litr.demo.data.TransformationState
+import com.linkedin.android.litr.demo.data.TrimConfig
+import com.linkedin.android.litr.demo.databinding.FragmentVideoVp9Binding
+import com.linkedin.android.litr.utils.TransformationUtil
+import java.io.File
+
+class TranscodeToVp9Fragment : BaseTransformationFragment(), MediaPickerListener {
+
+    private lateinit var binding: FragmentVideoVp9Binding
+    private lateinit var mediaTransformer: MediaTransformer
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        mediaTransformer = MediaTransformer(context!!.applicationContext)
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        mediaTransformer.release()
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?, savedInstanceState: Bundle?
+    ): View {
+        binding = FragmentVideoVp9Binding.inflate(inflater, container, false)
+
+        val sourceMedia = SourceMedia()
+        binding.sourceMedia = sourceMedia
+        binding.sectionPickVideo.buttonPickVideo.setOnClickListener { pickVideo(this@TranscodeToVp9Fragment) }
+        binding.transformationState = TransformationState()
+        binding.transformationPresenter = TransformationPresenter(context!!, mediaTransformer)
+
+        val targetMedia = TargetMedia()
+        val transcodingConfigPresenter = TranscodingConfigPresenter(this, targetMedia)
+        binding.transcodingConfigPresenter = transcodingConfigPresenter
+        binding.targetMedia = targetMedia
+        binding.trimConfig = TrimConfig()
+
+        return binding.root
+    }
+
+    override fun onMediaPicked(uri: Uri) {
+        binding.sourceMedia?.let { sourceMedia ->
+            updateSourceMedia(sourceMedia, uri)
+            binding.trimConfig?.let { trimConfig -> updateTrimConfig(trimConfig, sourceMedia) }
+            val targetFile = File(TransformationUtil.getTargetFileDirectory(requireContext().applicationContext),
+                "transcoded_" + TransformationUtil.getDisplayName(context!!, sourceMedia.uri))
+            binding.targetMedia?.setTargetFile(targetFile)
+            binding.targetMedia?.setTracks(sourceMedia.tracks)
+            binding.transformationState?.setState(TransformationState.STATE_IDLE)
+            binding.transformationState?.setStats(null)
+        }
+    }
+}

--- a/litr-demo/src/main/res/layout/fragment_video_vp9.xml
+++ b/litr-demo/src/main/res/layout/fragment_video_vp9.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2019 LinkedIn Corporation -->
+<!-- All Rights Reserved. -->
+<!-- -->
+<!-- Licensed under the BSD 2-Clause License (the "License").  See License in the project root -->
+<!-- for license information. -->
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <data>
+        <import type="android.view.View"/>
+
+        <variable
+            name="sourceMedia"
+            type="com.linkedin.android.litr.demo.data.SourceMedia" />
+
+        <variable
+            name="trimConfig"
+            type="com.linkedin.android.litr.demo.data.TrimConfig" />
+
+        <variable
+            name="targetMedia"
+            type="com.linkedin.android.litr.demo.data.TargetMedia" />
+
+        <variable
+            name="transformationState"
+            type="com.linkedin.android.litr.demo.data.TransformationState" />
+
+        <variable
+            name="transcodingConfigPresenter"
+            type="com.linkedin.android.litr.demo.data.TranscodingConfigPresenter" />
+
+        <variable
+            name="transformationPresenter"
+            type="com.linkedin.android.litr.demo.data.TransformationPresenter" />
+
+    </data>
+
+    <androidx.core.widget.NestedScrollView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <LinearLayout
+            android:orientation="vertical"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+
+            <include layout="@layout/section_pick_video"
+                android:id="@+id/section_pick_video"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:sourceMedia="@{sourceMedia}"/>
+
+            <include layout="@layout/section_trim"
+                android:id="@+id/section_trim"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:visibility="@{(sourceMedia != null &amp;&amp; targetMedia.getIncludedTrackCount() > 0) ? View.VISIBLE : View.GONE}"
+                app:sourceMedia="@{sourceMedia}"
+                app:trimConfig="@{trimConfig}"/>
+
+            <Button
+                android:id="@+id/button_transcode"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/transcode"
+                android:enabled="@{sourceMedia != null &amp;&amp; targetMedia != null &amp;&amp; targetMedia.getIncludedTrackCount() > 0 &amp;&amp; (transformationState.state != transformationState.STATE_RUNNING)}"
+                android:padding="@dimen/cell_padding"
+                android:onClick="@{() -> transformationPresenter.transcodeToVp9(sourceMedia, targetMedia, trimConfig, transformationState)}"/>
+
+            <include layout="@layout/section_transformation_progress"
+                android:id="@+id/section_transformation_progress"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:visibility="@{transformationState.state == transformationState.STATE_IDLE ? View.GONE : View.VISIBLE}"
+                app:transformationState="@{transformationState}"
+                app:presenter="@{transformationPresenter}"/>
+
+            <Button
+                android:id="@+id/button_play"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/play"
+                android:enabled="@{transformationState.state == transformationState.STATE_COMPLETED}"
+                android:padding="@dimen/cell_padding"
+                android:onClick="@{() -> transformationPresenter.play(targetMedia.contentUri)}"/>
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:padding="@dimen/cell_padding"
+                android:text="@{transformationState.stats}"
+                android:visibility="@{transformationState.state == transformationState.STATE_RUNNING || transformationState.stats == null ? View.GONE : View.VISIBLE}"/>
+
+        </LinearLayout>
+
+    </androidx.core.widget.NestedScrollView>
+
+</layout>

--- a/litr-demo/src/main/res/values/strings.xml
+++ b/litr-demo/src/main/res/values/strings.xml
@@ -17,6 +17,9 @@
     <string name="demo_case_mock_transcode_video">Mock Transcode Video</string>
     <string name="demo_case_transcode_audio">Transcode Audio</string>
     <string name="demo_case_extract_frames">Extract Video Frames</string>
+    <string name="demo_case_transcode_to_vp9">Transcode To VP9</string>
+
+    <string name="error_vp9_not_supported">VP8/VP9 is not supported</string>
 
     <string name="include">Include</string>
     <string name="overlay">Overlay</string>

--- a/litr/src/main/java/com/linkedin/android/litr/MediaTransformer.java
+++ b/litr/src/main/java/com/linkedin/android/litr/MediaTransformer.java
@@ -57,6 +57,7 @@ public class MediaTransformer {
     public static final int GRANULARITY_DEFAULT = 100;
 
     public static final int DEFAULT_KEY_FRAME_INTERVAL = 5;
+    private static final int DEFAULT_AUDIO_BITRATE = 256_000;
 
     private static final String TAG = MediaTransformer.class.getSimpleName();
     private static final int DEFAULT_FUTURE_MAP_SIZE = 10;
@@ -456,11 +457,11 @@ public class MediaTransformer {
                 targetMimeType,
                 sourceMediaFormat.getInteger(MediaFormat.KEY_SAMPLE_RATE),
                 sourceMediaFormat.getInteger(MediaFormat.KEY_CHANNEL_COUNT));
-        if (sourceMediaFormat.containsKey(MediaFormat.KEY_BIT_RATE)) {
-            adjustedAudioFormat.setInteger(
-                    MediaFormat.KEY_BIT_RATE,
-                    sourceMediaFormat.getInteger(MediaFormat.KEY_BIT_RATE));
-        }
+        adjustedAudioFormat.setInteger(
+                MediaFormat.KEY_BIT_RATE,
+                sourceMediaFormat.containsKey(MediaFormat.KEY_BIT_RATE)
+                        ? sourceMediaFormat.getInteger(MediaFormat.KEY_BIT_RATE)
+                        : DEFAULT_AUDIO_BITRATE);
         if (sourceMediaFormat.containsKey(MediaFormat.KEY_DURATION)) {
             adjustedAudioFormat.setLong(
                     MediaFormat.KEY_DURATION,

--- a/litr/src/main/java/com/linkedin/android/litr/MediaTransformer.java
+++ b/litr/src/main/java/com/linkedin/android/litr/MediaTransformer.java
@@ -449,7 +449,7 @@ public class MediaTransformer {
     private MediaFormat createTargetAudioFormat(@NonNull MediaFormat sourceMediaFormat,
                                                 @Nullable MediaFormat targetAudioFormat,
                                                 @Nullable String targetMimeType) {
-        if (targetMimeType == null) {
+        if (targetMimeType == null || targetAudioFormat != null) {
             return targetAudioFormat;
         }
         MediaFormat adjustedAudioFormat = MediaFormat.createAudioFormat(


### PR DESCRIPTION
Implementation of support for encoding video to VP8/VP9:
 - version gated for Lollipop
 - clients could already encode into VP8/VP9 via track transform API, this PR adds that support for simple `transform` API
 - if audio track format is not specified, audio will be transcoded to Opus codec, with source encoding parameters (channel count, bitrate, etc.)
 - WebM container will be automatically set if target video track format is VP8 or VP9