### PR TITLE
Fix for incorrect audio frame presentation time when trimming

### DIFF
--- a/litr/src/main/java/com/linkedin/android/litr/transcoder/AudioTrackTranscoder.java
+++ b/litr/src/main/java/com/linkedin/android/litr/transcoder/AudioTrackTranscoder.java
@@ -174,8 +174,9 @@ public class AudioTrackTranscoder extends TrackTranscoder {
 
             if (decoderOutputFrame.bufferInfo.presentationTimeUs >= sourceMediaSelection.getStart()
                     || (decoderOutputFrame.bufferInfo.flags & MediaCodec.BUFFER_FLAG_END_OF_STREAM) != 0) {
-                renderer.renderFrame(decoderOutputFrame,
-                        TimeUnit.MICROSECONDS.toNanos(decoderOutputFrame.bufferInfo.presentationTimeUs - sourceMediaSelection.getStart()));
+                long presentationTimeUs = decoderOutputFrame.bufferInfo.presentationTimeUs - sourceMediaSelection.getStart();
+                decoderOutputFrame.bufferInfo.presentationTimeUs = presentationTimeUs;
+                renderer.renderFrame(decoderOutputFrame, TimeUnit.MICROSECONDS.toNanos(presentationTimeUs));
             }
             decoder.releaseOutputFrame(tag, false);
 


### PR DESCRIPTION
When trimming, presentation time of an audio frame was not adjusted with respect to trim start time. This caused odd progress values (>1, starting at large non-zero values, etc.) reported in #223 

This is now fixed by adjusting the presentation time in audio frame before passing it to an audio processor. 