### PR TITLE
Enforce transcoding of incompatible audio track(s)

### DIFF
--- a/litr/src/main/java/com/linkedin/android/litr/MimeType.java
+++ b/litr/src/main/java/com/linkedin/android/litr/MimeType.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2022 LinkedIn Corporation
+ * All Rights Reserved.
+ *
+ * Licensed under the BSD 2-Clause License (the "License").  See License in the project root for
+ * license information.
+ */
+package com.linkedin.android.litr;
+
+public class MimeType {
+
+    public static final String AUDIO_AAC = "audio/mp4a-latm";
+    public static final String AUDIO_RAW = "audio/raw";
+    public static final String AUDIO_OPUS = "audio/opus";
+    public static final String AUDIO_VORBIS = "audio/vorbis";
+
+    public static final String VIDEO_AVC = "video/avc";
+    public static final String VIDEO_HEVC = "video/hevc";
+    public static final String VIDEO_VP8 = "video/x-vnd.on2.vp8";
+    public static final String VIDEO_VP9 = "video/x-vnd.on2.vp9";
+}


### PR DESCRIPTION
We had special handling for VP8/VP9 video transcoding when we enforced audio to OPUS codec. Recently an issue #215  was reported where transcoding from MOV to MP4 failed because MOV file contained an audio track in `audio/raw` format which did not have an encoder, which could be fixed by enforcing AAC codec for AVC/HEVC videos. In this PR we fix both problems by introducing more general approach to audio codec enforcement:
 
- we use video MIME type to determine if audio codec is compatible with video codec in target video. If not compatible, we transcode audio as well if incompatible audio is asked to be coped to target "as is"
- for H.264 formats (AVC, HEVC) `audio/raw` is listed as incompatible and will be transcoded to AAC
- for VP8/VP9 format any non-OPUS or non-VORBIS audio track is listed as incompatible and will be transcoded to OPUS
- if target audio format is passed, we respect that and do not enforce audio transcoding