### PR TITLE
Recreate AudioProcessor on source/target audio format change

### DIFF
--- a/litr/src/main/java/com/linkedin/android/litr/utils/MediaFormatUtils.kt
+++ b/litr/src/main/java/com/linkedin/android/litr/utils/MediaFormatUtils.kt
@@ -7,12 +7,22 @@ class MediaFormatUtils {
     companion object {
         @JvmStatic
         fun getIFrameInterval(format: MediaFormat, defaultValue: Number): Number {
-            return getNumber(format, MediaFormat.KEY_I_FRAME_INTERVAL) ?: return defaultValue
+            return getNumber(format, MediaFormat.KEY_I_FRAME_INTERVAL) ?: defaultValue
         }
 
         @JvmStatic
         fun getFrameRate(format: MediaFormat, defaultValue: Number): Number {
-            return getNumber(format, MediaFormat.KEY_FRAME_RATE) ?: return defaultValue
+            return getNumber(format, MediaFormat.KEY_FRAME_RATE) ?: defaultValue
+        }
+
+        @JvmStatic
+        fun getChannelCount(format: MediaFormat, defaultValue: Number): Number {
+            return getNumber(format, MediaFormat.KEY_CHANNEL_COUNT) ?: defaultValue
+        }
+
+        @JvmStatic
+        fun getSampleRate(format: MediaFormat, defaultValue: Number): Number {
+            return getNumber(format, MediaFormat.KEY_SAMPLE_RATE) ?: defaultValue
         }
 
         @JvmStatic


### PR DESCRIPTION
Currently `AudioRenderer` initializes `AudioProcessor` once, when created. What happens in reality sometimes (as reported in https://github.com/linkedin/LiTr/issues/188) audio track format reported in track metadata does not correspond to actual track format reported by MediaCodec. This causes audio processing to fail because we initialize `AudioProcessor` for one set of sampling rate / channel count combination but actual sampling rate / channel count could be different which causes a `BufferOverflowException`. 
Solution is to re-create `AudioProcessor` each time either source or target format changes. This ensures that it is configured correctly.