### PR TITLE
Move RecordCamera2Fragment to fragment package

### DIFF
--- a/litr-demo/src/main/java/com/linkedin/android/litr/demo/DemoCase.java
+++ b/litr-demo/src/main/java/com/linkedin/android/litr/demo/DemoCase.java
@@ -19,6 +19,7 @@ import com.linkedin.android.litr.demo.fragment.FreeTransformVideoGlFragment;
 import com.linkedin.android.litr.demo.fragment.MockTranscodeFragment;
 import com.linkedin.android.litr.demo.fragment.MuxVideoAndAudioFragment;
 import com.linkedin.android.litr.demo.fragment.RecordAudioFragment;
+import com.linkedin.android.litr.demo.fragment.RecordCamera2Fragment;
 import com.linkedin.android.litr.demo.fragment.SquareCenterCropFragment;
 import com.linkedin.android.litr.demo.fragment.TranscodeAudioFragment;
 import com.linkedin.android.litr.demo.fragment.TranscodeToVp9Fragment;

--- a/litr-demo/src/main/java/com/linkedin/android/litr/demo/fragment/CameraSizes.kt
+++ b/litr-demo/src/main/java/com/linkedin/android/litr/demo/fragment/CameraSizes.kt
@@ -7,7 +7,7 @@
  *
  * Author: Ian Bird
  */
-package com.linkedin.android.litr.demo
+package com.linkedin.android.litr.demo.fragment
 
 import android.graphics.Point
 import android.hardware.camera2.CameraCharacteristics

--- a/litr-demo/src/main/java/com/linkedin/android/litr/demo/fragment/RecordAudioFragment.kt
+++ b/litr-demo/src/main/java/com/linkedin/android/litr/demo/fragment/RecordAudioFragment.kt
@@ -26,7 +26,6 @@ import com.linkedin.android.litr.demo.BaseTransformationFragment
 import com.linkedin.android.litr.demo.R
 import com.linkedin.android.litr.demo.data.RecordAudioPresenter
 import com.linkedin.android.litr.demo.data.TargetMedia
-import com.linkedin.android.litr.demo.data.TransformationPresenter
 import com.linkedin.android.litr.demo.data.TransformationState
 import com.linkedin.android.litr.demo.databinding.FragmentAudioRecordBinding
 import com.linkedin.android.litr.io.AudioRecordMediaSource

--- a/litr-demo/src/main/java/com/linkedin/android/litr/demo/fragment/RecordCamera2Fragment.kt
+++ b/litr-demo/src/main/java/com/linkedin/android/litr/demo/fragment/RecordCamera2Fragment.kt
@@ -7,7 +7,7 @@
  *
  * Author: Ian Bird
  */
-package com.linkedin.android.litr.demo
+package com.linkedin.android.litr.demo.fragment
 
 import android.Manifest
 import android.app.Activity
@@ -26,6 +26,8 @@ import androidx.annotation.RequiresApi
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import com.linkedin.android.litr.MediaTransformer
+import com.linkedin.android.litr.demo.BaseTransformationFragment
+import com.linkedin.android.litr.demo.R
 import com.linkedin.android.litr.demo.data.RecordCameraPresenter
 import com.linkedin.android.litr.demo.data.TargetMedia
 import com.linkedin.android.litr.demo.data.TransformationState


### PR DESCRIPTION
It looks like I landed the `RecordCamera2Fragment` **after** the fragments had been moved into a new / dedicated package. This PR simply moves these new classes to their suitable location, along with fixing the imports.