### PR TITLE
Parameter to remove metadata tracks

### DIFF
--- a/litr-demo/src/main/java/com/linkedin/android/litr/demo/data/TransformationPresenter.java
+++ b/litr-demo/src/main/java/com/linkedin/android/litr/demo/data/TransformationPresenter.java
@@ -644,6 +644,7 @@ public class TransformationPresenter {
         TransformationOptions transformationOptions = new TransformationOptions.Builder()
                 .setGranularity(MediaTransformer.GRANULARITY_DEFAULT)
                 .setSourceMediaRange(mediaRange)
+                .setRemoveMetadata(true)
                 .build();
 
         MediaFormat targetVideoFormat = MediaFormat.createVideoFormat(

--- a/litr/src/main/java/com/linkedin/android/litr/MediaTransformer.java
+++ b/litr/src/main/java/com/linkedin/android/litr/MediaTransformer.java
@@ -156,7 +156,7 @@ public class MediaTransformer {
 
             int targetTrackCount = 0;
             for (int track = 0; track < mediaSource.getTrackCount(); track++) {
-                if (shouldIncludeTrack(mediaSource.getTrackFormat(track), options.removeAudio)) {
+                if (shouldIncludeTrack(mediaSource.getTrackFormat(track), options.removeAudio, options.removeMetadata)) {
                     targetTrackCount++;
                 }
             }
@@ -189,7 +189,7 @@ public class MediaTransformer {
                         mimeType = sourceMediaFormat.getString(MediaFormat.KEY_MIME);
                     }
 
-                    if (!shouldIncludeTrack(mimeType, options.removeAudio)) {
+                    if (!shouldIncludeTrack(mimeType, options.removeAudio, options.removeMetadata)) {
                         continue;
                     }
 
@@ -338,22 +338,23 @@ public class MediaTransformer {
         return TranscoderUtils.getEstimatedTargetFileSize(trackTransforms);
     }
 
-    private boolean shouldIncludeTrack(@NonNull MediaFormat sourceMediaFormat, boolean removeAudio) {
+    private boolean shouldIncludeTrack(@NonNull MediaFormat sourceMediaFormat, boolean removeAudio, boolean removeMetadata) {
         String mimeType = null;
         if (sourceMediaFormat.containsKey(MediaFormat.KEY_MIME)) {
             mimeType = sourceMediaFormat.getString(MediaFormat.KEY_MIME);
         }
 
-        return shouldIncludeTrack(mimeType, removeAudio);
+        return shouldIncludeTrack(mimeType, removeAudio, removeMetadata);
     }
 
-    private boolean shouldIncludeTrack(@Nullable String mimeType, boolean removeAudio) {
+    private boolean shouldIncludeTrack(@Nullable String mimeType, boolean removeAudio, boolean removeMetadata) {
         if (mimeType == null) {
             Log.e(TAG, "Mime type is null for track ");
             return false;
         }
 
-        return !removeAudio || !mimeType.startsWith("audio");
+        return !(removeAudio && mimeType.startsWith("audio")
+                || removeMetadata && !mimeType.startsWith("video") && !mimeType.startsWith("audio"));
     }
 
     @Nullable

--- a/litr/src/main/java/com/linkedin/android/litr/TransformationOptions.java
+++ b/litr/src/main/java/com/linkedin/android/litr/TransformationOptions.java
@@ -33,17 +33,20 @@ public class TransformationOptions {
     @Nullable public final List<BufferFilter> audioFilters;
     @NonNull public final MediaRange sourceMediaRange;
     public final boolean removeAudio;
+    public final boolean removeMetadata;
 
     private TransformationOptions(@IntRange(from = GRANULARITY_NONE) int granularity,
                                   @Nullable List<GlFilter> videoFilters,
                                   @Nullable List<BufferFilter> audioFilters,
                                   @Nullable MediaRange sourceMediaRange,
-                                  boolean removeAudio) {
+                                  boolean removeAudio,
+                                  boolean removeMetadata) {
         this.granularity = granularity;
         this.videoFilters = videoFilters;
         this.audioFilters = audioFilters;
         this.sourceMediaRange = sourceMediaRange == null ? new MediaRange(0, Long.MAX_VALUE) : sourceMediaRange;
         this.removeAudio = removeAudio;
+        this.removeMetadata = removeMetadata;
     }
 
     public static class Builder {
@@ -52,6 +55,7 @@ public class TransformationOptions {
         private List<BufferFilter> audioFilters;
         private MediaRange sourceMediaRange;
         private boolean removeAudio;
+        private boolean removeMetadata;
 
         @NonNull
         public Builder setGranularity(@IntRange(from = GRANULARITY_NONE) int granularity) {
@@ -84,8 +88,14 @@ public class TransformationOptions {
         }
 
         @NonNull
+        public Builder setRemoveMetadata(boolean removeMetadata) {
+            this.removeMetadata = removeMetadata;
+            return this;
+        }
+
+        @NonNull
         public TransformationOptions build() {
-            return new TransformationOptions(granularity, videoFilters, audioFilters, sourceMediaRange, removeAudio);
+            return new TransformationOptions(granularity, videoFilters, audioFilters, sourceMediaRange, removeAudio, removeMetadata);
         }
     }
 }


### PR DESCRIPTION
Similar to ability to remove audio tracks via `TransformationOptions` parameter, adding an option to remove metadata tracks. This is useful for use cases like transcoding to VP9 which does not support metadata tracks.