### PR TITLE
Set default buffer size when creating VideoRendererInputSurface

### DIFF
--- a/litr/src/main/java/com/linkedin/android/litr/render/GlSingleFrameRenderer.kt
+++ b/litr/src/main/java/com/linkedin/android/litr/render/GlSingleFrameRenderer.kt
@@ -74,9 +74,7 @@ class GlSingleFrameRenderer(filters: List<GlFilter>?) : SingleFrameRenderer {
 
         // Creates a GL texture, and a SurfaceTexture. Since the rest of the pipeline (e.g. filters) rely on an external texture sampler, we will render the
         // source bitmap into this surface, instead of dealing with GL_TEXTURE_2D, so this surface be passed to the rest of the pipeline with no changes.
-        inputSurface = VideoRenderInputSurface().apply {
-            surfaceTexture.setDefaultBufferSize(inputSize.x, inputSize.y)
-        }
+        inputSurface = VideoRenderInputSurface(width, height)
 
         // The outputSurface is needed to set up EGL surface and context
         val surfaceTexture = SurfaceTexture(0).apply {

--- a/litr/src/main/java/com/linkedin/android/litr/render/GlVideoRenderer.java
+++ b/litr/src/main/java/com/linkedin/android/litr/render/GlVideoRenderer.java
@@ -109,7 +109,15 @@ public class GlVideoRenderer implements Renderer {
 
         this.outputSurface = new VideoRenderOutputSurface(outputSurface);
 
-        inputSurface = new VideoRenderInputSurface();
+        int sourceWidth = VideoRenderInputSurface.UNDEFINED_DIMENSION;
+        if (sourceMediaFormat != null && sourceMediaFormat.containsKey(MediaFormat.KEY_WIDTH)) {
+            sourceWidth = sourceMediaFormat.getInteger(MediaFormat.KEY_WIDTH);
+        }
+        int sourceHeight = VideoRenderInputSurface.UNDEFINED_DIMENSION;
+        if (sourceMediaFormat != null && sourceMediaFormat.containsKey(MediaFormat.KEY_HEIGHT)) {
+            sourceHeight = sourceMediaFormat.getInteger(MediaFormat.KEY_HEIGHT);
+        }
+        inputSurface = new VideoRenderInputSurface(sourceWidth, sourceHeight);
         initMvpMatrix(rotation, aspectRatio);
 
         for (GlFilter filter : filters) {

--- a/litr/src/main/java/com/linkedin/android/litr/render/VideoRenderInputSurface.java
+++ b/litr/src/main/java/com/linkedin/android/litr/render/VideoRenderInputSurface.java
@@ -23,6 +23,8 @@ import android.graphics.SurfaceTexture;
 import android.opengl.GLES11Ext;
 import android.opengl.GLES20;
 import android.view.Surface;
+
+import androidx.annotation.IntRange;
 import androidx.annotation.NonNull;
 
 /**
@@ -42,6 +44,8 @@ import androidx.annotation.NonNull;
  */
 class VideoRenderInputSurface implements SurfaceTexture.OnFrameAvailableListener {
 
+    public static final int UNDEFINED_DIMENSION = -1;
+
     private static final int FRAME_WAIT_TIMEOUT_MS = 10000;
 
     private SurfaceTexture surfaceTexture;
@@ -55,9 +59,12 @@ class VideoRenderInputSurface implements SurfaceTexture.OnFrameAvailableListener
      * Creates an RenderInputSurface using the current EGL context (rather than establishing a
      * new one).  Creates a Surface that can be passed to MediaCodec.configure().
      */
-    VideoRenderInputSurface() {
+    VideoRenderInputSurface(@IntRange(from = UNDEFINED_DIMENSION) int width, @IntRange(from = UNDEFINED_DIMENSION) int height) {
         textureId = createTexture();
         surfaceTexture = new SurfaceTexture(textureId);
+        if (width != UNDEFINED_DIMENSION && height != UNDEFINED_DIMENSION) {
+            surfaceTexture.setDefaultBufferSize(width, height);
+        }
         surface = new Surface(surfaceTexture);
         surfaceTexture.setOnFrameAvailableListener(this);
     }
@@ -80,10 +87,6 @@ class VideoRenderInputSurface implements SurfaceTexture.OnFrameAvailableListener
     @NonNull
     Surface getSurface() {
         return surface;
-    }
-
-    SurfaceTexture getSurfaceTexture() {
-        return surfaceTexture;
     }
 
     /**


### PR DESCRIPTION
Inside `VideoRendererInputSurface` we create a `SurfaceTexture` but do not set a buffer size for it. This works when using `MediaCodec` decoder, but doesn't work well in other use cases, such as rendering into a bitmap or using camera as a producer. Fixing this now by accepting heigh/width in `VideoRendererInputSurface` constructor and initializing `SurfaceTexture` there. 

A nice side effect is that now we no longer have to expose `VideoRendererInputSurface.surfaceTexture` field.

Video transcoding still works as expected. Frame extraction works. 