### PR TITLE
Add ability to reduce the target video's frame rate

### DIFF
--- a/litr-demo/src/main/res/layout/item_video_track.xml
+++ b/litr-demo/src/main/res/layout/item_video_track.xml
@@ -236,16 +236,19 @@
                     android:paddingStart="@dimen/cell_padding"
                     android:paddingEnd="@dimen/cell_padding"/>
 
-                <TextView
+                <EditText
                     android:id="@+id/target_video_frame_rate"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="@{Integer.toString(targetTrack.getTrackFormat().frameRate)}"
+                    android:text="@={Converter.integerToString(targetTrack.getTrackFormat().frameRate)}"
+                    android:inputType="number"
                     android:textAlignment="textEnd"
                     android:paddingStart="@dimen/cell_padding"
                     android:paddingEnd="@dimen/cell_padding"
                     android:paddingTop="0dp"
-                    android:paddingBottom="@dimen/edit_text_padding"/>
+                    android:paddingBottom="@dimen/edit_text_padding"
+                    android:textSize="15sp"/>
+
             </TableRow>
 
             <TableRow

--- a/litr/src/main/java/com/linkedin/android/litr/render/FrameDropper.kt
+++ b/litr/src/main/java/com/linkedin/android/litr/render/FrameDropper.kt
@@ -1,0 +1,33 @@
+package com.linkedin.android.litr.render
+
+/**
+ * A simple video frame dropper which provides a [shouldRender] function. May be used when the
+ * target video should have a lower frame rate than its source video.
+ *
+ * @see <a href="https://github.com/linkedin/LiTr/issues/120#issuecomment-859318538">Suggested by @alexvasilkov</a>
+ */
+internal interface FrameDropper {
+
+    fun shouldRender(): Boolean
+}
+
+class DefaultFrameDropper(
+    inputFps: Int,
+    outputFps: Int,
+) : FrameDropper {
+
+    private val inputSpf = 1.0 / inputFps
+    private val outputSpf = 1.0 / outputFps
+    private var currentSpf = 0.0
+    private var frameCount = 0
+
+    override fun shouldRender(): Boolean {
+        currentSpf += inputSpf
+
+        return when {
+            frameCount++ == 0 -> true
+            currentSpf > outputSpf -> true.also { currentSpf -= outputSpf }
+            else -> false
+        }
+    }
+}

--- a/litr/src/main/java/com/linkedin/android/litr/transcoder/TrackTranscoder.java
+++ b/litr/src/main/java/com/linkedin/android/litr/transcoder/TrackTranscoder.java
@@ -29,7 +29,8 @@ public abstract class TrackTranscoder {
 
     public static final int RESULT_OUTPUT_MEDIA_FORMAT_CHANGED = 1;
     public static final int RESULT_FRAME_PROCESSED = 2;
-    public static final int RESULT_EOS_REACHED = 3;
+    public static final int RESULT_FRAME_SKIPPED = 3;
+    public static final int RESULT_EOS_REACHED = 4;
 
     @NonNull protected final MediaSource mediaSource;
     @NonNull protected final MediaTarget mediaMuxer;

--- a/litr/src/main/java/com/linkedin/android/litr/transcoder/VideoTrackTranscoder.java
+++ b/litr/src/main/java/com/linkedin/android/litr/transcoder/VideoTrackTranscoder.java
@@ -295,4 +295,10 @@ public class VideoTrackTranscoder extends TrackTranscoder {
 
         return encodeFrameResult;
     }
+
+    @VisibleForTesting
+    @Nullable
+    public FrameDropper getFrameDropper() {
+        return frameDropper;
+    }
 }

--- a/litr/src/main/java/com/linkedin/android/litr/transcoder/VideoTrackTranscoder.java
+++ b/litr/src/main/java/com/linkedin/android/litr/transcoder/VideoTrackTranscoder.java
@@ -149,6 +149,8 @@ public class VideoTrackTranscoder extends TrackTranscoder {
             && lastDecodeFrameResult == RESULT_EOS_REACHED
             && lastEncodeFrameResult == RESULT_EOS_REACHED) {
             result = RESULT_EOS_REACHED;
+        } else if (lastDecodeFrameResult == RESULT_FRAME_SKIPPED) {
+            result = RESULT_FRAME_SKIPPED;
         }
 
         return result;

--- a/litr/src/main/java/com/linkedin/android/litr/transcoder/VideoTrackTranscoder.java
+++ b/litr/src/main/java/com/linkedin/android/litr/transcoder/VideoTrackTranscoder.java
@@ -11,6 +11,7 @@ import android.media.MediaCodec;
 import android.media.MediaFormat;
 import android.util.Log;
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.annotation.RestrictTo;
 import androidx.annotation.VisibleForTesting;
 import com.linkedin.android.litr.codec.Decoder;
@@ -19,6 +20,8 @@ import com.linkedin.android.litr.codec.Frame;
 import com.linkedin.android.litr.exception.TrackTranscoderException;
 import com.linkedin.android.litr.io.MediaSource;
 import com.linkedin.android.litr.io.MediaTarget;
+import com.linkedin.android.litr.render.DefaultFrameDropper;
+import com.linkedin.android.litr.render.FrameDropper;
 import com.linkedin.android.litr.render.GlVideoRenderer;
 import com.linkedin.android.litr.render.Renderer;
 import com.linkedin.android.litr.utils.MediaFormatUtils;
@@ -40,6 +43,7 @@ public class VideoTrackTranscoder extends TrackTranscoder {
 
     @NonNull private MediaFormat sourceVideoFormat;
     @NonNull private MediaFormat targetVideoFormat;
+    @Nullable private FrameDropper frameDropper;
 
     VideoTrackTranscoder(@NonNull MediaSource mediaSource,
                          int sourceTrack,
@@ -67,14 +71,33 @@ public class VideoTrackTranscoder extends TrackTranscoder {
 
     private void initCodecs() throws TrackTranscoderException {
         sourceVideoFormat = mediaSource.getTrackFormat(sourceTrack);
-        Number sourceFrameRate = MediaFormatUtils.getNumber(sourceVideoFormat, MediaFormat.KEY_FRAME_RATE);
-        if (sourceFrameRate != null) {
-            targetVideoFormat.setInteger(MediaFormat.KEY_FRAME_RATE, sourceFrameRate.intValue());
-        }
+        frameDropper = createFrameDropper();
 
         encoder.init(targetFormat);
         renderer.init(encoder.createInputSurface(), sourceVideoFormat, targetVideoFormat);
         decoder.init(sourceVideoFormat, renderer.getInputSurface());
+    }
+
+    /**
+     * Initialize and return a {@link FrameDropper} if required.
+     *
+     * @return {@link FrameDropper}, or null if we shouldn't skip any frames
+     */
+    @Nullable
+    private FrameDropper createFrameDropper() {
+        @Nullable final Number sourceFrameRate = MediaFormatUtils
+                .getNumber(sourceVideoFormat, MediaFormat.KEY_FRAME_RATE);
+        @Nullable Number targetFrameRate = MediaFormatUtils
+                .getNumber(targetVideoFormat, MediaFormat.KEY_FRAME_RATE);
+        if (targetFrameRate == null || targetFrameRate.intValue() < 1) {
+            targetFrameRate = sourceFrameRate;
+        }
+
+        if (sourceFrameRate != null && sourceFrameRate.intValue() > targetFrameRate.intValue()) {
+            return new DefaultFrameDropper(sourceFrameRate.intValue(), targetFrameRate.intValue());
+        } else {
+            return null;
+        }
     }
 
     @Override
@@ -195,9 +218,14 @@ public class VideoTrackTranscoder extends TrackTranscoder {
             } else {
                 boolean isFrameAfterSelectionStart = frame.bufferInfo.presentationTimeUs >= sourceMediaSelection.getStart();
                 decoder.releaseOutputFrame(tag, isFrameAfterSelectionStart);
-                if (isFrameAfterSelectionStart) {
+
+                final boolean shouldRender = frameDropper == null || frameDropper.shouldRender();
+
+                if (isFrameAfterSelectionStart && shouldRender) {
                     renderer.renderFrame(null,
                             TimeUnit.MICROSECONDS.toNanos(frame.bufferInfo.presentationTimeUs - sourceMediaSelection.getStart()));
+                } else {
+                    decodeFrameResult = RESULT_FRAME_SKIPPED;
                 }
             }
         } else {

--- a/litr/src/test/java/com/linkedin/android/litr/transcoder/FrameDropperShould.kt
+++ b/litr/src/test/java/com/linkedin/android/litr/transcoder/FrameDropperShould.kt
@@ -1,0 +1,131 @@
+package com.linkedin.android.litr.transcoder
+
+import android.media.MediaFormat
+import com.linkedin.android.litr.codec.Decoder
+import com.linkedin.android.litr.codec.Encoder
+import com.linkedin.android.litr.io.MediaRange
+import com.linkedin.android.litr.io.MediaSource
+import com.linkedin.android.litr.io.MediaTarget
+import com.linkedin.android.litr.render.GlVideoRenderer
+import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.MatcherAssert.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.mockito.ArgumentMatchers
+import org.mockito.Mock
+import org.mockito.Mockito
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.doReturn
+import org.mockito.MockitoAnnotations
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+private const val VIDEO_TRACK = 0
+
+class FrameDropperShould {
+
+    @Mock
+    lateinit var sourceFormat: MediaFormat
+
+    @Mock
+    lateinit var targetFormat: MediaFormat
+
+    @Mock
+    lateinit var mediaSource: MediaSource
+
+    @Mock
+    lateinit var mediaTarget: MediaTarget
+
+    @Mock
+    lateinit var encoder: Encoder
+
+    @Mock
+    lateinit var decoder: Decoder
+
+    @Mock
+    lateinit var renderer: GlVideoRenderer
+
+    private var videoTrackTranscoder: VideoTrackTranscoder? = null
+
+    @Before
+    @Throws(Exception::class)
+    fun setup() {
+        MockitoAnnotations.openMocks(this)
+
+        doReturn(sourceFormat).`when`(mediaSource).getTrackFormat(ArgumentMatchers.anyInt())
+        `when`(mediaSource.selection).thenReturn(MediaRange(0, Long.MAX_VALUE))
+
+        `when`(sourceFormat.containsKey(MediaFormat.KEY_FRAME_RATE)).thenReturn(true)
+        `when`(targetFormat.containsKey(MediaFormat.KEY_FRAME_RATE)).thenReturn(true)
+    }
+
+    private fun initTranscoder() {
+        videoTrackTranscoder = Mockito.spy(
+            VideoTrackTranscoder(
+                mediaSource,
+                VIDEO_TRACK,
+                mediaTarget,
+                VIDEO_TRACK,
+                targetFormat,
+                renderer,
+                decoder,
+                encoder
+            )
+        ).also { it.start() }
+    }
+
+    @Test
+    fun `not initialize frame dropper when source and target have the same frame rate`() {
+        `when`(sourceFormat.getInteger(MediaFormat.KEY_FRAME_RATE)).thenReturn(60)
+        `when`(targetFormat.getInteger(MediaFormat.KEY_FRAME_RATE)).thenReturn(60)
+        initTranscoder()
+
+        videoTrackTranscoder?.frameDropper.run {
+            assertNull(this)
+        }
+    }
+
+    @Test
+    fun `not initialize frame dropper when the target has a higher frame rate than its source`() {
+        `when`(sourceFormat.getInteger(MediaFormat.KEY_FRAME_RATE)).thenReturn(30)
+        `when`(targetFormat.getInteger(MediaFormat.KEY_FRAME_RATE)).thenReturn(60)
+        initTranscoder()
+
+        videoTrackTranscoder?.frameDropper.run {
+            assertNull(this)
+        }
+    }
+
+    @Test
+    fun `always render the first frame`() {
+        `when`(sourceFormat.getInteger(MediaFormat.KEY_FRAME_RATE)).thenReturn(60)
+        `when`(targetFormat.getInteger(MediaFormat.KEY_FRAME_RATE)).thenReturn(30)
+        initTranscoder()
+
+        videoTrackTranscoder?.frameDropper.run {
+            assertNotNull(this)
+            assertThat(shouldRender(), equalTo(true))
+        }
+
+    }
+
+    @Test
+    fun `render a quarter of the frames if the target's frame rate is four times less`() {
+        val sourceFrameAmount = 200
+        val sourceFrameRate = 60
+
+        `when`(sourceFormat.getInteger(MediaFormat.KEY_FRAME_RATE)).thenReturn(sourceFrameRate)
+        `when`(targetFormat.getInteger(MediaFormat.KEY_FRAME_RATE)).thenReturn(sourceFrameRate / 4)
+        initTranscoder()
+
+        videoTrackTranscoder?.frameDropper.run {
+            assertNotNull(this)
+            assertThat(
+                (0 until sourceFrameAmount)
+                    .map { shouldRender() }
+                    .filter { it }
+                    .size,
+                equalTo(sourceFrameAmount / 4))
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a simple `FrameDropper` as recommended by alexvaliskov in [issue #120](https://github.com/linkedin/LiTr/issues/120#issuecomment-859318538). This allows users to reduce the target video's frame rate, which has been a requested feature for some time.

I've also included some tests and the ability to alter the frame rate in the demo app, which makes it easy to runtime test this feature.