### PR TITLE
Notify TransformationListener before releasing TransformationJob

### DIFF
--- a/litr/src/main/java/com/linkedin/android/litr/TransformationJob.java
+++ b/litr/src/main/java/com/linkedin/android/litr/TransformationJob.java
@@ -119,14 +119,14 @@ class TransformationJob implements Runnable {
 
     @VisibleForTesting
     void cancel() {
-        release(false);
         marshallingTransformationListener.onCancelled(jobId, statsCollector.getStats());
+        release(false);
     }
 
     @VisibleForTesting
     protected void error(@Nullable Throwable cause) {
-        release(false);
         marshallingTransformationListener.onError(jobId, cause, statsCollector.getStats());
+        release(false);
     }
 
     @VisibleForTesting


### PR DESCRIPTION
I have seen the `release()` call hang in certain cases when processing failed as a result of which the listener
callback never invoked. Which then broke our internal app logic as the processing seemed stuck forever. 
I think it's better to first invoke the callback so that LiTr users can at least somehow propagate the error to end users or log the associated exception.

How to test:
1. It's hard to test, but I was able to simulate this on simulator with API 26 (arm64). Granted all video processing than seems broken as the emulator likely simply doesn't support it, but if you open LiTr demo there and try to encode any video it just appears stuck. 

This video shows a recording of the issue in Android Studio. I set a breakpoint to manifest that the listener is never hit when it gets stuck in the release call. 
https://youtu.be/vo-QVk0agJE