### PR TITLE
Remove deprecated MediaTransformer methods

### DIFF
--- a/litr/src/main/java/com/linkedin/android/litr/test/MockMediaTransformer.java
+++ b/litr/src/main/java/com/linkedin/android/litr/test/MockMediaTransformer.java
@@ -10,18 +10,15 @@ package com.linkedin.android.litr.test;
 import android.content.Context;
 import android.media.MediaFormat;
 import android.net.Uri;
+
 import androidx.annotation.IntRange;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+
 import com.linkedin.android.litr.MediaTransformer;
 import com.linkedin.android.litr.TrackTransform;
 import com.linkedin.android.litr.TransformationListener;
-import com.linkedin.android.litr.codec.Decoder;
-import com.linkedin.android.litr.codec.Encoder;
-import com.linkedin.android.litr.filter.GlFilter;
-import com.linkedin.android.litr.io.MediaSource;
-import com.linkedin.android.litr.io.MediaTarget;
-import com.linkedin.android.litr.render.Renderer;
+import com.linkedin.android.litr.TransformationOptions;
 
 import java.util.List;
 
@@ -43,26 +40,11 @@ public class MockMediaTransformer extends MediaTransformer {
     @Override
     public void transform(@NonNull String requestId,
                           @NonNull Uri inputUri,
-                          @NonNull String outputFilePath,
+                          @NonNull Uri outputUri,
                           @Nullable MediaFormat targetVideoFormat,
                           @Nullable MediaFormat targetAudioFormat,
                           @NonNull TransformationListener listener,
-                          @IntRange(from = GRANULARITY_NONE) int granularity,
-                          @Nullable List<GlFilter> filters) {
-        playEvents(listener);
-    }
-
-    @Override
-    public void transform(@NonNull String requestId,
-                          @NonNull MediaSource mediaSource,
-                          @NonNull Decoder decoder,
-                          @NonNull Renderer videoRenderer,
-                          @NonNull Encoder encoder,
-                          @NonNull MediaTarget mediaTarget,
-                          @Nullable MediaFormat targetVideoFormat,
-                          @Nullable MediaFormat targetAudioFormat,
-                          @NonNull TransformationListener listener,
-                          @IntRange(from = GRANULARITY_NONE) int granularity) {
+                          @Nullable TransformationOptions transformationOptions) {
         playEvents(listener);
     }
 
@@ -84,7 +66,8 @@ public class MockMediaTransformer extends MediaTransformer {
     @Override
     public long getEstimatedTargetVideoSize(@NonNull Uri inputUri,
                                             @NonNull MediaFormat targetVideoFormat,
-                                            @Nullable MediaFormat targetAudioFormat) {
+                                            @Nullable MediaFormat targetAudioFormat,
+                                            @Nullable TransformationOptions transformationOptions) {
         return 0;
     }
 


### PR DESCRIPTION
Removing `@Deprecated` methods from `MediaTransformer`. They have been deprecated for a while.