### PR TITLE
Implementation of audio overlay filter

### DIFF
--- a/litr-demo/src/main/java/com/linkedin/android/litr/demo/data/TargetTrack.java
+++ b/litr-demo/src/main/java/com/linkedin/android/litr/demo/data/TargetTrack.java
@@ -7,6 +7,8 @@
  */
 package com.linkedin.android.litr.demo.data;
 
+import android.net.Uri;
+
 import androidx.annotation.NonNull;
 import androidx.databinding.BaseObservable;
 
@@ -14,6 +16,8 @@ public class TargetTrack extends BaseObservable {
     public int sourceTrackIndex;
     public boolean shouldInclude;
     public boolean shouldTranscode;
+    public boolean shouldApplyOverlay;
+    public Uri overlay;
     public MediaTrackFormat format;
 
     public TargetTrack(int sourceTrackIndex, boolean shouldInclude, boolean shouldTranscode, @NonNull MediaTrackFormat format) {

--- a/litr-demo/src/main/java/com/linkedin/android/litr/demo/data/TargetVideoTrack.java
+++ b/litr-demo/src/main/java/com/linkedin/android/litr/demo/data/TargetVideoTrack.java
@@ -7,12 +7,7 @@
  */
 package com.linkedin.android.litr.demo.data;
 
-import android.net.Uri;
-
 public class TargetVideoTrack extends TargetTrack {
-
-    public boolean shouldApplyOverlay;
-    public Uri overlay;
 
     public TargetVideoTrack(int sourceTrackIndex,
                             boolean shouldInclude,

--- a/litr-demo/src/main/java/com/linkedin/android/litr/demo/data/TranscodingConfigPresenter.java
+++ b/litr-demo/src/main/java/com/linkedin/android/litr/demo/data/TranscodingConfigPresenter.java
@@ -7,9 +7,12 @@
  */
 package com.linkedin.android.litr.demo.data;
 
+import android.content.Context;
 import android.widget.ImageView;
+
 import androidx.annotation.NonNull;
 import androidx.databinding.BindingAdapter;
+
 import com.bumptech.glide.Glide;
 import com.linkedin.android.litr.demo.BaseTransformationFragment;
 import com.linkedin.android.litr.demo.MediaPickerListener;
@@ -39,13 +42,21 @@ public class TranscodingConfigPresenter {
         targetTrack.notifyChange();
     }
 
-    public void onApplyOverlayChanged(@NonNull TargetVideoTrack targetTrack, boolean applyOverlay) {
+    public void onApplyOverlayChanged(@NonNull TargetTrack targetTrack, boolean applyOverlay) {
         targetTrack.shouldApplyOverlay = applyOverlay;
         targetTrack.notifyChange();
     }
 
     public void onPickOverlayClicked(@NonNull MediaPickerListener mediaPickerListener) {
         fragment.pickOverlay(mediaPickerListener);
+    }
+
+    public void onPickAudioOverlayClicked(@NonNull MediaPickerListener mediaPickerListener) {
+        fragment.pickAudio(mediaPickerListener);
+    }
+
+    public Context getContext() {
+        return fragment.getContext();
     }
 
     @BindingAdapter("overlayThumbnail")

--- a/litr-demo/src/main/java/com/linkedin/android/litr/demo/data/TransformationPresenter.java
+++ b/litr-demo/src/main/java/com/linkedin/android/litr/demo/data/TransformationPresenter.java
@@ -28,14 +28,13 @@ import com.linkedin.android.litr.TransformationOptions;
 import com.linkedin.android.litr.codec.Encoder;
 import com.linkedin.android.litr.codec.MediaCodecDecoder;
 import com.linkedin.android.litr.codec.MediaCodecEncoder;
-import com.linkedin.android.litr.codec.PassthroughDecoder;
 import com.linkedin.android.litr.codec.PassthroughBufferEncoder;
+import com.linkedin.android.litr.codec.PassthroughDecoder;
 import com.linkedin.android.litr.demo.R;
 import com.linkedin.android.litr.exception.MediaTransformationException;
 import com.linkedin.android.litr.filter.GlFilter;
 import com.linkedin.android.litr.filter.GlFrameRenderFilter;
 import com.linkedin.android.litr.filter.Transform;
-import com.linkedin.android.litr.filter.audio.VolumeFilter;
 import com.linkedin.android.litr.filter.audio.AudioOverlayFilter;
 import com.linkedin.android.litr.filter.video.gl.DefaultVideoFrameRenderFilter;
 import com.linkedin.android.litr.io.MediaExtractorMediaSource;
@@ -136,15 +135,13 @@ public class TransformationPresenter {
                             0.56f,
                             new PointF(0.6f, 0.4f),
                             30)));
-                } else if (targetTrack.format instanceof AudioTrackFormat) {
-                    if (audioVolumeConfig.enabled) {
-                        trackTransformBuilder.setRenderer(
-                                new AudioRenderer(
-                                        encoder,
-                                        Collections.singletonList(new VolumeFilter(audioVolumeConfig.value))
-                                )
-                        ).build();
-                    }
+                } else if (targetTrack.format instanceof AudioTrackFormat && targetTrack.overlay != null) {
+                    trackTransformBuilder.setRenderer(
+                            new AudioRenderer(
+                                    encoder,
+                                    Collections.singletonList(new AudioOverlayFilter(context, targetTrack.overlay))
+                            )
+                    );
                 }
 
                 trackTransforms.add(trackTransformBuilder.build());

--- a/litr-demo/src/main/java/com/linkedin/android/litr/demo/data/TransformationPresenter.java
+++ b/litr-demo/src/main/java/com/linkedin/android/litr/demo/data/TransformationPresenter.java
@@ -138,7 +138,7 @@ public class TransformationPresenter {
                     trackTransformBuilder.setRenderer(
                             new AudioRenderer(
                                     encoder,
-                                    Collections.singletonList(new AudioOverlayFilter(context, targetTrack.overlay, 0))
+                                    Collections.singletonList(new AudioOverlayFilter(context, targetTrack.overlay))
                             )
                     );
                 }

--- a/litr-demo/src/main/java/com/linkedin/android/litr/demo/view/AudioTrackViewHolder.java
+++ b/litr-demo/src/main/java/com/linkedin/android/litr/demo/view/AudioTrackViewHolder.java
@@ -7,14 +7,20 @@
  */
 package com.linkedin.android.litr.demo.view;
 
+import android.content.Context;
+import android.content.Intent;
+import android.net.Uri;
+
 import androidx.annotation.NonNull;
 import androidx.recyclerview.widget.RecyclerView;
+
+import com.linkedin.android.litr.demo.MediaPickerListener;
 import com.linkedin.android.litr.demo.data.AudioTrackFormat;
 import com.linkedin.android.litr.demo.data.TargetAudioTrack;
 import com.linkedin.android.litr.demo.data.TranscodingConfigPresenter;
 import com.linkedin.android.litr.demo.databinding.ItemAudioTrackBinding;
 
-public class AudioTrackViewHolder extends RecyclerView.ViewHolder {
+public class AudioTrackViewHolder extends RecyclerView.ViewHolder implements MediaPickerListener {
 
     private ItemAudioTrackBinding binding;
 
@@ -30,5 +36,26 @@ public class AudioTrackViewHolder extends RecyclerView.ViewHolder {
         binding.setPresenter(presenter);
         binding.setAudioTrack(sourceTrackFormat);
         binding.executePendingBindings();
+
+        binding.buttonPickAudioOverlay.setOnClickListener( view ->
+                presenter.onPickAudioOverlayClicked(AudioTrackViewHolder.this)
+        );
+
+        binding.playAudioOverlay.setOnClickListener( view -> {
+            Context context = presenter.getContext();
+            Uri audioOverlayUri = binding.getTargetTrack().overlay;
+
+            if (context != null && audioOverlayUri != null) {
+                Intent playIntent = new Intent(Intent.ACTION_VIEW);
+                playIntent.setDataAndType(audioOverlayUri, context.getContentResolver().getType(audioOverlayUri));
+                context.startActivity(playIntent);
+            }
+        });
+    }
+
+    @Override
+    public void onMediaPicked(@NonNull Uri uri) {
+        binding.getTargetTrack().overlay = uri;
+        binding.getTargetTrack().notifyChange();
     }
 }

--- a/litr-demo/src/main/res/layout/item_audio_track.xml
+++ b/litr-demo/src/main/res/layout/item_audio_track.xml
@@ -62,6 +62,17 @@
                 android:visibility="@{targetTrack.shouldInclude ? View.VISIBLE : View.GONE}"
                 android:onCheckedChanged="@{(switch, checked) -> presenter.onTranscodeTrackChanged(targetTrack, checked)}"/>
 
+            <CheckBox
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="@string/overlay"
+                android:textStyle="bold"
+                android:padding="@dimen/cell_padding"
+                android:checked="@={targetTrack.shouldApplyOverlay}"
+                android:visibility="@{targetTrack.shouldInclude ? View.VISIBLE : View.GONE}"
+                android:onCheckedChanged="@{(switch, checked) -> presenter.onApplyOverlayChanged(targetTrack, checked)}"/>
+
         </LinearLayout>
 
         <TableLayout
@@ -202,6 +213,29 @@
             </TableRow>
 
         </TableLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:visibility="@{targetTrack.shouldApplyOverlay ? View.VISIBLE : View.GONE}"
+            android:orientation="horizontal">
+
+            <Button
+                android:id="@+id/button_pick_audio_overlay"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:gravity="center"
+                android:text="@string/pick_audio_overlay"/>
+
+            <ImageButton
+                android:id="@+id/play_audio_overlay"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:visibility="@{targetTrack.overlay == null ? View.GONE : View.VISIBLE}"
+                android:src="@android:drawable/ic_media_play" />
+
+        </LinearLayout>
 
     </LinearLayout>
 

--- a/litr-demo/src/main/res/values/strings.xml
+++ b/litr-demo/src/main/res/values/strings.xml
@@ -32,6 +32,7 @@
     <string name="pick_video">Pick Video</string>
     <string name="pick_audio">Pick Audio</string>
     <string name="pick_video_overlay">Pick Video Overlay</string>
+    <string name="pick_audio_overlay">Pick Audio Overlay</string>
     <string name="source_path" formatted="true">Uri: %s</string>
     <string name="size" formatted="true">Size: %.2f MB</string>
 

--- a/litr-filters/src/main/java/com/linkedin/android/litr/filter/audio/AudioOverlayFilter.kt
+++ b/litr-filters/src/main/java/com/linkedin/android/litr/filter/audio/AudioOverlayFilter.kt
@@ -112,13 +112,13 @@ class AudioOverlayFilter(
 
             renderOverlay(frameBuffer)
         }
+    }
 
-        if ((frame.bufferInfo.flags and MediaCodec.BUFFER_FLAG_END_OF_STREAM) != 0) {
-            decoder.stop()
-            decoder.release()
-            mediaSource.release()
-            bufferPool.clear()
-        }
+    override fun release() {
+        decoder.stop()
+        decoder.release()
+        mediaSource.release()
+        bufferPool.clear()
     }
 
     private fun sufficientOverlayFramesInQueue(frameBuffer: ByteBuffer): Boolean {

--- a/litr-filters/src/main/java/com/linkedin/android/litr/filter/audio/AudioOverlayFilter.kt
+++ b/litr-filters/src/main/java/com/linkedin/android/litr/filter/audio/AudioOverlayFilter.kt
@@ -40,7 +40,8 @@ class AudioOverlayFilter(
 
     private val renderQueue = LinkedBlockingDeque<ByteBuffer>()
     private val bufferPool = ByteBufferPool(true)
-    private lateinit var audioProcessor: AudioProcessor
+    private val audioProcessorFactory = AudioProcessorFactory()
+    private var audioProcessor: AudioProcessor? = null
 
     private var overlayTrack = 0
     private var channelCount = UNDEFINED_VALUE
@@ -90,7 +91,8 @@ class AudioOverlayFilter(
 
         samplingRatio = sampleRate.toDouble() / overlaySampleRate.toDouble()
 
-        audioProcessor = AudioProcessorFactory().createAudioProcessor(
+        audioProcessor?.release()
+        audioProcessor = audioProcessorFactory.createAudioProcessor(
             mediaSource.getTrackFormat(overlayTrack),
             mediaFormat
         )
@@ -173,7 +175,7 @@ class AudioOverlayFilter(
 
         val processedBuffer = bufferPool.get(targetBufferCapacity)
         val processedFrame = Frame(outputTag, processedBuffer, MediaCodec.BufferInfo())
-        audioProcessor.processFrame(decoderOutputFrame, processedFrame)
+        audioProcessor?.processFrame(decoderOutputFrame, processedFrame)
 
         decoder.releaseOutputFrame(outputTag, false)
 

--- a/litr-filters/src/main/java/com/linkedin/android/litr/filter/audio/AudioOverlayFilter.kt
+++ b/litr-filters/src/main/java/com/linkedin/android/litr/filter/audio/AudioOverlayFilter.kt
@@ -1,0 +1,151 @@
+package com.linkedin.android.litr.filter.audio
+
+import android.content.Context
+import android.media.MediaCodec
+import android.media.MediaFormat
+import android.net.Uri
+import android.util.Log
+import com.linkedin.android.litr.codec.Frame
+import com.linkedin.android.litr.codec.MediaCodecDecoder
+import com.linkedin.android.litr.exception.TrackTranscoderException
+import com.linkedin.android.litr.filter.BufferFilter
+import com.linkedin.android.litr.io.MediaExtractorMediaSource
+import com.linkedin.android.litr.render.AudioProcessor
+import com.linkedin.android.litr.render.AudioProcessorFactory
+import com.linkedin.android.litr.transcoder.TrackTranscoder
+import com.linkedin.android.litr.utils.ByteBufferPool
+import kotlin.math.ceil
+
+private const val BYTES_PER_SAMPLE = 2 // android uses 2 bytes per audio sample
+private const val UNDEFINED_VALUE = -1
+
+private const val TAG = "AudioOverlayFilter"
+
+class AudioOverlayFilter(
+    context: Context,
+    uri: Uri,
+    private val overlayTrack: Int = 0
+) : BufferFilter {
+
+    private val mediaSource = MediaExtractorMediaSource(context, uri)
+    private val decoder = MediaCodecDecoder()
+
+    private val overlayChannelCount: Int
+    private val overlaySampleRate: Int
+
+    private val bufferPool = ByteBufferPool(true)
+    private lateinit var audioProcessor: AudioProcessor
+
+    private var channelCount = UNDEFINED_VALUE
+    private var sampleRate = UNDEFINED_VALUE
+    private var samplingRatio = 1.0
+
+    init {
+        val mediaFormats = mutableListOf<MediaFormat>()
+        for (track in 0 until mediaSource.trackCount) {
+            mediaFormats.add(track, mediaSource.getTrackFormat(track))
+        }
+        val audioMediaFormat = mediaFormats.firstOrNull { mediaFormat ->
+            mediaFormat.containsKey(MediaFormat.KEY_MIME) &&
+                mediaFormat.getString(MediaFormat.KEY_MIME)?.startsWith("audio") == true
+        } ?: throw IllegalArgumentException("Audio overlay does not have an audio track")
+
+        overlayChannelCount = if (audioMediaFormat.containsKey(MediaFormat.KEY_CHANNEL_COUNT)) {
+            audioMediaFormat.getInteger(MediaFormat.KEY_CHANNEL_COUNT)
+        } else {
+            throw IllegalArgumentException("Audio overlay track must have channel count in MediaFormat")
+        }
+
+        overlaySampleRate = if (audioMediaFormat.containsKey(MediaFormat.KEY_SAMPLE_RATE)) {
+            audioMediaFormat.getInteger(MediaFormat.KEY_SAMPLE_RATE)
+        } else {
+            throw IllegalArgumentException("Audio overlay track must have channel count in MediaFormat")
+        }
+    }
+
+    override fun init(mediaFormat: MediaFormat?) {
+        channelCount = if (mediaFormat?.containsKey(MediaFormat.KEY_CHANNEL_COUNT) == true) {
+            mediaFormat.getInteger(MediaFormat.KEY_CHANNEL_COUNT)
+        } else {
+            UNDEFINED_VALUE
+        }
+
+        sampleRate = if (mediaFormat?.containsKey(MediaFormat.KEY_SAMPLE_RATE) == true) {
+            mediaFormat.getInteger(MediaFormat.KEY_SAMPLE_RATE)
+        } else {
+            UNDEFINED_VALUE
+        }
+
+        samplingRatio = sampleRate.toDouble() / overlaySampleRate.toDouble()
+
+        audioProcessor = AudioProcessorFactory().createAudioProcessor(
+            mediaSource.getTrackFormat(overlayTrack),
+            mediaFormat
+        )
+
+        mediaSource.selectTrack(overlayTrack)
+
+        decoder.init(mediaSource.getTrackFormat(overlayTrack), null)
+        decoder.start()
+    }
+
+    override fun apply(frame: Frame) {
+        Log.d(TAG, "frame ${frame.bufferInfo.presentationTimeUs}")
+        val overlayBuffer = getNextOverlayFrame()
+    }
+
+    private fun getNextOverlayFrame(): Frame? {
+        while (mediaSource.sampleTrackIndex != overlayTrack &&
+            mediaSource.sampleTrackIndex != TrackTranscoder.NO_SELECTED_TRACK) {
+            // if source contains multiple tracks, skip samples for other tracks
+            // until we are reading from the track we need
+            mediaSource.advance()
+        }
+
+        // get the input frame from the decoder, we will read into it
+        var inputTag = MediaCodec.INFO_TRY_AGAIN_LATER
+        while (inputTag < 0) {
+            inputTag = decoder.dequeueInputFrame(-1)
+        }
+        val decoderInputFrame = decoder.getInputFrame(inputTag)
+            ?: throw TrackTranscoderException(TrackTranscoderException.Error.NO_FRAME_AVAILABLE)
+
+        val bytesRead = mediaSource.readSampleData(decoderInputFrame.buffer!!, 0)
+        val sampleTime = mediaSource.sampleTime
+        val sampleFlags = mediaSource.sampleFlags
+
+        Log.d(TAG, "Overlay frame sample time $sampleTime")
+
+        if (bytesRead == 0) {
+            // nothing was read from the source
+            return null
+        }
+
+        // send the frame to decoder and advance the source position
+        decoderInputFrame.bufferInfo[0, bytesRead, sampleTime] = sampleFlags
+        decoder.queueInputFrame(decoderInputFrame)
+        mediaSource.advance()
+
+        // get the decoder output (decoded frame)
+        var outputTag = MediaCodec.INFO_TRY_AGAIN_LATER
+        while (outputTag < 0) {
+            outputTag = decoder.dequeueOutputFrame(-1)
+        }
+
+        val decoderOutputFrame = decoder.getOutputFrame(outputTag)
+            ?: throw TrackTranscoderException(TrackTranscoderException.Error.NO_FRAME_AVAILABLE)
+
+        // resize decoded overlay frame to match the target frame it will be applied to
+        val sourceSampleCount = decoderOutputFrame.bufferInfo.size / (BYTES_PER_SAMPLE * overlayChannelCount)
+        val estimatedTargetSampleCount = ceil(sourceSampleCount * samplingRatio).toInt()
+        val targetBufferCapacity = estimatedTargetSampleCount * channelCount * BYTES_PER_SAMPLE
+
+        val processedBuffer = bufferPool.get(targetBufferCapacity)
+        val processedFrame = Frame(outputTag, processedBuffer, MediaCodec.BufferInfo())
+        audioProcessor.processFrame(decoderOutputFrame, processedFrame)
+
+        decoder.releaseOutputFrame(outputTag, false)
+
+        return processedFrame
+    }
+}

--- a/litr-filters/src/main/java/com/linkedin/android/litr/filter/audio/AudioOverlayFilter.kt
+++ b/litr-filters/src/main/java/com/linkedin/android/litr/filter/audio/AudioOverlayFilter.kt
@@ -220,7 +220,7 @@ class AudioOverlayFilter(
 
     private fun applyOverlaySample(frameBuffer: ByteBuffer, overlayBuffer: ByteBuffer, byteCount: Int) {
         repeat(byteCount / 2) {
-            val mixedValue = (frameBuffer.short + overlayBuffer.short) / 2
+            val mixedValue = frameBuffer.short + overlayBuffer.short
             frameBuffer.putShort(frameBuffer.position() - 2, mixedValue.toShort())
         }
     }

--- a/litr-filters/src/main/java/com/linkedin/android/litr/filter/audio/AudioOverlayFilter.kt
+++ b/litr-filters/src/main/java/com/linkedin/android/litr/filter/audio/AudioOverlayFilter.kt
@@ -4,11 +4,13 @@ import android.content.Context
 import android.media.MediaCodec
 import android.media.MediaFormat
 import android.net.Uri
+import com.linkedin.android.litr.codec.Decoder
 import com.linkedin.android.litr.codec.Frame
 import com.linkedin.android.litr.codec.MediaCodecDecoder
 import com.linkedin.android.litr.exception.TrackTranscoderException
 import com.linkedin.android.litr.filter.BufferFilter
 import com.linkedin.android.litr.io.MediaExtractorMediaSource
+import com.linkedin.android.litr.io.MediaSource
 import com.linkedin.android.litr.render.AudioProcessor
 import com.linkedin.android.litr.render.AudioProcessorFactory
 import com.linkedin.android.litr.transcoder.TrackTranscoder
@@ -21,10 +23,15 @@ private const val UNDEFINED_VALUE = -1
 
 private const val TAG = "AudioOverlayFilter"
 
-class AudioOverlayFilter(context: Context, uri: Uri) : BufferFilter {
+class AudioOverlayFilter(
+    private val mediaSource: MediaSource,
+    private val decoder: Decoder
+) : BufferFilter {
 
-    private val mediaSource = MediaExtractorMediaSource(context, uri)
-    private val decoder = MediaCodecDecoder()
+    constructor(context: Context, uri: Uri) : this(
+        MediaExtractorMediaSource(context, uri),
+        MediaCodecDecoder()
+    )
 
     private val overlayChannelCount: Int
     private val overlaySampleRate: Int

--- a/litr-filters/src/main/java/com/linkedin/android/litr/filter/audio/AudioOverlayFilter.kt
+++ b/litr-filters/src/main/java/com/linkedin/android/litr/filter/audio/AudioOverlayFilter.kt
@@ -108,9 +108,6 @@ class AudioOverlayFilter(
         }
 
         renderOverlay(frame)
-
-        // switch the buffer to "read" mode
-        frame.buffer?.flip()
     }
 
     private fun sufficientOverlayFramesInQueue(frame: Frame): Boolean {
@@ -189,6 +186,9 @@ class AudioOverlayFilter(
                 }
             }
         }
+
+        // reset the position back to 0 by flipping the frame to "read" mode
+        frame.buffer?.flip()
     }
 
     private fun applyOverlaySample(frameBuffer: ByteBuffer, overlayFrameBuffer: ByteBuffer, byteCount: Int) {

--- a/litr-filters/src/main/java/com/linkedin/android/litr/filter/audio/AudioOverlayFilter.kt
+++ b/litr-filters/src/main/java/com/linkedin/android/litr/filter/audio/AudioOverlayFilter.kt
@@ -110,6 +110,13 @@ class AudioOverlayFilter(
 
             renderOverlay(frameBuffer)
         }
+
+        if ((frame.bufferInfo.flags and MediaCodec.BUFFER_FLAG_END_OF_STREAM) != 0) {
+            decoder.stop()
+            decoder.release()
+            mediaSource.release()
+            bufferPool.clear()
+        }
     }
 
     private fun sufficientOverlayFramesInQueue(frameBuffer: ByteBuffer): Boolean {

--- a/litr/src/main/java/com/linkedin/android/litr/render/AudioProcessorFactory.kt
+++ b/litr/src/main/java/com/linkedin/android/litr/render/AudioProcessorFactory.kt
@@ -9,7 +9,7 @@ package com.linkedin.android.litr.render
 
 import android.media.MediaFormat
 
-internal class AudioProcessorFactory {
+class AudioProcessorFactory {
 
     fun createAudioProcessor(sourceMediaFormat: MediaFormat?, targetMediaFormat: MediaFormat?): AudioProcessor {
         return if (sourceMediaFormat != null &&

--- a/litr/src/main/java/com/linkedin/android/litr/utils/ByteBufferPool.kt
+++ b/litr/src/main/java/com/linkedin/android/litr/utils/ByteBufferPool.kt
@@ -15,7 +15,7 @@ import java.util.concurrent.LinkedBlockingQueue
  * A helper thread safe class that manages a [ByteBuffer] pool, to increase buffer reuse.
  * This class is very useful in classes like renderers because they work with sequences of same sized buffers.
  */
-internal class ByteBufferPool(private val isDirect: Boolean = false) {
+class ByteBufferPool(private val isDirect: Boolean = false) {
 
     private val bufferQueue = LinkedBlockingQueue<ByteBuffer>()
 


### PR DESCRIPTION
Implementation of audio overlay filter, which "mixes in" an audio track over audio track(s) of source media. This functionality  could be used to add a voiceover, or background music.

- It is a pretty complicated filter, that reads an audio frame from a uri, decodes it, resamples/channel mixes it to match the media audio configuration, then "mixes" it with the audio track frame. 
- When reading overlay frames, we make sure that we have enough samples to apply to all audio frame samples. We queue those samples in internal render queue.
- When mixing in overlay frames, we consume overlay samples from the render queue until all audio frame samples are modified.
- We use `AudioProcessorFactory` and `BufferPool` from main `litr` library, so they had to be made public.