### PR TITLE
Implement Camera2 support as a MediaSource

### DIFF
--- a/litr-demo/src/main/AndroidManifest.xml
+++ b/litr-demo/src/main/AndroidManifest.xml
@@ -11,6 +11,9 @@
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
+    <uses-permission android:name="android.permission.CAMERA" />
+
+    <uses-feature android:name="android.hardware.camera" />
 
     <application
         android:allowBackup="false"

--- a/litr-demo/src/main/java/com/linkedin/android/litr/demo/CameraSizes.kt
+++ b/litr-demo/src/main/java/com/linkedin/android/litr/demo/CameraSizes.kt
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2022 LinkedIn Corporation
+ * All Rights Reserved.
+ *
+ * Licensed under the BSD 2-Clause License (the "License").  See License in the project root for
+ * license information.
+ *
+ * Author: Ian Bird
+ */
+package com.linkedin.android.litr.demo
+
+import android.graphics.Point
+import android.hardware.camera2.CameraCharacteristics
+import android.hardware.camera2.params.StreamConfigurationMap
+import android.os.Build
+import android.util.Size
+import android.view.Display
+import androidx.annotation.RequiresApi
+import kotlin.math.max
+import kotlin.math.min
+
+/** Helper class used to pre-compute shortest and longest sides of a [Size] */
+@RequiresApi(Build.VERSION_CODES.LOLLIPOP)
+class SmartSize(width: Int, height: Int) {
+    var size = Size(width, height)
+    var long = max(size.width, size.height)
+    var short = min(size.width, size.height)
+    override fun toString() = "SmartSize(${long}x${short})"
+}
+
+/** Standard High Definition size for pictures and video */
+@RequiresApi(Build.VERSION_CODES.LOLLIPOP)
+val SIZE_1080P: SmartSize = SmartSize(1920, 1080)
+
+/** Returns a [SmartSize] object for the given [Display] */
+@RequiresApi(Build.VERSION_CODES.LOLLIPOP)
+fun getDisplaySmartSize(display: Display): SmartSize {
+    val outPoint = Point()
+    display.getRealSize(outPoint)
+    return SmartSize(outPoint.x, outPoint.y)
+}
+
+/**
+ * Returns the largest available PREVIEW size. For more information, see:
+ * https://d.android.com/reference/android/hardware/camera2/CameraDevice and
+ * https://developer.android.com/reference/android/hardware/camera2/params/StreamConfigurationMap
+ */
+@RequiresApi(Build.VERSION_CODES.LOLLIPOP)
+fun <T>getPreviewOutputSize(
+        display: Display,
+        characteristics: CameraCharacteristics,
+        targetClass: Class<T>,
+        format: Int? = null
+): Size {
+
+    // Find which is smaller: screen or 1080p
+    val screenSize = getDisplaySmartSize(display)
+    val hdScreen = screenSize.long >= SIZE_1080P.long || screenSize.short >= SIZE_1080P.short
+    val maxSize = if (hdScreen) SIZE_1080P else screenSize
+
+    // If image format is provided, use it to determine supported sizes; else use target class
+    val config = characteristics.get(
+            CameraCharacteristics.SCALER_STREAM_CONFIGURATION_MAP)!!
+    if (format == null)
+        assert(StreamConfigurationMap.isOutputSupportedFor(targetClass))
+    else
+        assert(config.isOutputSupportedFor(format))
+    val allSizes = if (format == null)
+        config.getOutputSizes(targetClass) else config.getOutputSizes(format)
+
+    // Get available sizes and sort them by area from largest to smallest
+    val validSizes = allSizes
+            .sortedWith(compareBy { it.height * it.width })
+            .map { SmartSize(it.width, it.height) }.reversed()
+
+    // Then, get the largest output size that is smaller or equal than our max size
+    return validSizes.first { it.long <= maxSize.long && it.short <= maxSize.short }.size
+}

--- a/litr-demo/src/main/java/com/linkedin/android/litr/demo/DemoCase.java
+++ b/litr-demo/src/main/java/com/linkedin/android/litr/demo/DemoCase.java
@@ -7,6 +7,8 @@
  */
 package com.linkedin.android.litr.demo;
 
+import android.annotation.SuppressLint;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.StringRes;
 import androidx.fragment.app.Fragment;
@@ -38,7 +40,8 @@ public enum DemoCase {
     TRANSCODE_AUDIO(R.string.demo_case_transcode_audio, "TranscodeAudio", new TranscodeAudioFragment()),
     EXTRACT_FRAMES(R.string.demo_case_extract_frames, "ExtractFramesFragment", new ExtractFramesFragment()),
     TRANSCODE_TO_VP9(R.string.demo_case_transcode_to_vp9, "TranscodeToVp9Fragment", new TranscodeToVp9Fragment()),
-    RECORD_AUDIO(R.string.demo_case_audio_record, "RecordAudio", new RecordAudioFragment());
+    RECORD_AUDIO(R.string.demo_case_audio_record, "RecordAudio", new RecordAudioFragment()),
+    @SuppressLint("NewApi") RECORD_CAMERA(R.string.demo_case_camera_record, "RecordCamera2", new RecordCamera2Fragment());
 
     @StringRes int displayName;
     String fragmentTag;

--- a/litr-demo/src/main/java/com/linkedin/android/litr/demo/RecordCamera2Fragment.kt
+++ b/litr-demo/src/main/java/com/linkedin/android/litr/demo/RecordCamera2Fragment.kt
@@ -1,0 +1,212 @@
+/*
+ * Copyright 2022 LinkedIn Corporation
+ * All Rights Reserved.
+ *
+ * Licensed under the BSD 2-Clause License (the "License").  See License in the project root for
+ * license information.
+ *
+ * Author: Ian Bird
+ */
+package com.linkedin.android.litr.demo
+
+import android.Manifest
+import android.app.Activity
+import android.app.AlertDialog
+import android.content.Context
+import android.content.pm.PackageManager
+import android.hardware.camera2.*
+import android.os.Build
+import android.os.Bundle
+import android.util.Log
+import android.view.LayoutInflater
+import android.view.SurfaceHolder
+import android.view.View
+import android.view.ViewGroup
+import androidx.annotation.RequiresApi
+import androidx.core.app.ActivityCompat
+import androidx.core.content.ContextCompat
+import com.linkedin.android.litr.MediaTransformer
+import com.linkedin.android.litr.demo.data.RecordCameraPresenter
+import com.linkedin.android.litr.demo.data.TargetMedia
+import com.linkedin.android.litr.demo.data.TransformationState
+import com.linkedin.android.litr.demo.databinding.FragmentCamera2RecordBinding
+import com.linkedin.android.litr.io.AudioRecordMediaSource
+import com.linkedin.android.litr.io.Camera2MediaSource
+import com.linkedin.android.litr.utils.TransformationUtil
+import java.io.File
+import java.util.*
+
+private const val TAG = "RecordCamera2Fragment"
+
+private const val REQUEST_AUDIO_AND_CAMERA_PERMISSION = 27
+
+private const val DEFAULT_CAMERA_FPS = 30
+private const val DEFAULT_TARGET_BITRATE = 5_000_000 // 5Mbps
+private const val DEFAULT_RECORD_WIDTH = 1280
+
+@RequiresApi(Build.VERSION_CODES.M)
+class RecordCamera2Fragment : BaseTransformationFragment() {
+    private lateinit var binding: FragmentCamera2RecordBinding
+
+    private lateinit var mediaTransformer: MediaTransformer
+    private var targetMedia: TargetMedia = TargetMedia()
+
+    private lateinit var cameraManager: CameraManager
+
+    private val cameraId: String? by lazy {
+        val cameraIds = cameraManager.cameraIdList
+        for (id in cameraIds) {
+            val characteristics = cameraManager.getCameraCharacteristics(id)
+            if (characteristics.get(CameraCharacteristics.LENS_FACING)
+                    == CameraCharacteristics.LENS_FACING_FRONT
+            ) {
+                continue
+            }
+
+            return@lazy id
+        }
+
+        return@lazy null
+    }
+
+    private val mediaSourceCallback = object : Camera2MediaSource.Callback {
+        override fun onDeviceReady(cameraCharacteristics: CameraCharacteristics) {
+            initPreview(cameraCharacteristics)
+
+            binding.transformationPresenter?.recordCamera(
+                    binding.audioMediaSource!!,
+                    binding.videoMediaSource!!,
+                    binding.targetMedia!!,
+                    binding.transformationState!!
+            )
+        }
+
+        override fun onFrameSkipped(frameSkipCount: Int) {
+            Log.e(TAG, "onFrameSkipped (Count: $frameSkipCount)")
+        }
+
+        override fun onError(exception: Exception) {
+            Log.e(TAG, "onError $exception")
+        }
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        cameraManager = requireContext().getSystemService(Context.CAMERA_SERVICE) as CameraManager
+        mediaTransformer = MediaTransformer(context!!.applicationContext)
+
+        // This demo fragment requires Android M or newer, in order to support reading data from
+        // AudioRecord in a non-blocking way. Let's double check that the current device supports
+        // this.
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+            AlertDialog.Builder(requireContext())
+                    .setMessage(R.string.error_marshmallow_or_newer_required)
+                    .setPositiveButton(R.string.ok) { _, _ ->
+                        activity?.onBackPressed()
+                    }
+                    .show()
+            return
+        }
+
+        // Check to see what permission, if any, are required.
+        val requiredPermissions = mutableListOf<String>()
+        if (!hasAudioRecordPermission()) {
+            requiredPermissions.add(Manifest.permission.RECORD_AUDIO)
+        }
+        if (!hasCameraPermission()) {
+            requiredPermissions.add(Manifest.permission.CAMERA)
+        }
+
+        if (requiredPermissions.isNotEmpty()) {
+            ActivityCompat.requestPermissions(
+                    context as Activity,
+                    requiredPermissions.toTypedArray(),
+                    REQUEST_AUDIO_AND_CAMERA_PERMISSION
+            )
+        }
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        mediaTransformer.release()
+    }
+
+    override fun onCreateView(
+            inflater: LayoutInflater,
+            container: ViewGroup?,
+            savedInstanceState: Bundle?
+    ): View {
+        binding = FragmentCamera2RecordBinding.inflate(layoutInflater, container, false)
+
+        binding.buttonRecord.setOnClickListener { startRecording() }
+        binding.buttonStop.setOnClickListener { stopRecording() }
+
+        binding.transformationState = TransformationState()
+        binding.transformationPresenter = RecordCameraPresenter(context!!, mediaTransformer)
+        binding.audioMediaSource = AudioRecordMediaSource()
+
+        binding.videoMediaSource = Camera2MediaSource(requireContext(), cameraId!!).apply {
+            frameRate = DEFAULT_CAMERA_FPS
+            bitrate = DEFAULT_TARGET_BITRATE
+            recordWidth = DEFAULT_RECORD_WIDTH
+
+            setCallback(mediaSourceCallback)
+            addPreviewSurfaceHolder(binding.cameraView.holder)
+        }
+
+        val targetFile = File(
+                TransformationUtil.getTargetFileDirectory(requireContext().applicationContext),
+                "recorded_camera_${System.currentTimeMillis()}.mp4"
+        )
+        targetMedia.setTargetFile(targetFile)
+        binding.targetMedia = targetMedia
+
+        return binding.root
+    }
+
+    private fun startRecording() {
+        if (ActivityCompat.checkSelfPermission(
+                        requireContext(),
+                        Manifest.permission.CAMERA
+                ) == PackageManager.PERMISSION_GRANTED)
+        {
+            binding.videoMediaSource?.openCamera()
+        }
+    }
+
+    private fun initPreview(characteristics: CameraCharacteristics) {
+        val previewSize = getPreviewOutputSize(
+                binding.cameraView.display,
+                characteristics,
+                SurfaceHolder::class.java)
+        Log.i(TAG, "View finder size: ${binding.cameraView.width} x ${binding.cameraView.height}")
+        Log.i(TAG, "Selected preview size: $previewSize")
+
+        binding.cameraView.post {
+            binding.cameraView.setAspectRatio(previewSize.width, previewSize.height)
+        }
+    }
+
+    private fun stopRecording() {
+        binding.transformationPresenter?.stopRecording(
+                binding.audioMediaSource!!,
+                binding.videoMediaSource!!
+        )
+    }
+
+    private fun hasAudioRecordPermission(): Boolean {
+        val validContext = context ?: return false
+        return ContextCompat.checkSelfPermission(
+                validContext,
+                Manifest.permission.RECORD_AUDIO
+        ) == PackageManager.PERMISSION_GRANTED
+    }
+
+    private fun hasCameraPermission(): Boolean {
+        val validContext = context ?: return false
+        return ContextCompat.checkSelfPermission(
+                validContext,
+                Manifest.permission.CAMERA
+        ) == PackageManager.PERMISSION_GRANTED
+    }
+}

--- a/litr-demo/src/main/java/com/linkedin/android/litr/demo/data/RecordCameraPresenter.kt
+++ b/litr-demo/src/main/java/com/linkedin/android/litr/demo/data/RecordCameraPresenter.kt
@@ -10,7 +10,6 @@
 package com.linkedin.android.litr.demo.data
 
 import android.content.Context
-import android.graphics.Color
 import android.media.MediaMuxer
 import android.os.Build
 import android.util.Log
@@ -19,29 +18,24 @@ import com.linkedin.android.litr.MimeType
 import com.linkedin.android.litr.TrackTransform
 import com.linkedin.android.litr.codec.MediaCodecDecoder
 import com.linkedin.android.litr.codec.MediaCodecEncoder
-import com.linkedin.android.litr.codec.PassthroughDecoder
 import com.linkedin.android.litr.exception.MediaTransformationException
 import com.linkedin.android.litr.filter.GlFilter
-import com.linkedin.android.litr.filter.video.gl.SolidBackgroundColorFilter
-import com.linkedin.android.litr.io.AudioRecordMediaSource
-import com.linkedin.android.litr.io.MediaMuxerMediaTarget
-import com.linkedin.android.litr.io.MediaTarget
-import com.linkedin.android.litr.io.MockVideoMediaSource
+import com.linkedin.android.litr.io.*
 import com.linkedin.android.litr.render.GlVideoRenderer
 import java.util.UUID
-import java.util.concurrent.TimeUnit
 
-private const val TAG = "RecordAudioPresenter"
+private const val TAG = "RecordCameraPresenter"
 
-class RecordAudioPresenter(
+class RecordCameraPresenter(
     private val context: Context,
     private val mediaTransformer: MediaTransformer
 ) : TransformationPresenter(context, mediaTransformer) {
 
-    fun recordAudio(
-        mediaSource: AudioRecordMediaSource,
-        targetMedia: TargetMedia,
-        transformationState: TransformationState
+    fun recordCamera(
+            audioMediaSource: AudioRecordMediaSource,
+            videoMediaSource: Camera2MediaSource,
+            targetMedia: TargetMedia,
+            transformationState: TransformationState
     ) {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
             throw UnsupportedOperationException("Android Marshmallow or newer required")
@@ -67,20 +61,17 @@ class RecordAudioPresenter(
                 MediaMuxer.OutputFormat.MUXER_OUTPUT_MPEG_4
             )
 
-            // Create a single (synthetic) video track to ensure our output is playable by the demo
-            // app. We only use 1 second of video (a solid color) so the duration of the video will
-            // likely depend on the length of the audio recording.
             val videoTrackFormat = VideoTrackFormat(0, MimeType.VIDEO_AVC)
                 .apply {
-                    duration = TimeUnit.SECONDS.toMicros(1)
-                    frameRate = 30
-                    width = 512
-                    height = 512
+                    width = videoMediaSource.width
+                    height = videoMediaSource.height
+                    frameRate = videoMediaSource.frameRate
+                    bitrate = videoMediaSource.bitrate
+                    keyFrameInterval = videoMediaSource.keyFrameInterval
+                    rotation = videoMediaSource.orientation
                 }
 
             val videoMediaFormat = createVideoMediaFormat(videoTrackFormat)
-            val videoMediaSource = MockVideoMediaSource(videoMediaFormat)
-            val filter = SolidBackgroundColorFilter(Color.RED)
 
             val videoTransformBuilder = TrackTransform.Builder(
                 videoMediaSource,
@@ -90,8 +81,8 @@ class RecordAudioPresenter(
                 .setTargetTrack(0)
                 .setTargetFormat(videoMediaFormat)
                 .setEncoder(MediaCodecEncoder())
-                .setDecoder(PassthroughDecoder(1))
-                .setRenderer(GlVideoRenderer(listOf<GlFilter>(filter)))
+                .setDecoder(videoMediaSource)
+                .setRenderer(GlVideoRenderer(listOf<GlFilter>()))
 
             val audioTrackFormat = AudioTrackFormat(0, MimeType.AUDIO_AAC)
                 .apply {
@@ -101,7 +92,7 @@ class RecordAudioPresenter(
                 }
 
             val audioTransformBuilder = TrackTransform.Builder(
-                mediaSource,
+                audioMediaSource,
                 0,
                 mediaTarget
             )
@@ -114,8 +105,7 @@ class RecordAudioPresenter(
             trackTransforms.add(videoTransformBuilder.build())
             trackTransforms.add(audioTransformBuilder.build())
 
-            mediaSource.startRecording()
-
+            audioMediaSource.startRecording()
             mediaTransformer.transform(
                 transformationState.requestId,
                 trackTransforms,
@@ -127,10 +117,14 @@ class RecordAudioPresenter(
         }
     }
 
-    fun stopRecording(mediaSource: AudioRecordMediaSource) {
+    fun stopRecording(
+            audioMediaSource: AudioRecordMediaSource,
+            videoMediaSource: Camera2MediaSource
+    ) {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
             throw UnsupportedOperationException("Android Marshmallow or newer required")
         }
-        mediaSource.stopRecording()
+        audioMediaSource.stopRecording()
+        videoMediaSource.stopRecording()
     }
 }

--- a/litr-demo/src/main/java/com/linkedin/android/litr/demo/fragment/RecordAudioFragment.kt
+++ b/litr-demo/src/main/java/com/linkedin/android/litr/demo/fragment/RecordAudioFragment.kt
@@ -23,6 +23,7 @@ import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import com.linkedin.android.litr.MediaTransformer
 import com.linkedin.android.litr.demo.BaseTransformationFragment
+import com.linkedin.android.litr.demo.R
 import com.linkedin.android.litr.demo.data.RecordAudioPresenter
 import com.linkedin.android.litr.demo.data.TargetMedia
 import com.linkedin.android.litr.demo.data.TransformationPresenter
@@ -49,8 +50,8 @@ class RecordAudioFragment : BaseTransformationFragment() {
         // this.
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
             AlertDialog.Builder(requireContext())
-                    .setMessage("Android Marshmallow or newer required")
-                    .setPositiveButton("Ok") { _, _ ->
+                    .setMessage(R.string.error_marshmallow_or_newer_required)
+                    .setPositiveButton(R.string.ok) { _, _ ->
                         activity?.onBackPressed()
                     }
                     .show()

--- a/litr-demo/src/main/java/com/linkedin/android/litr/demo/view/AutoFitSurfaceView.kt
+++ b/litr-demo/src/main/java/com/linkedin/android/litr/demo/view/AutoFitSurfaceView.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2022 LinkedIn Corporation
+ * All Rights Reserved.
+ *
+ * Licensed under the BSD 2-Clause License (the "License").  See License in the project root for
+ * license information.
+ *
+ * Author: Ian Bird
+ */
+package com.linkedin.android.litr.demo.view
+
+import android.content.Context
+import android.util.AttributeSet
+import android.util.Log
+import android.view.SurfaceView
+import kotlin.math.roundToInt
+
+private const val TAG = "AutoFitSurfaceView"
+
+/**
+ * A [SurfaceView] that can be adjusted to a specified aspect ratio and performs center-crop
+ * transformation of input frames.
+ */
+class AutoFitSurfaceView @JvmOverloads constructor(
+        context: Context,
+        attrs: AttributeSet? = null,
+        defStyle: Int = 0
+) : SurfaceView(context, attrs, defStyle) {
+
+    private var aspectRatio = 0f
+
+    /**
+     * Sets the aspect ratio for this view. The size of the view will be measured based on the ratio
+     * calculated from the parameters.
+     *
+     * @param width  Camera resolution horizontal size
+     * @param height Camera resolution vertical size
+     */
+    fun setAspectRatio(width: Int, height: Int) {
+        require(width > 0 && height > 0) { "Size cannot be negative" }
+        aspectRatio = width.toFloat() / height.toFloat()
+        holder.setFixedSize(width, height)
+        requestLayout()
+    }
+
+    override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
+        super.onMeasure(widthMeasureSpec, heightMeasureSpec)
+        val width = MeasureSpec.getSize(widthMeasureSpec)
+        val height = MeasureSpec.getSize(heightMeasureSpec)
+        if (aspectRatio == 0f) {
+            setMeasuredDimension(width, height)
+        } else {
+            // Performs center-crop transformation of the camera frames
+            val newWidth: Int
+            val newHeight: Int
+            val actualRatio = if (width > height) aspectRatio else 1f / aspectRatio
+            if (width < height * actualRatio) {
+                newHeight = height
+                newWidth = (height * actualRatio).roundToInt()
+            } else {
+                newWidth = width
+                newHeight = (width / actualRatio).roundToInt()
+            }
+
+            Log.d(TAG, "Measured dimensions set: $newWidth x $newHeight")
+            setMeasuredDimension(newWidth, newHeight)
+        }
+    }
+}

--- a/litr-demo/src/main/res/layout/fragment_camera2_record.xml
+++ b/litr-demo/src/main/res/layout/fragment_camera2_record.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2022 LinkedIn Corporation -->
+<!-- All Rights Reserved. -->
+<!-- -->
+<!-- Licensed under the BSD 2-Clause License (the "License").  See License in the project root -->
+<!-- for license information. -->
+<!-- -->
+<!-- Author: Ian Bird -->
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <data>
+        <import type="android.view.View"/>
+
+        <variable
+            name="audioMediaSource"
+            type="com.linkedin.android.litr.io.AudioRecordMediaSource" />
+
+        <variable
+            name="videoMediaSource"
+            type="com.linkedin.android.litr.io.Camera2MediaSource" />
+
+        <variable
+            name="targetMedia"
+            type="com.linkedin.android.litr.demo.data.TargetMedia" />
+
+        <variable
+            name="transformationState"
+            type="com.linkedin.android.litr.demo.data.TransformationState" />
+
+        <variable
+            name="transformationPresenter"
+            type="com.linkedin.android.litr.demo.data.RecordCameraPresenter" />
+
+    </data>
+
+    <RelativeLayout
+        android:orientation="vertical"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <com.linkedin.android.litr.demo.view.AutoFitSurfaceView
+            android:id="@+id/camera_view"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_centerInParent="true"/>
+
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:background="@color/design_default_color_background"
+            android:visibility="@{transformationState.state == transformationState.STATE_RUNNING ? View.GONE : View.VISIBLE}"/>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:layout_alignParentBottom="true">
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:padding="@dimen/cell_padding"
+                android:text="@{transformationState.stats}"
+                android:visibility="@{transformationState.state == transformationState.STATE_RUNNING || transformationState.stats == null ? View.GONE : View.VISIBLE}"/>
+
+            <Button
+                android:id="@+id/button_record"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/record"
+                android:enabled="@{(transformationState.state != transformationState.STATE_RUNNING)}"
+                android:padding="@dimen/cell_padding"/>
+
+            <Button
+                android:id="@+id/button_stop"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/stop"
+                android:enabled="@{transformationState.state == transformationState.STATE_RUNNING}"
+                android:padding="@dimen/cell_padding"/>
+
+            <Button
+                android:id="@+id/button_play"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/play"
+                android:enabled="@{transformationState.state == transformationState.STATE_COMPLETED}"
+                android:padding="@dimen/cell_padding"
+                android:onClick="@{() -> transformationPresenter.play(targetMedia.contentUri)}"/>
+
+        </LinearLayout>
+
+    </RelativeLayout>
+
+</layout>

--- a/litr-demo/src/main/res/values/strings.xml
+++ b/litr-demo/src/main/res/values/strings.xml
@@ -19,8 +19,11 @@
     <string name="demo_case_extract_frames">Extract Video Frames</string>
     <string name="demo_case_transcode_to_vp9">Transcode To VP9</string>
     <string name="demo_case_audio_record">Record Audio</string>
+    <string name="demo_case_camera_record">Record Camera (via Camera2)</string>
 
     <string name="error_vp9_not_supported">VP8/VP9 is not supported</string>
+    <string name="error_marshmallow_or_newer_required">Android Marshmallow or newer required</string>
+    <string name="ok">OK</string>
 
     <string name="include">Include</string>
     <string name="overlay">Overlay</string>

--- a/litr/src/main/java/com/linkedin/android/litr/MimeType.java
+++ b/litr/src/main/java/com/linkedin/android/litr/MimeType.java
@@ -18,4 +18,5 @@ public class MimeType {
     public static final String VIDEO_HEVC = "video/hevc";
     public static final String VIDEO_VP8 = "video/x-vnd.on2.vp8";
     public static final String VIDEO_VP9 = "video/x-vnd.on2.vp9";
+    public static final String VIDEO_RAW = "video/raw";
 }

--- a/litr/src/main/java/com/linkedin/android/litr/io/AudioRecordMediaSource.kt
+++ b/litr/src/main/java/com/linkedin/android/litr/io/AudioRecordMediaSource.kt
@@ -61,7 +61,7 @@ class AudioRecordMediaSource(
     private var isRecording = false
 
     @Synchronized
-    fun start() {
+    fun startRecording() {
         createAudioRecord()
 
         // Check to make sure the AudioRecord instance is initialized.
@@ -89,7 +89,7 @@ class AudioRecordMediaSource(
     }
 
     @Synchronized
-    fun stop() {
+    fun stopRecording() {
         if (isRecording) {
             // Stop recording.
             audioRecord?.stop()

--- a/litr/src/main/java/com/linkedin/android/litr/io/Camera2MediaSource.kt
+++ b/litr/src/main/java/com/linkedin/android/litr/io/Camera2MediaSource.kt
@@ -1,0 +1,253 @@
+package com.linkedin.android.litr.io
+
+import android.content.Context
+import android.graphics.Rect
+import android.hardware.camera2.*
+import android.os.Build
+import android.os.Handler
+import android.os.HandlerThread
+import android.util.Log
+import android.util.Range
+import android.util.Size
+import android.view.Surface
+import android.view.SurfaceHolder
+import androidx.annotation.RequiresApi
+import androidx.annotation.RequiresPermission
+
+private const val TAG = "Camera2MediaSource"
+
+private const val DEFAULT_RECORD_WIDTH = 1280
+
+/**
+ * An implementation of MediaSource, which utilises Android's Camera2 APIs to capture from a
+ * CameraDevice and render to the CaptureMediaSource's input Surface. An instance of this class is
+ * expected to be both the MediaSource, and Decoder for which the pipeline is configured. This
+ * allows these components to be bypassed.
+ */
+@RequiresApi(Build.VERSION_CODES.LOLLIPOP)
+class Camera2MediaSource(
+        context: Context,
+        private val cameraId: String
+): CaptureMediaSource(), CaptureMediaSource.Callback {
+    /**
+     * Callback which notifies when the device is ready, as well as other details regarding the
+     * capture session.
+     */
+    interface Callback {
+        fun onDeviceReady(cameraCharacteristics: CameraCharacteristics)
+        fun onFrameSkipped(frameSkipCount: Int)
+
+        fun onError(exception: Exception)
+    }
+
+    var recordWidth = DEFAULT_RECORD_WIDTH
+
+    private var callback: Callback? = null
+    private var inputSurface: Surface? = null
+
+    // We support an optional SurfaceHolder that can be used as a Preview for the Camera capture.
+    private var previewSurfaceHolder: SurfaceHolder? = null
+    private val previewSurfaceHolderListener = object : SurfaceHolder.Callback {
+        override fun surfaceCreated(holder: SurfaceHolder) {
+            Log.i(TAG, "Preview Surface Created")
+            previewSurfaceHolder = holder
+        }
+
+        override fun surfaceChanged(surfaceHolder: SurfaceHolder, format: Int, width: Int, height: Int) {}
+        override fun surfaceDestroyed(surfaceHolder: SurfaceHolder) {}
+    }
+
+    private lateinit var backgroundHandlerThread: HandlerThread
+    private lateinit var backgroundHandler: Handler
+
+    private val cameraManager = context.getSystemService(Context.CAMERA_SERVICE) as CameraManager
+
+    private var cameraDevice: CameraDevice? = null
+    private var captureRequest: CaptureRequest? = null
+    private var captureSession: CameraCaptureSession? = null
+
+    private val cameraStateCallback = object : CameraDevice.StateCallback() {
+        override fun onOpened(device: CameraDevice) {
+            initDevice(device)
+        }
+
+        override fun onDisconnected(device: CameraDevice) { }
+        override fun onError(device: CameraDevice, error: Int) {
+            val msg = when(error) {
+                ERROR_CAMERA_DEVICE -> "Fatal (device)"
+                ERROR_CAMERA_DISABLED -> "Device policy"
+                ERROR_CAMERA_IN_USE -> "Camera in use"
+                ERROR_CAMERA_SERVICE -> "Fatal (service)"
+                ERROR_MAX_CAMERAS_IN_USE -> "Maximum cameras in use"
+                else -> "Unknown"
+            }
+
+            // Notify via the Callback that an error occurred.
+            val exception = RuntimeException("Camera $cameraId error: ($error) $msg")
+            Log.e(TAG, exception.message, exception)
+            callback?.onError(exception)
+        }
+    }
+
+    private val captureStateCallback = object : CameraCaptureSession.StateCallback() {
+        override fun onConfigured(session: CameraCaptureSession) {
+            captureSession = session
+            captureRequest?.let {
+                session.setRepeatingRequest(it, object : CameraCaptureSession.CaptureCallback() {
+                    override fun onCaptureCompleted(
+                            session: CameraCaptureSession,
+                            request: CaptureRequest,
+                            result: TotalCaptureResult
+                    ) {
+                        // Notify the CaptureMediaSource when a frame is captured.
+                        onFrameAvailable()
+                    }
+                }, backgroundHandler)
+            }
+        }
+
+        override fun onClosed(session: CameraCaptureSession) {
+            // When the session has been cleanly closed, we can go ahead and stop our background
+            // Thread.
+            stopBackgroundThread()
+        }
+
+        override fun onConfigureFailed(session: CameraCaptureSession) { }
+    }
+
+    init {
+        // Add ourselves as a callback to our parent CaptureMediaSource. This will allow us to
+        // determine when an input Surface is available to draw too via the Camera.
+        setCallback(this)
+    }
+
+    /**
+     * Sets the callback that will be notified on the state of our recording session.
+     */
+    fun setCallback(callback: Callback) {
+        this.callback = callback
+    }
+
+    /**
+     * Adds an optional SurfaceHolder that can be used as a Preview surface.
+     */
+    fun addPreviewSurfaceHolder(surfaceHolder: SurfaceHolder) {
+        surfaceHolder.addCallback(previewSurfaceHolderListener)
+    }
+
+    /**
+     * Opens the configured CameraDevice so that it's ready for recording. Once available, the
+     * configured Callback will be notified via onDeviceReady. Once this has done, the consumer is
+     * able to start the Transcode session.
+     */
+    @RequiresPermission("android.permission.CAMERA")
+    @Synchronized
+    fun openCamera() {
+        startBackgroundThread()
+        cameraManager.openCamera(cameraId, cameraStateCallback, backgroundHandler)
+    }
+
+    /**
+     * Stops any in-progress recording, allowing the MediaSource to notify the end of the video
+     * stream. It will also allow any internal resources to be cleaned up.
+     */
+    @Synchronized
+    fun stopRecording() {
+        stopExternal()
+
+        captureSession?.apply {
+            stopRepeating()
+            close()
+        }
+    }
+
+    /**
+     * Once a device has been opened, we can query it's Characteristics to know how to configure
+     * the session.
+     */
+    private fun initDevice(camera: CameraDevice) {
+        cameraDevice = camera
+
+        val characteristics = cameraManager.getCameraCharacteristics(camera.id)
+        val sensorRect = characteristics.get(CameraCharacteristics.SENSOR_INFO_ACTIVE_ARRAY_SIZE)
+        val sensorOrientation = characteristics.get(CameraCharacteristics.SENSOR_ORIENTATION)
+
+        val recordSize = getRecordSize(sensorRect, sensorOrientation)
+        width = recordSize.width
+        height = recordSize.height
+
+        callback?.onDeviceReady(characteristics)
+    }
+
+    /**
+     * Starts the capture session for the given CameraDevice. We will configure the input Surface
+     * provided by the CaptureMediaSource, as well as the optional Preview SurfaceHolder.
+     */
+    private fun startCaptureSession(camera: CameraDevice) {
+        val surfaces = mutableListOf<Surface>()
+        captureRequest = camera.createCaptureRequest(CameraDevice.TEMPLATE_RECORD).apply {
+            // Add the (optional) preview SurfaceHolder.
+            previewSurfaceHolder?.let {
+                addTarget(it.surface)
+                surfaces.add(it.surface)
+            }
+
+            // Add the CaptureMediaSource's input Surface.
+            inputSurface?.let {
+                addTarget(it)
+                surfaces.add(it)
+            }
+
+            // Set a fixed target frame rate. This will match what we'll assume we are encoding too.
+            set(CaptureRequest.CONTROL_AE_TARGET_FPS_RANGE, Range(frameRate, frameRate))
+        }.build()
+
+        camera.createCaptureSession(surfaces, captureStateCallback, backgroundHandler)
+    }
+
+    /**
+     * Since we don't support cropping of the sensor or input surface, we will record to a Surface
+     * that has the same aspect ratio as the camera's sensor.
+     */
+    private fun getRecordSize(sensorRect: Rect?, sensorOrientation: Int?): Size {
+        val aspectRatio = sensorRect?.let { it.height().toFloat() / it.width().toFloat() } ?: (3f / 4f)
+        val orientation = sensorOrientation ?: 0
+
+        val width = recordWidth
+
+        // Compute a suitable height of Surface, ensuring that we always generate something that is
+        // dividable by 4. This ensures a supported alignment.
+        var height = (width * aspectRatio).toInt()
+        height -= height % 4
+
+        return if (orientation == 0 || orientation == 180) {
+            Size(width, height)
+        } else {
+            Size(height, width)
+        }
+    }
+
+    private fun startBackgroundThread() {
+        backgroundHandlerThread = HandlerThread("Camera2VideoThread")
+        backgroundHandlerThread.start()
+        backgroundHandler = Handler(backgroundHandlerThread.looper)
+    }
+
+    private fun stopBackgroundThread() {
+        backgroundHandlerThread.quitSafely()
+        backgroundHandlerThread.join()
+    }
+
+    //region CaptureMediaSource...
+
+    override fun onInputSurfaceAvailable(surface: Surface) {
+        inputSurface = surface
+        cameraDevice?.let { startCaptureSession(it) }
+    }
+
+    override fun onFrameSkipped(frameSkipCount: Int) {
+        callback?.onFrameSkipped(frameSkipCount)
+    }
+
+    //endregion
+}

--- a/litr/src/main/java/com/linkedin/android/litr/io/CaptureMediaSource.kt
+++ b/litr/src/main/java/com/linkedin/android/litr/io/CaptureMediaSource.kt
@@ -1,0 +1,261 @@
+/*
+ * Copyright 2022 LinkedIn Corporation
+ * All Rights Reserved.
+ *
+ * Licensed under the BSD 2-Clause License (the "License").  See License in the project root for
+ * license information.
+ *
+ * Author: Ian Bird
+ */
+package com.linkedin.android.litr.io
+
+import android.media.MediaCodec
+import android.media.MediaFormat
+import android.util.Log
+import android.view.Surface
+import com.linkedin.android.litr.MimeType
+import com.linkedin.android.litr.codec.Decoder
+import com.linkedin.android.litr.codec.Frame
+import com.linkedin.android.litr.codec.PassthroughDecoder
+import com.linkedin.android.litr.exception.MediaSourceException
+import java.nio.ByteBuffer
+
+private const val TAG = "CaptureMediaSource"
+private const val DECODER_NAME = "CaptureMediaSource.Decoder"
+
+private const val DEFAULT_FRAME_RATE = 30
+private const val DEFAULT_BITRATE = 10_000_000
+private const val DEFAULT_KEY_FRAME_INTERVAL = 5
+
+/**
+ * An implementation of MediaSource, which exposes the input {@link Surface} of the encoder via a
+ * Callback. An instance of this class is expected to be both the MediaSource, and Decoder for which
+ * the pipeline is configured. This allows these components to be bypassed.
+ */
+open class CaptureMediaSource: MediaSource, Decoder {
+    /**
+     * Callback which notifies when the input surface is available to be written too.
+     */
+    interface Callback {
+        fun onInputSurfaceAvailable(inputSurface: Surface)
+        fun onFrameSkipped(frameSkipCount: Int)
+    }
+
+    var width = 0
+    var height = 0
+    var bitrate = DEFAULT_BITRATE
+    var keyFrameInterval = DEFAULT_KEY_FRAME_INTERVAL
+    var orientation = 0
+
+    private var callback: Callback? = null
+
+    // We compute the presentation time stamps ourselves using the known (fixed) frame rate to know
+    // the duration of each frame.
+    private var sampleIncrementUs = getSampleIncrementUs(DEFAULT_FRAME_RATE)
+    var frameRate = DEFAULT_FRAME_RATE
+        set(value) {
+            field = value
+
+            // After the frame rate has been modified, we need to make sure we update our sample
+            // increment.
+            sampleIncrementUs = getSampleIncrementUs(value)
+        }
+
+    // Internally, we use the PassthroughDecoder to handle input and output Frames. This is because
+    // we are rendering to the Surface directly, but still need to manage input/output presentation
+    // times as well as flags.
+    private var passthroughDecoder = PassthroughDecoder(1)
+
+    private var frameCounter = 0
+    private var frameAvailable = false
+    private var frameSkipCount = 0
+    private var isCapturing = false
+
+    /**
+     * Sets the callback that will be notified when the input Surface is available, and details of
+     * any skipped frames.
+     */
+    fun setCallback(callback: Callback) {
+        this.callback = callback
+    }
+
+    //region MediaSource...
+    override fun getOrientationHint() = orientation
+
+    override fun getTrackCount() = 1
+
+    override fun getTrackFormat(track: Int): MediaFormat {
+        return MediaFormat.createVideoFormat(
+                MimeType.VIDEO_RAW,
+                width,
+                height
+        ).apply {
+            setInteger(MediaFormat.KEY_FRAME_RATE, frameRate)
+        }
+    }
+
+    override fun selectTrack(track: Int) {
+        // Since we only support a single (audio) track, there is nothing to select.
+    }
+
+    override fun seekTo(position: Long, mode: Int) {
+        // We don't support seeking, since we're recording live.
+    }
+
+    override fun getSampleTrackIndex() = 0
+
+    override fun readSampleData(buffer: ByteBuffer, offset: Int): Int {
+        // If the recording has been stopped, then there are no more samples to be read.
+        if (!isCapturing) {
+            Log.i(TAG, "Reporting no more samples")
+            return -1
+        }
+
+        // There is no real data to read, but we can pretend...
+        return 0
+    }
+
+    override fun getSampleTime(): Long {
+        // If the recording has been stopped, then there are no more samples to be read.
+        if (!isCapturing) {
+            Log.i(TAG, "Reporting no more sample times")
+            return -1
+        }
+
+        // We overwrite the presentation time stamp when decoding, to match which frame we expect to
+        // be rendering. This is more reliable than trying to guess/assume inside the MediaSource.
+        return 0
+    }
+
+    override fun getSampleFlags(): Int {
+        // If the capturing has been stopped, then any further samples read should report the end of
+        // the stream.
+        if (!isCapturing) {
+            Log.i(TAG, "Reporting end of stream")
+            return MediaCodec.BUFFER_FLAG_END_OF_STREAM
+        }
+
+        return 0
+    }
+
+    override fun advance() {
+        // Nothing to advance.
+    }
+
+    override fun getSize() = -1L
+
+    //endregion MediaSource
+
+    //region Decoder
+
+    override fun init(mediaFormat: MediaFormat, surface: Surface?) {
+        passthroughDecoder.init(mediaFormat, surface)
+
+        // Notify via our Callback that the Surface has become available.
+        surface?.let { callback?.onInputSurfaceAvailable(it) }
+    }
+
+    override fun start() {
+        // Check to make sure we've been configured with a valid width and height.
+        if (width <= 0 || height <= 0) {
+            throw MediaSourceException(
+                    MediaSourceException.Error.DATA_SOURCE,
+                    null,
+                    IllegalStateException("Invalid width and height"))
+        }
+
+        passthroughDecoder.start()
+        isCapturing = true
+    }
+
+    override fun isRunning() = passthroughDecoder.isRunning
+
+    override fun dequeueInputFrame(timeout: Long) = passthroughDecoder.dequeueInputFrame(timeout)
+
+    override fun getInputFrame(tag: Int) = passthroughDecoder.getInputFrame(tag)
+
+    override fun queueInputFrame(frame: Frame) = passthroughDecoder.queueInputFrame(frame)
+
+    override fun dequeueOutputFrame(timeout: Long) = passthroughDecoder.dequeueOutputFrame(timeout)
+
+    override fun getOutputFrame(tag: Int): Frame? {
+        // The input frame will not have a correct presentation time stamp. We will therefore
+        // update it based upon which frame we expect to be rendering.
+        return passthroughDecoder.getOutputFrame(tag)?.apply {
+            val frame = (frameCounter - 1).coerceAtLeast(0)
+            bufferInfo.presentationTimeUs = frame * sampleIncrementUs
+        }
+    }
+
+    override fun releaseOutputFrame(tag: Int, render: Boolean) {
+        if (render && !frameAvailable) {
+            Log.e(TAG, "Frame not yet available")
+        }
+
+        passthroughDecoder.releaseOutputFrame(tag, false)
+        frameAvailable = false
+    }
+
+    override fun getOutputFormat() = getTrackFormat(0)
+
+    override fun stop() {
+        passthroughDecoder.stop()
+    }
+
+    override fun getName() = DECODER_NAME
+
+    //endregion
+
+    /**
+     * Method to be called when a new frame is available from the Surface provided via
+     * {@link Callback}.
+     */
+    fun onFrameAvailable() {
+        // If a frame is still available when a new frame becomes available, this means it will be
+        // skipped in the output. The encoder hasn't had the opportunity to read it from the
+        // Surface. Too many skipped frames could suggest that we're trying to capture a video at a
+        // quality that is too high for the device's encoder.
+        if (frameAvailable && isCapturing) {
+            frameSkipCount++
+
+            Log.e(TAG, "Frame Skipped (Count: $frameSkipCount)")
+            callback?.onFrameSkipped(frameSkipCount)
+        }
+
+        frameCounter += 1
+        frameAvailable = true
+    }
+
+    /**
+     * Method to notify that the Media Source should expect no further renders. This will allow the
+     * source to notify that we've hit the end of the stream, allowing the transcode to complete.
+     */
+    fun stopExternal() {
+        isCapturing = false
+    }
+
+    override fun release() {
+        passthroughDecoder.release()
+        isCapturing = false
+
+        if (frameCounter > 0) {
+            Log.i(TAG, "Frame Count: $frameCounter")
+            Log.i(TAG, "Video Duration: ${frameCounter * sampleIncrementUs}")
+        }
+
+        if (frameSkipCount > 0) {
+            Log.e(TAG, "Frame Skip Count: $frameSkipCount")
+        }
+
+        frameCounter = 0
+        frameSkipCount = 0
+    }
+
+    /**
+     * Computes the duration of each sample based upon the target frame rate, in microseconds.
+     */
+    private fun getSampleIncrementUs(frameRate: Int): Long {
+        val frameIncrementS = 1.0 / frameRate
+        return (frameIncrementS * 1000000).toLong()
+    }
+}


### PR DESCRIPTION
This PR introduces two new MediaSources:
 - `ExternalMediaSource`: This provides the owner direct access to the Surface that will be used as the input into any configured filters, followed by the encoder. The reason for this is to allow non-file based sources of video.
 - `Camera2MediaSource`: This utilises the `ExternalMediaSource` and uses Android's Camera2 APIs to render from the camera to the input Surface. This is being combined with the previously landed `AudioRecordMediaSource` that is adding the audio stream. This demonstrates a Camera to File example.

Also, one thing to note is that the ExternalMediaSource does not support cropping. It expects the source aspect ratio to match that of the file/target aspect ratio. We could either keep this as a hard constraint, or we could introduce a CroppingFilter to handle this case.