### PR TITLE
Allocate/deallocate native input/output buffers on init/release

### DIFF
--- a/litr/src/main/cpp/audio-processor.cpp
+++ b/litr/src/main/cpp/audio-processor.cpp
@@ -14,6 +14,9 @@ MultiChannelResampler* oboeResampler = nullptr;
 int inputChannelCount = -1;
 int outputChannelCount = -1;
 
+float* resamplerInputBuffer = nullptr;
+float* resamplerOutputBuffer = nullptr;
+
 void populateInputBuffer(const jbyte *sourceBuffer, int sourceSample, float* inputBuffer, int sourceChannelCount, int targetChannelCount);
 
 extern "C" JNIEXPORT void JNICALL
@@ -38,6 +41,9 @@ Java_com_linkedin_android_litr_render_OboeAudioProcessor_initProcessor(
 
     inputChannelCount = sourceChannelCount;
     outputChannelCount = targetChannelCount;
+
+    resamplerInputBuffer = new float[outputChannelCount];
+    resamplerOutputBuffer = new float[outputChannelCount];
 }
 
 extern "C" JNIEXPORT int JNICALL
@@ -50,9 +56,6 @@ Java_com_linkedin_android_litr_render_OboeAudioProcessor_processAudioFrame(
     if (oboeResampler != nullptr && inputChannelCount > 0 && outputChannelCount > 0) {
         auto sourceBuffer = (jbyte *) env->GetDirectBufferAddress(jsourceBuffer);
         auto targetBuffer = (jbyte *) env->GetDirectBufferAddress(jtargetBuffer);
-
-        auto resamplerInputBuffer = new float[outputChannelCount];
-        auto resamplerOutputBuffer = new float[outputChannelCount];
 
         int framesProcessed = 0;
         int inputFramesLeft = sampleCount;
@@ -93,6 +96,14 @@ Java_com_linkedin_android_litr_render_OboeAudioProcessor_releaseProcessor(
         oboeResampler = nullptr;
         inputChannelCount = -1;
         outputChannelCount = -1;
+    }
+    if (resamplerInputBuffer != nullptr) {
+        delete resamplerInputBuffer;
+        resamplerInputBuffer = nullptr;
+    }
+    if (resamplerOutputBuffer != nullptr) {
+        delete resamplerOutputBuffer;
+        resamplerOutputBuffer = nullptr;
     }
 }
 

--- a/litr/src/main/cpp/audio-processor.cpp
+++ b/litr/src/main/cpp/audio-processor.cpp
@@ -98,11 +98,11 @@ Java_com_linkedin_android_litr_render_OboeAudioProcessor_releaseProcessor(
         outputChannelCount = -1;
     }
     if (resamplerInputBuffer != nullptr) {
-        delete resamplerInputBuffer;
+        delete[] resamplerInputBuffer;
         resamplerInputBuffer = nullptr;
     }
     if (resamplerOutputBuffer != nullptr) {
-        delete resamplerOutputBuffer;
+        delete[] resamplerOutputBuffer;
         resamplerOutputBuffer = nullptr;
     }
 }


### PR DESCRIPTION
We were allocating native buffers for Oboe audio processor on each frame and not de-allocating them, as was pointed out in https://github.com/linkedin/LiTr/issues/201 
Instead, now we are allocating them when we initialize the resampler (when we know the buffer size) and deallocating them when we release the resampler. 