### PR TITLE
Fix for incorrect bitrate extraction in size estimation

### DIFF
--- a/litr/src/main/java/com/linkedin/android/litr/utils/TranscoderUtils.java
+++ b/litr/src/main/java/com/linkedin/android/litr/utils/TranscoderUtils.java
@@ -68,7 +68,7 @@ public final class TranscoderUtils {
             String mimeType = getMimeType(sourceTrackFormat);
             if (mimeType != null) {
                 if (trackTransform.getTargetFormat() != null) {
-                    bitrate = trackTransform.getTargetFormat().getInteger(MediaFormat.KEY_BIT_RATE);
+                    bitrate = getBitrate(trackTransform.getTargetFormat());
                 } else if (mimeType.startsWith("audio") && bitrate < 0) {
                     bitrate = COMMON_AUDIO_BITRATE_KBPS * BITS_IN_KILO;
                 }

--- a/litr/src/test/java/com/linkedin/android/litr/TransformationJobShould.java
+++ b/litr/src/test/java/com/linkedin/android/litr/TransformationJobShould.java
@@ -7,36 +7,6 @@
  */
 package com.linkedin.android.litr;
 
-import android.media.MediaExtractor;
-import android.media.MediaFormat;
-import com.linkedin.android.litr.analytics.TrackTransformationInfo;
-import com.linkedin.android.litr.analytics.TransformationStatsCollector;
-import com.linkedin.android.litr.codec.Decoder;
-import com.linkedin.android.litr.codec.Encoder;
-import com.linkedin.android.litr.exception.InsufficientDiskSpaceException;
-import com.linkedin.android.litr.exception.TrackTranscoderException;
-import com.linkedin.android.litr.io.MediaRange;
-import com.linkedin.android.litr.io.MediaSource;
-import com.linkedin.android.litr.io.MediaTarget;
-import com.linkedin.android.litr.render.Renderer;
-import com.linkedin.android.litr.transcoder.PassthroughTranscoder;
-import com.linkedin.android.litr.transcoder.TrackTranscoder;
-import com.linkedin.android.litr.transcoder.TrackTranscoderFactory;
-import com.linkedin.android.litr.transcoder.VideoTrackTranscoder;
-import com.linkedin.android.litr.utils.DiskUtil;
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.ArgumentCaptor;
-import org.mockito.ArgumentMatchers;
-import org.mockito.Captor;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
-
 import static com.linkedin.android.litr.transcoder.TrackTranscoder.RESULT_EOS_REACHED;
 import static junit.framework.Assert.assertFalse;
 import static org.hamcrest.CoreMatchers.is;
@@ -54,6 +24,38 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+
+import android.media.MediaExtractor;
+import android.media.MediaFormat;
+
+import com.linkedin.android.litr.analytics.TrackTransformationInfo;
+import com.linkedin.android.litr.analytics.TransformationStatsCollector;
+import com.linkedin.android.litr.codec.Decoder;
+import com.linkedin.android.litr.codec.Encoder;
+import com.linkedin.android.litr.exception.InsufficientDiskSpaceException;
+import com.linkedin.android.litr.exception.TrackTranscoderException;
+import com.linkedin.android.litr.io.MediaRange;
+import com.linkedin.android.litr.io.MediaSource;
+import com.linkedin.android.litr.io.MediaTarget;
+import com.linkedin.android.litr.render.Renderer;
+import com.linkedin.android.litr.transcoder.PassthroughTranscoder;
+import com.linkedin.android.litr.transcoder.TrackTranscoder;
+import com.linkedin.android.litr.transcoder.TrackTranscoderFactory;
+import com.linkedin.android.litr.transcoder.VideoTrackTranscoder;
+import com.linkedin.android.litr.utils.DiskUtil;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 public class TransformationJobShould {
     private static final String JOB_ID = "42";
@@ -113,6 +115,7 @@ public class TransformationJobShould {
         when(sourceAudioFormat.containsKey(MediaFormat.KEY_DURATION)).thenReturn(true);
         when(sourceAudioFormat.getLong(MediaFormat.KEY_DURATION)).thenReturn(60000000L);
         when(diskUtil.getAvailableDiskSpaceInDataDirectory()).thenReturn(1000000000L);
+        when(targetVideoFormat.containsKey(MediaFormat.KEY_BIT_RATE)).thenReturn(true);
         when(targetVideoFormat.getInteger(MediaFormat.KEY_BIT_RATE)).thenReturn(6 * 1024 * 1024);
 
         doReturn(videoTrackTranscoder)


### PR DESCRIPTION
Bitrate extraction when estimating size was unsafe and could throw a 'NullPointerException' for metadata tracks that wouldn't have a bitrate in their `MediaFormat`. This happened in https://github.com/linkedin/LiTr/issues/210 , for example. Now using safe method that checks for presence of the key.