### PR TITLE
Allow transcoders advance to next track or EoS past selection end

### DIFF
--- a/litr/src/main/java/com/linkedin/android/litr/transcoder/AudioTrackTranscoder.java
+++ b/litr/src/main/java/com/linkedin/android/litr/transcoder/AudioTrackTranscoder.java
@@ -77,7 +77,7 @@ public class AudioTrackTranscoder extends TrackTranscoder {
         int result = RESULT_FRAME_PROCESSED;
 
         if (lastExtractFrameResult == RESULT_END_OF_RANGE_REACHED) {
-            lastExtractFrameResult = advanceToNextTrack() ? RESULT_EOS_REACHED : RESULT_END_OF_RANGE_REACHED;
+            lastExtractFrameResult = advanceToNextTrack();
         }
 
         // extract the frame from the incoming stream and send it to the decoder
@@ -142,7 +142,7 @@ public class AudioTrackTranscoder extends TrackTranscoder {
                 } else if (sampleTime >= sourceMediaSelection.getEnd()) {
                     frame.bufferInfo.set(0, 0, -1, MediaCodec.BUFFER_FLAG_END_OF_STREAM);
                     decoder.queueInputFrame(frame);
-                    extractFrameResult = advanceToNextTrack() ? RESULT_EOS_REACHED : RESULT_END_OF_RANGE_REACHED;
+                    extractFrameResult = advanceToNextTrack();
                     Log.d(TAG, "Selection end reached on the input stream");
                 } else {
                     frame.bufferInfo.set(0, bytesRead, sampleTime, sampleFlags);

--- a/litr/src/main/java/com/linkedin/android/litr/transcoder/AudioTrackTranscoder.java
+++ b/litr/src/main/java/com/linkedin/android/litr/transcoder/AudioTrackTranscoder.java
@@ -76,8 +76,12 @@ public class AudioTrackTranscoder extends TrackTranscoder {
         }
         int result = RESULT_FRAME_PROCESSED;
 
+        if (lastExtractFrameResult == RESULT_END_OF_RANGE_REACHED) {
+            lastExtractFrameResult = advanceToNextTrack() ? RESULT_EOS_REACHED : RESULT_END_OF_RANGE_REACHED;
+        }
+
         // extract the frame from the incoming stream and send it to the decoder
-        if (lastExtractFrameResult != RESULT_EOS_REACHED) {
+        if (lastExtractFrameResult != RESULT_EOS_REACHED && lastExtractFrameResult != RESULT_END_OF_RANGE_REACHED) {
             lastExtractFrameResult = extractAndEnqueueInputFrame();
         }
 
@@ -95,7 +99,7 @@ public class AudioTrackTranscoder extends TrackTranscoder {
             result = RESULT_OUTPUT_MEDIA_FORMAT_CHANGED;
         }
 
-        if (lastExtractFrameResult == RESULT_EOS_REACHED
+        if ((lastExtractFrameResult == RESULT_EOS_REACHED || lastExtractFrameResult == RESULT_END_OF_RANGE_REACHED)
             && lastDecodeFrameResult == RESULT_EOS_REACHED
             && lastEncodeFrameResult == RESULT_EOS_REACHED) {
             result = RESULT_EOS_REACHED;
@@ -138,8 +142,7 @@ public class AudioTrackTranscoder extends TrackTranscoder {
                 } else if (sampleTime >= sourceMediaSelection.getEnd()) {
                     frame.bufferInfo.set(0, 0, -1, MediaCodec.BUFFER_FLAG_END_OF_STREAM);
                     decoder.queueInputFrame(frame);
-                    advanceToNextTrack();
-                    extractFrameResult = RESULT_EOS_REACHED;
+                    extractFrameResult = advanceToNextTrack() ? RESULT_EOS_REACHED : RESULT_END_OF_RANGE_REACHED;
                     Log.d(TAG, "Selection end reached on the input stream");
                 } else {
                     frame.bufferInfo.set(0, bytesRead, sampleTime, sampleFlags);

--- a/litr/src/main/java/com/linkedin/android/litr/transcoder/PassthroughTranscoder.java
+++ b/litr/src/main/java/com/linkedin/android/litr/transcoder/PassthroughTranscoder.java
@@ -65,7 +65,7 @@ public class PassthroughTranscoder extends TrackTranscoder {
         }
 
         if (lastResult == RESULT_END_OF_RANGE_REACHED) {
-            lastResult = advanceToNextTrack() ? RESULT_EOS_REACHED : RESULT_END_OF_RANGE_REACHED;
+            lastResult = advanceToNextTrack();
             return RESULT_EOS_REACHED;
         }
 
@@ -110,7 +110,7 @@ public class PassthroughTranscoder extends TrackTranscoder {
             progress = 1.0f;
             outputBufferInfo.set(0, 0, sampleTime - sourceMediaSelection.getStart(), outputBufferInfo.flags | MediaCodec.BUFFER_FLAG_END_OF_STREAM);
             mediaMuxer.writeSampleData(targetTrack, outputBuffer, outputBufferInfo);
-            lastResult = advanceToNextTrack() ? RESULT_EOS_REACHED : RESULT_END_OF_RANGE_REACHED;
+            lastResult = advanceToNextTrack();
             Log.d(TAG, "Reach selection end on input stream");
         } else {
             if (sampleTime >= sourceMediaSelection.getStart()) {

--- a/litr/src/main/java/com/linkedin/android/litr/transcoder/PassthroughTranscoder.java
+++ b/litr/src/main/java/com/linkedin/android/litr/transcoder/PassthroughTranscoder.java
@@ -64,6 +64,11 @@ public class PassthroughTranscoder extends TrackTranscoder {
             return lastResult;
         }
 
+        if (lastResult == RESULT_END_OF_RANGE_REACHED) {
+            lastResult = advanceToNextTrack() ? RESULT_EOS_REACHED : RESULT_END_OF_RANGE_REACHED;
+            return RESULT_EOS_REACHED;
+        }
+
         // TranscoderJob expects the first result to be RESULT_OUTPUT_MEDIA_FORMAT_CHANGED, so that it can start the mediaMuxer
         if (!targetTrackAdded) {
             targetFormat = mediaSource.getTrackFormat(sourceTrack);
@@ -105,8 +110,7 @@ public class PassthroughTranscoder extends TrackTranscoder {
             progress = 1.0f;
             outputBufferInfo.set(0, 0, sampleTime - sourceMediaSelection.getStart(), outputBufferInfo.flags | MediaCodec.BUFFER_FLAG_END_OF_STREAM);
             mediaMuxer.writeSampleData(targetTrack, outputBuffer, outputBufferInfo);
-            advanceToNextTrack();
-            lastResult = RESULT_EOS_REACHED;
+            lastResult = advanceToNextTrack() ? RESULT_EOS_REACHED : RESULT_END_OF_RANGE_REACHED;
             Log.d(TAG, "Reach selection end on input stream");
         } else {
             if (sampleTime >= sourceMediaSelection.getStart()) {

--- a/litr/src/main/java/com/linkedin/android/litr/transcoder/TrackTranscoder.java
+++ b/litr/src/main/java/com/linkedin/android/litr/transcoder/TrackTranscoder.java
@@ -119,16 +119,16 @@ public abstract class TrackTranscoder {
         return targetFormat;
     }
 
-    protected boolean advanceToNextTrack() {
+    protected int advanceToNextTrack() {
         // done with this track, advance until track switches to let other track transcoders finish work
         while (mediaSource.getSampleTrackIndex() == sourceTrack) {
             mediaSource.advance();
             if ((mediaSource.getSampleFlags() & MediaCodec.BUFFER_FLAG_END_OF_STREAM) != 0) {
                 // reached the end of container, no more tracks left
-                return true;
+                return RESULT_EOS_REACHED;
             }
         }
-        return false;
+        return RESULT_END_OF_RANGE_REACHED;
     }
 
 }

--- a/litr/src/main/java/com/linkedin/android/litr/transcoder/TrackTranscoder.java
+++ b/litr/src/main/java/com/linkedin/android/litr/transcoder/TrackTranscoder.java
@@ -31,6 +31,7 @@ public abstract class TrackTranscoder {
     public static final int RESULT_FRAME_PROCESSED = 2;
     public static final int RESULT_FRAME_SKIPPED = 3;
     public static final int RESULT_EOS_REACHED = 4;
+    public static final int RESULT_END_OF_RANGE_REACHED = 5;
 
     @NonNull protected final MediaSource mediaSource;
     @NonNull protected final MediaTarget mediaMuxer;
@@ -118,15 +119,16 @@ public abstract class TrackTranscoder {
         return targetFormat;
     }
 
-    protected void advanceToNextTrack() {
+    protected boolean advanceToNextTrack() {
         // done with this track, advance until track switches to let other track transcoders finish work
         while (mediaSource.getSampleTrackIndex() == sourceTrack) {
             mediaSource.advance();
             if ((mediaSource.getSampleFlags() & MediaCodec.BUFFER_FLAG_END_OF_STREAM) != 0) {
                 // reached the end of container, no more tracks left
-                return;
+                return true;
             }
         }
+        return false;
     }
 
 }

--- a/litr/src/main/java/com/linkedin/android/litr/transcoder/VideoTrackTranscoder.java
+++ b/litr/src/main/java/com/linkedin/android/litr/transcoder/VideoTrackTranscoder.java
@@ -126,8 +126,12 @@ public class VideoTrackTranscoder extends TrackTranscoder {
         }
         int result = RESULT_FRAME_PROCESSED;
 
+        if (lastExtractFrameResult == RESULT_END_OF_RANGE_REACHED) {
+            lastExtractFrameResult = advanceToNextTrack() ? RESULT_EOS_REACHED : RESULT_END_OF_RANGE_REACHED;
+        }
+
         // extract the frame from the incoming stream and send it to the decoder
-        if (lastExtractFrameResult != RESULT_EOS_REACHED) {
+        if (lastExtractFrameResult != RESULT_EOS_REACHED && lastExtractFrameResult != RESULT_END_OF_RANGE_REACHED) {
             lastExtractFrameResult = extractAndEnqueueInputFrame();
         }
 
@@ -145,7 +149,7 @@ public class VideoTrackTranscoder extends TrackTranscoder {
             result = RESULT_OUTPUT_MEDIA_FORMAT_CHANGED;
         }
 
-        if (lastExtractFrameResult == RESULT_EOS_REACHED
+        if ((lastExtractFrameResult == RESULT_EOS_REACHED || lastExtractFrameResult == RESULT_END_OF_RANGE_REACHED)
             && lastDecodeFrameResult == RESULT_EOS_REACHED
             && lastEncodeFrameResult == RESULT_EOS_REACHED) {
             result = RESULT_EOS_REACHED;
@@ -179,9 +183,8 @@ public class VideoTrackTranscoder extends TrackTranscoder {
                 } else if (sampleTime >= sourceMediaSelection.getEnd()) {
                     frame.bufferInfo.set(0, 0, -1, MediaCodec.BUFFER_FLAG_END_OF_STREAM);
                     decoder.queueInputFrame(frame);
-                    advanceToNextTrack();
-                    extractFrameResult = RESULT_EOS_REACHED;
-                    Log.d(TAG, "EoS reached on the input stream");
+                    extractFrameResult = advanceToNextTrack() ? RESULT_EOS_REACHED : RESULT_END_OF_RANGE_REACHED;
+                    Log.d(TAG, "Selection end reached on the input stream");
                 } else {
                     frame.bufferInfo.set(0, bytesRead, sampleTime, sampleFlags);
                     decoder.queueInputFrame(frame);

--- a/litr/src/main/java/com/linkedin/android/litr/transcoder/VideoTrackTranscoder.java
+++ b/litr/src/main/java/com/linkedin/android/litr/transcoder/VideoTrackTranscoder.java
@@ -127,7 +127,7 @@ public class VideoTrackTranscoder extends TrackTranscoder {
         int result = RESULT_FRAME_PROCESSED;
 
         if (lastExtractFrameResult == RESULT_END_OF_RANGE_REACHED) {
-            lastExtractFrameResult = advanceToNextTrack() ? RESULT_EOS_REACHED : RESULT_END_OF_RANGE_REACHED;
+            lastExtractFrameResult = advanceToNextTrack();
         }
 
         // extract the frame from the incoming stream and send it to the decoder
@@ -183,7 +183,7 @@ public class VideoTrackTranscoder extends TrackTranscoder {
                 } else if (sampleTime >= sourceMediaSelection.getEnd()) {
                     frame.bufferInfo.set(0, 0, -1, MediaCodec.BUFFER_FLAG_END_OF_STREAM);
                     decoder.queueInputFrame(frame);
-                    extractFrameResult = advanceToNextTrack() ? RESULT_EOS_REACHED : RESULT_END_OF_RANGE_REACHED;
+                    extractFrameResult = advanceToNextTrack();
                     Log.d(TAG, "Selection end reached on the input stream");
                 } else {
                     frame.bufferInfo.set(0, bytesRead, sampleTime, sampleFlags);

--- a/litr/src/test/java/com/linkedin/android/litr/transcoder/AudioTrackTranscoderShould.java
+++ b/litr/src/test/java/com/linkedin/android/litr/transcoder/AudioTrackTranscoderShould.java
@@ -7,8 +7,25 @@
  */
 package com.linkedin.android.litr.transcoder;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import android.media.MediaCodec;
 import android.media.MediaFormat;
+
 import com.linkedin.android.litr.codec.Decoder;
 import com.linkedin.android.litr.codec.Encoder;
 import com.linkedin.android.litr.codec.Frame;
@@ -26,22 +43,6 @@ import org.mockito.MockitoAnnotations;
 
 import java.nio.ByteBuffer;
 import java.util.concurrent.TimeUnit;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.Is.is;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.atLeast;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 public class AudioTrackTranscoderShould {
 
@@ -587,7 +588,7 @@ public class AudioTrackTranscoderShould {
     }
 
     @Test
-    public void notDecodeFrameAndAdvanceToOtherTrackAndSendEosWhenFrameAfterSelectionEnd() throws Exception {
+    public void notDecodeFrameAndAdvanceToOtherTrackAndSendEorWhenFrameAfterSelectionEnd() throws Exception {
         int tag = 1;
 
         when(decoder.dequeueInputFrame(anyLong())).thenReturn(tag);
@@ -617,7 +618,95 @@ public class AudioTrackTranscoderShould {
 
         verify(decoder).queueInputFrame(sampleFrame);
         verify(sampleFrame.bufferInfo).set(0, 0, -1, MediaCodec.BUFFER_FLAG_END_OF_STREAM);
+        assertThat(audioTrackTranscoder.lastExtractFrameResult, is(VideoTrackTranscoder.RESULT_END_OF_RANGE_REACHED));
+    }
+
+    @Test
+    public void notDecodeFrameAndAdvanceToEndOfTrackAndSendEosWhenFrameAfterSelectionEnd() throws Exception {
+        int tag = 1;
+
+        when(decoder.dequeueInputFrame(anyLong())).thenReturn(tag);
+        when(decoder.getInputFrame(tag)).thenReturn(sampleFrame);
+        when(mediaSource.getSelection()).thenReturn(trimmedMediaRange);
+        when(mediaSource.getSampleTime()).thenReturn(SELECTION_END + 1);
+        when(mediaSource.getSampleFlags())
+                .thenReturn(0)
+                .thenReturn(MediaCodec.BUFFER_FLAG_END_OF_STREAM);
+        when(mediaSource.readSampleData(sampleFrame.buffer, 0)).thenReturn(BUFFER_SIZE);
+        when(mediaSource.getSampleTrackIndex()).thenReturn(AUDIO_TRACK);
+
+        AudioTrackTranscoder audioTrackTranscoder = new AudioTrackTranscoder(
+                mediaSource,
+                AUDIO_TRACK,
+                mediaTarget,
+                AUDIO_TRACK,
+                targetAudioFormat,
+                renderer,
+                decoder,
+                encoder);
+        audioTrackTranscoder.lastDecodeFrameResult = VideoTrackTranscoder.RESULT_EOS_REACHED;
+        audioTrackTranscoder.lastEncodeFrameResult = VideoTrackTranscoder.RESULT_EOS_REACHED;
+
+        audioTrackTranscoder.processNextFrame();
+
+        verify(decoder).queueInputFrame(sampleFrame);
+        verify(sampleFrame.bufferInfo).set(0, 0, -1, MediaCodec.BUFFER_FLAG_END_OF_STREAM);
         assertThat(audioTrackTranscoder.lastExtractFrameResult, is(VideoTrackTranscoder.RESULT_EOS_REACHED));
+    }
+
+    @Test
+    public void advanceToOtherTrackWhenEndOfRangeReached() throws Exception {
+        when(mediaSource.getSampleTrackIndex())
+                .thenReturn(AUDIO_TRACK)
+                .thenReturn(AUDIO_TRACK)
+                .thenReturn(VIDEO_TRACK);
+
+        AudioTrackTranscoder audioTrackTranscoder = new AudioTrackTranscoder(
+                mediaSource,
+                AUDIO_TRACK,
+                mediaTarget,
+                AUDIO_TRACK,
+                targetAudioFormat,
+                renderer,
+                decoder,
+                encoder);
+        audioTrackTranscoder.lastExtractFrameResult = TrackTranscoder.RESULT_END_OF_RANGE_REACHED;
+        audioTrackTranscoder.lastDecodeFrameResult = TrackTranscoder.RESULT_EOS_REACHED;
+        audioTrackTranscoder.lastEncodeFrameResult = TrackTranscoder.RESULT_EOS_REACHED;
+
+        int result = audioTrackTranscoder.processNextFrame();
+
+        verify(decoder, never()).dequeueInputFrame(anyLong());
+        verify(decoder, never()).getInputFrame(anyInt());
+        verify(mediaSource, never()).readSampleData(any(), anyInt());
+        assertThat(audioTrackTranscoder.lastExtractFrameResult, is(TrackTranscoder.RESULT_END_OF_RANGE_REACHED));
+        assertThat(result, is(TrackTranscoder.RESULT_EOS_REACHED));
+    }
+
+    @Test
+    public void advanceToEndOfTrackWhenEndOfRangeReached() throws Exception {
+        when(mediaSource.getSampleFlags()).thenReturn(MediaCodec.BUFFER_FLAG_END_OF_STREAM);
+
+        AudioTrackTranscoder audioTrackTranscoder = new AudioTrackTranscoder(
+                mediaSource,
+                AUDIO_TRACK,
+                mediaTarget,
+                AUDIO_TRACK,
+                targetAudioFormat,
+                renderer,
+                decoder,
+                encoder);
+        audioTrackTranscoder.lastExtractFrameResult = TrackTranscoder.RESULT_END_OF_RANGE_REACHED;
+        audioTrackTranscoder.lastDecodeFrameResult = TrackTranscoder.RESULT_EOS_REACHED;
+        audioTrackTranscoder.lastEncodeFrameResult = TrackTranscoder.RESULT_EOS_REACHED;
+
+        int result = audioTrackTranscoder.processNextFrame();
+
+        verify(decoder, never()).dequeueInputFrame(anyLong());
+        verify(decoder, never()).getInputFrame(anyInt());
+        verify(mediaSource, never()).readSampleData(any(), anyInt());
+        assertThat(audioTrackTranscoder.lastExtractFrameResult, is(TrackTranscoder.RESULT_EOS_REACHED));
+        assertThat(result, is(TrackTranscoder.RESULT_EOS_REACHED));
     }
 
     // endregion: trimming media


### PR DESCRIPTION
One of recent bug reports (#216 ) has an interesting use case - metadata track that starts after selection range end. Current logic never advances far past the end of selection, so we never process that metadata track thus "hanging" indefinitely.

Changing trim logic to handle cases like this:
 - introduce new "end of range" transcoder state. It is similar to "end of stream" state, but it is less "final" - track transcoder is still allowed to advance to next track or end of current track.
 - new logic that correctly detects "end of range" and "end of stream" states
 - track transcoder's "end of range" state is still reported as "end of stream" to `TransformationJob`, to indicate that processing of that track is done and it is ok to complete the job.
 - if `TransformationJob` is not completed, it asks a `TrackTranscoder` to `processNextFrame`. If `TrackTranscoder` is in "end of range" state, it will simply advance to next track or its own EoS (whichever is first) without processing any frames. This way we can reach frames in all tracks.

Fix was tested manually with the test file provided in that bug report, fix worked. Unit tests were added.