### PR TITLE
Add TransformationOptions flag to remove audio track(s)

### DIFF
--- a/litr-demo/src/main/java/com/linkedin/android/litr/demo/data/TransformationPresenter.java
+++ b/litr-demo/src/main/java/com/linkedin/android/litr/demo/data/TransformationPresenter.java
@@ -644,7 +644,6 @@ public class TransformationPresenter {
         TransformationOptions transformationOptions = new TransformationOptions.Builder()
                 .setGranularity(MediaTransformer.GRANULARITY_DEFAULT)
                 .setSourceMediaRange(mediaRange)
-                .setRemoveAudio(true)
                 .build();
 
         MediaFormat targetVideoFormat = MediaFormat.createVideoFormat(

--- a/litr-demo/src/main/java/com/linkedin/android/litr/demo/data/TransformationPresenter.java
+++ b/litr-demo/src/main/java/com/linkedin/android/litr/demo/data/TransformationPresenter.java
@@ -644,6 +644,7 @@ public class TransformationPresenter {
         TransformationOptions transformationOptions = new TransformationOptions.Builder()
                 .setGranularity(MediaTransformer.GRANULARITY_DEFAULT)
                 .setSourceMediaRange(mediaRange)
+                .setRemoveAudio(true)
                 .build();
 
         MediaFormat targetVideoFormat = MediaFormat.createVideoFormat(

--- a/litr/src/main/java/com/linkedin/android/litr/TransformationOptions.java
+++ b/litr/src/main/java/com/linkedin/android/litr/TransformationOptions.java
@@ -25,21 +25,25 @@ import java.util.List;
  *  - callback granularity (how frequently listener is called back during transformation)
  *  - video filters, in order they must be applied
  *  - source media range, if only part of {@link com.linkedin.android.litr.io.MediaSource} should be used
+ *  - ability to mute video by removing audio track(s)
  */
 public class TransformationOptions {
     @IntRange(from = GRANULARITY_NONE) public final int granularity;
     @Nullable public final List<GlFilter> videoFilters;
     @Nullable public final List<BufferFilter> audioFilters;
     @NonNull public final MediaRange sourceMediaRange;
+    public final boolean removeAudio;
 
     private TransformationOptions(@IntRange(from = GRANULARITY_NONE) int granularity,
                                   @Nullable List<GlFilter> videoFilters,
                                   @Nullable List<BufferFilter> audioFilters,
-                                  @Nullable MediaRange sourceMediaRange) {
+                                  @Nullable MediaRange sourceMediaRange,
+                                  boolean removeAudio) {
         this.granularity = granularity;
         this.videoFilters = videoFilters;
         this.audioFilters = audioFilters;
         this.sourceMediaRange = sourceMediaRange == null ? new MediaRange(0, Long.MAX_VALUE) : sourceMediaRange;
+        this.removeAudio = removeAudio;
     }
 
     public static class Builder {
@@ -47,6 +51,7 @@ public class TransformationOptions {
         private List<GlFilter> videoFilters;
         private List<BufferFilter> audioFilters;
         private MediaRange sourceMediaRange;
+        private boolean removeAudio;
 
         @NonNull
         public Builder setGranularity(@IntRange(from = GRANULARITY_NONE) int granularity) {
@@ -73,8 +78,14 @@ public class TransformationOptions {
         }
 
         @NonNull
+        public Builder setRemoveAudio(boolean removeAudio) {
+            this.removeAudio = removeAudio;
+            return this;
+        }
+
+        @NonNull
         public TransformationOptions build() {
-            return new TransformationOptions(granularity, videoFilters, audioFilters, sourceMediaRange);
+            return new TransformationOptions(granularity, videoFilters, audioFilters, sourceMediaRange, removeAudio);
         }
     }
 }

--- a/litr/src/main/java/com/linkedin/android/litr/exception/MediaTargetException.java
+++ b/litr/src/main/java/com/linkedin/android/litr/exception/MediaTargetException.java
@@ -16,6 +16,7 @@ public class MediaTargetException extends MediaTransformationException {
     private static final String INVALID_PARAMS_TEXT = "Invalid parameters";
     private static final String IO_FAILURE_TEXT = "Failed to open the media target for write.";
     private static final String UNSUPPORTED_URI_TYPE_TEXT = "URI type not supported at API level below 26";
+    private static final String NO_OUTPUT_TRACKS_TEXT = "No output tracks";
 
     private final Error error;
     private final String outputFilePath;
@@ -35,7 +36,9 @@ public class MediaTargetException extends MediaTransformationException {
     public enum Error {
         INVALID_PARAMS(INVALID_PARAMS_TEXT),
         IO_FAILUE(IO_FAILURE_TEXT),
-        UNSUPPORTED_URI_TYPE(UNSUPPORTED_URI_TYPE_TEXT);
+        UNSUPPORTED_URI_TYPE(UNSUPPORTED_URI_TYPE_TEXT),
+        NO_OUTPUT_TRACKS(NO_OUTPUT_TRACKS_TEXT);
+
 
         private final String text;
         Error(String text) {


### PR DESCRIPTION
There were multiple requests to support removing audio track(s) when using non-`TrackTransform` based `transform` API: https://github.com/linkedin/LiTr/issues/196

We are adding a new `removeAudio` flag to `TransformationOptions` which does just that.