### PR TITLE
Frame extractor: fix ConcurrentModificationException when removing jobs

### DIFF
--- a/litr/src/main/java/com/linkedin/android/litr/frameextract/VideoFrameExtractor.kt
+++ b/litr/src/main/java/com/linkedin/android/litr/frameextract/VideoFrameExtractor.kt
@@ -81,14 +81,16 @@ class VideoFrameExtractor @JvmOverloads constructor(
      * Cancels all started extract jobs. [FrameExtractListener.onCancelled] will be called for jobs that have been started.
      */
     fun stopAll() {
-        activeJobMap.forEach { (requestId, job) ->
+        val iterator = activeJobMap.iterator()
+        while (iterator.hasNext()) {
+            val job = iterator.next().value
             if (!job.future.isCancelled && !job.future.isDone) {
                 job.future.cancel(true)
             }
             if (!job.future.isStarted) {
                 // If the job hasn't started, it won't probably even start, but it will remain in the activeJobMap,
                 // we must remove it from there.
-                activeJobMap.remove(requestId)
+                iterator.remove()
             }
         }
     }


### PR DESCRIPTION
Collection of jobs was being modified while iterating.

To reproduce, run the demo and:
- Tap Extract Video Frames
- Pick a video
- Tap Extract
- While frames are being extracted, tap Extract again

With the fix, the exception will no longer be thrown, and extracting will restart as expected.