### PR TITLE
Implement AudioRecord support for audio track

### DIFF
--- a/litr-demo/src/main/AndroidManifest.xml
+++ b/litr-demo/src/main/AndroidManifest.xml
@@ -10,6 +10,7 @@
 
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
+    <uses-permission android:name="android.permission.RECORD_AUDIO" />
 
     <application
         android:allowBackup="false"

--- a/litr-demo/src/main/java/com/linkedin/android/litr/demo/DemoCase.java
+++ b/litr-demo/src/main/java/com/linkedin/android/litr/demo/DemoCase.java
@@ -23,7 +23,8 @@ public enum DemoCase {
     TRANSCODE_VIDEO_MOCK(R.string.demo_case_mock_transcode_video, "TranscodeVideoMock", new MockTranscodeFragment()),
     TRANSCODE_AUDIO(R.string.demo_case_transcode_audio, "TranscodeAudio", new TranscodeAudioFragment()),
     EXTRACT_FRAMES(R.string.demo_case_extract_frames, "ExtractFramesFragment", new ExtractFramesFragment()),
-    TRANSCODE_TO_VP9(R.string.demo_case_transcode_to_vp9, "TranscodeToVp9Fragment", new TranscodeToVp9Fragment());
+    TRANSCODE_TO_VP9(R.string.demo_case_transcode_to_vp9, "TranscodeToVp9Fragment", new TranscodeToVp9Fragment()),
+    RECORD_AUDIO(R.string.demo_case_audio_record, "RecordAudio", new RecordAudioFragment());
 
     @StringRes int displayName;
     String fragmentTag;

--- a/litr-demo/src/main/java/com/linkedin/android/litr/demo/RecordAudioFragment.kt
+++ b/litr-demo/src/main/java/com/linkedin/android/litr/demo/RecordAudioFragment.kt
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2022 LinkedIn Corporation
+ * All Rights Reserved.
+ *
+ * Licensed under the BSD 2-Clause License (the "License").  See License in the project root for
+ * license information.
+ *
+ * Author: Ian Bird
+ */
+package com.linkedin.android.litr.demo
+
+import android.Manifest
+import android.app.Activity
+import android.app.AlertDialog
+import android.content.pm.PackageManager
+import android.os.Build
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.annotation.RequiresApi
+import androidx.core.app.ActivityCompat
+import androidx.core.content.ContextCompat
+import com.linkedin.android.litr.MediaTransformer
+import com.linkedin.android.litr.demo.data.TargetMedia
+import com.linkedin.android.litr.demo.data.TransformationPresenter
+import com.linkedin.android.litr.demo.data.TransformationState
+import com.linkedin.android.litr.demo.databinding.FragmentAudioRecordBinding
+import com.linkedin.android.litr.io.AudioRecordMediaSource
+import com.linkedin.android.litr.utils.TransformationUtil
+import java.io.File
+
+private const val REQUEST_AUDIO_RECORD_PERMISSION = 14
+
+class RecordAudioFragment : BaseTransformationFragment() {
+    private lateinit var binding: FragmentAudioRecordBinding
+
+    private lateinit var mediaTransformer: MediaTransformer
+    private var targetMedia: TargetMedia = TargetMedia()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        mediaTransformer = MediaTransformer(context!!.applicationContext)
+
+        // This demo fragment requires Android M or newer, in order to support reading data from
+        // AudioRecord in a non-blocking way. Let's double check that the current device supports
+        // this.
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+            AlertDialog.Builder(requireContext())
+                    .setMessage("Android Marshmallow or newer required")
+                    .setPositiveButton("Ok") { _, _ ->
+                        activity?.onBackPressed()
+                    }
+                    .show()
+            return
+        }
+
+        // Check to make sure the user has granted permission to record audio.
+        if (!hasAudioRecordPermission()) {
+            ActivityCompat.requestPermissions(
+                    context as Activity,
+                    arrayOf(Manifest.permission.RECORD_AUDIO),
+                    REQUEST_AUDIO_RECORD_PERMISSION
+            )
+        }
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        mediaTransformer.release()
+    }
+
+    @RequiresApi(Build.VERSION_CODES.M)
+    override fun onCreateView(
+            inflater: LayoutInflater,
+            container: ViewGroup?,
+            savedInstanceState: Bundle?
+    ): View {
+        binding = FragmentAudioRecordBinding.inflate(layoutInflater, container, false)
+
+        binding.transformationState = TransformationState()
+        binding.transformationPresenter = TransformationPresenter(context!!, mediaTransformer)
+        binding.mediaSource = AudioRecordMediaSource()
+
+        val targetFile = File(
+                TransformationUtil.getTargetFileDirectory(requireContext().applicationContext),
+                "recorded_audio_${System.currentTimeMillis()}.mp4"
+        )
+        targetMedia.setTargetFile(targetFile)
+        binding.targetMedia = targetMedia
+
+        return binding.root
+    }
+
+    private fun hasAudioRecordPermission(): Boolean {
+        val validContext = context ?: return false
+        return ContextCompat.checkSelfPermission(
+                validContext,
+                Manifest.permission.RECORD_AUDIO
+        ) == PackageManager.PERMISSION_GRANTED
+    }
+}

--- a/litr-demo/src/main/res/layout/fragment_audio_record.xml
+++ b/litr-demo/src/main/res/layout/fragment_audio_record.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2022 LinkedIn Corporation -->
+<!-- All Rights Reserved. -->
+<!-- -->
+<!-- Licensed under the BSD 2-Clause License (the "License").  See License in the project root -->
+<!-- for license information. -->
+<!-- -->
+<!-- Author: Ian Bird -->
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <data>
+        <import type="android.view.View"/>
+
+        <variable
+            name="mediaSource"
+            type="com.linkedin.android.litr.io.AudioRecordMediaSource" />
+
+        <variable
+            name="targetMedia"
+            type="com.linkedin.android.litr.demo.data.TargetMedia" />
+
+        <variable
+            name="transformationState"
+            type="com.linkedin.android.litr.demo.data.TransformationState" />
+
+        <variable
+            name="transformationPresenter"
+            type="com.linkedin.android.litr.demo.data.TransformationPresenter" />
+
+    </data>
+
+    <androidx.core.widget.NestedScrollView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <LinearLayout
+            android:orientation="vertical"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+
+            <Button
+                android:id="@+id/button_record"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/record"
+                android:enabled="@{(transformationState.state != transformationState.STATE_RUNNING)}"
+                android:padding="@dimen/cell_padding"
+                android:onClick="@{() -> transformationPresenter.recordAudio(mediaSource, targetMedia, transformationState)}"/>
+
+            <Button
+                android:id="@+id/button_stop"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/stop"
+                android:enabled="@{transformationState.state == transformationState.STATE_RUNNING}"
+                android:padding="@dimen/cell_padding"
+                android:onClick="@{() -> transformationPresenter.stopRecording(mediaSource)}"/>
+
+            <Button
+                android:id="@+id/button_play"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/play"
+                android:enabled="@{transformationState.state == transformationState.STATE_COMPLETED}"
+                android:padding="@dimen/cell_padding"
+                android:onClick="@{() -> transformationPresenter.play(targetMedia.contentUri)}"/>
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:padding="@dimen/cell_padding"
+                android:text="@{transformationState.stats}"
+                android:visibility="@{transformationState.state == transformationState.STATE_RUNNING || transformationState.stats == null ? View.GONE : View.VISIBLE}"/>
+
+        </LinearLayout>
+
+    </androidx.core.widget.NestedScrollView>
+
+</layout>

--- a/litr-demo/src/main/res/values/strings.xml
+++ b/litr-demo/src/main/res/values/strings.xml
@@ -18,6 +18,7 @@
     <string name="demo_case_transcode_audio">Transcode Audio</string>
     <string name="demo_case_extract_frames">Extract Video Frames</string>
     <string name="demo_case_transcode_to_vp9">Transcode To VP9</string>
+    <string name="demo_case_audio_record">Record Audio</string>
 
     <string name="error_vp9_not_supported">VP8/VP9 is not supported</string>
 
@@ -47,6 +48,9 @@
     <string name="pick_background">Pick Background</string>
     <string name="transcode">Transcode</string>
     <string name="cancel">Cancel</string>
+
+    <string name="record">Record</string>
+    <string name="stop">Stop</string>
 
     <string name="target_path" formatted="true">Target: %s</string>
     <string name="play">Play</string>

--- a/litr/src/main/java/com/linkedin/android/litr/io/AudioRecordMediaSource.kt
+++ b/litr/src/main/java/com/linkedin/android/litr/io/AudioRecordMediaSource.kt
@@ -1,0 +1,212 @@
+/*
+ * Copyright 2022 LinkedIn Corporation
+ * All Rights Reserved.
+ *
+ * Licensed under the BSD 2-Clause License (the "License").  See License in the project root for
+ * license information.
+ *
+ * Author: Ian Bird
+ */
+package com.linkedin.android.litr.io
+
+import android.media.*
+import android.os.Build
+import android.util.Log
+import androidx.annotation.RequiresApi
+import com.linkedin.android.litr.MimeType
+import com.linkedin.android.litr.exception.MediaSourceException
+import java.nio.ByteBuffer
+
+private const val TAG = "AudioRecordMediaSource"
+
+private const val MEDIA_FORMAT_PCM_KEY = "pcm-encoding"
+private const val AUDIO_FORMAT = AudioFormat.ENCODING_PCM_16BIT
+private const val BYTES_PER_SAMPLE = 2
+
+/**
+ * An implementation of MediaSource, which utilizes Android's {@link AudioRecord} to record audio
+ * from a given audio source (i.e. the device's microphone).
+ *
+ * This class requires Android M+ in order to support reading data from {@link AudioRecord} in a
+ * non-blocking way.
+ */
+@RequiresApi(Build.VERSION_CODES.M)
+class AudioRecordMediaSource(
+        private val audioSource: Int = DEFAULT_AUDIO_SOURCE,
+        private val sampleRate: Int = DEFAULT_SAMPLE_RATE,
+        private val channelCount: Int = DEFAULT_CHANNEL_COUNT
+) : MediaSource {
+
+    private val channelConfig = when(channelCount) {
+        1 -> AudioFormat.CHANNEL_IN_MONO
+        2 -> AudioFormat.CHANNEL_IN_STEREO
+        else -> throw IllegalArgumentException("Unsupported channel count configuration")
+    }
+
+    // Compute the appropriate buffer size based upon the audio configuration.
+    private val bufferSize = AudioRecord.getMinBufferSize(sampleRate, channelConfig, AUDIO_FORMAT) * 8
+
+    // Compute the number of bytes per microsecond of audio.
+    private val bytesPerUs = (sampleRate * BYTES_PER_SAMPLE * channelCount) / 1000000.0
+
+    // The AudioRecord instance used to record the audio source.
+    private var audioRecord: AudioRecord? = null
+
+    // We track the amount of 16-bit PCM we have returned and calculate its duration, in order to
+    // know the presentation time of the next sample.
+    private var nextSampleTimeUs = 0L
+    private var sampleIncrementUs = 0L
+    private var totalDurationUs = 0L
+
+    private var isRecording = false
+
+    @Synchronized
+    fun start() {
+        createAudioRecord()
+
+        // Check to make sure the AudioRecord instance is initialized.
+        if (audioRecord?.state != AudioRecord.STATE_INITIALIZED) {
+            Log.e(TAG, "Error initializing AudioRecord")
+            throw MediaSourceException(
+                    MediaSourceException.Error.DATA_SOURCE,
+                    null,
+                    IllegalStateException("Error initializing AudioRecord: ${audioRecord?.state}"))
+        }
+
+        // Start recording.
+        audioRecord?.startRecording()
+        isRecording = true
+    }
+
+    private fun createAudioRecord() {
+        audioRecord = AudioRecord(
+                audioSource,
+                sampleRate,
+                channelConfig,
+                AUDIO_FORMAT,
+                bufferSize
+        )
+    }
+
+    @Synchronized
+    fun stop() {
+        if (isRecording) {
+            // Stop recording.
+            audioRecord?.stop()
+            isRecording = false
+        }
+    }
+
+    override fun getOrientationHint() = 0
+
+    override fun getTrackCount() = 1
+
+    override fun getTrackFormat(track: Int) = MediaFormat.createAudioFormat(
+            MimeType.AUDIO_RAW,
+            sampleRate,
+            channelCount
+    ).apply {
+        setInteger(MEDIA_FORMAT_PCM_KEY, AudioFormat.ENCODING_PCM_16BIT)
+    }
+
+    override fun selectTrack(track: Int) {
+        // Since we only support a single (audio) track, there is nothing to select.
+    }
+
+    override fun seekTo(position: Long, mode: Int) {
+        // We don't support seeking, since we're recording live.
+    }
+
+    override fun getSampleTrackIndex() = 0
+
+    override fun readSampleData(buffer: ByteBuffer, offset: Int): Int {
+        // If the recording has been stopped, then there are no more samples to be read.
+        if (!isRecording) {
+            return -1
+        }
+
+        // Slice the buffer at the given offset.
+        val sampleBuffer = buffer.sliceAtOffset(offset)
+
+        // Read the next audio sample from the recorder. As per the AudioRecord documentation, we
+        // need to leave some buffer for the AudioRecord to continue to queue too. We also don't
+        // want to block waiting for more data, we'll take whatever is available.
+        val targetSize = (bufferSize / 2).coerceAtMost(sampleBuffer.capacity())
+        val readBytes = audioRecord?.read(sampleBuffer, targetSize, AudioRecord.READ_NON_BLOCKING) ?: -1
+
+        // We look at how much data has been returned, to know the duration of that sample. We
+        // therefore know when the next sample will start, which we track.
+        sampleIncrementUs = (readBytes / bytesPerUs).toLong()
+        return readBytes
+    }
+
+    override fun getSampleTime(): Long {
+        // If the recording has been stopped, then there are no more samples to be read.
+        if (!isRecording) {
+            return -1
+        }
+
+        val sampleTime = nextSampleTimeUs
+        nextSampleTimeUs += sampleIncrementUs
+        totalDurationUs += sampleIncrementUs
+        return sampleTime
+    }
+
+    override fun getSampleFlags(): Int {
+        // If the recording has been stopped, then any further samples read should report the end of
+        // the stream.
+        if (!isRecording) {
+            return MediaCodec.BUFFER_FLAG_END_OF_STREAM
+        }
+
+        return 0
+    }
+
+    override fun advance() {
+        // Nothing to advance.
+    }
+
+    override fun release() {
+        audioRecord?.stop()
+        audioRecord?.release()
+        audioRecord = null
+
+        nextSampleTimeUs = 0L
+        sampleIncrementUs = 0L
+
+        if (totalDurationUs > 0L) {
+            Log.i(TAG, "Audio Duration: $totalDurationUs")
+        }
+
+        totalDurationUs = 0L
+    }
+
+    override fun getSize() = -1L
+
+    /**
+     * Slices a ByteBuffer at a given Offset.
+     */
+    private fun ByteBuffer.sliceAtOffset(offset: Int): ByteBuffer {
+        // Check to make sure we haven't been given an offset which is outside of our ByteBuffer.
+        if (offset > capacity() - 1) {
+            return this
+        }
+
+        val original = position()
+        try {
+            // Modify the buffer's position to the given offset, so that the returned slice will
+            // start there.
+            position(offset)
+            return slice()
+        } finally {
+            // Reset the position back to it's original value.
+            position(original)
+        }
+    }
+
+    companion object {
+        const val DEFAULT_AUDIO_SOURCE = MediaRecorder.AudioSource.MIC
+        const val DEFAULT_SAMPLE_RATE = 44100
+        const val DEFAULT_CHANNEL_COUNT = 1
+    }
+}


### PR DESCRIPTION
I'm hoping to introduce Camera support as an input into Litr. This would allow scenarios where the raw audio/video is not sourced from a static file, but instead coming from a "live" source. I am planning the following, separate, pull requests:
 - Audio Record Support: Ability to pull raw PCM from an audio source (e.g. microphone) to mux with video from another source
 - External Surface Support: Ability to expose the raw surface that is used by the filter pipeline, allowing some other component (e.g. Camera2, CameraX, 3rd party library) to render directly into this. This will essentially bypass the Demux/Decode steps of the pipeline.
 - Camera2/CameraX Support: Helper classes/source for most common camera source scenarios.

This first PR covers Audio Record Support. It introduces a new `AudioRecordMediaSource` class which is responsible for taking raw PCM from `AudioRecord`, computing the appropriate PTS and feeding into the rest of the pipeline via the `MediaSource` interface. For now, the Demo app is simply muxing this together with a blank/red video stream. In future updates, this will be combined with a Camera2 integration that will merge recorded video and audio into the same file.