### PR TITLE
[WIP] Implement native litr-muxers module

### DIFF
--- a/litr-demo/build.gradle
+++ b/litr-demo/build.gradle
@@ -40,6 +40,7 @@ android {
 dependencies {
     implementation project(':litr')
     implementation project(':litr-filters')
+    implementation project(':litr-muxers')
 
     implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation 'androidx.recyclerview:recyclerview:1.2.0'

--- a/litr-demo/src/main/java/com/linkedin/android/litr/demo/DemoCase.java
+++ b/litr-demo/src/main/java/com/linkedin/android/litr/demo/DemoCase.java
@@ -18,6 +18,8 @@ import com.linkedin.android.litr.demo.fragment.ExtractFramesFragment;
 import com.linkedin.android.litr.demo.fragment.FreeTransformVideoGlFragment;
 import com.linkedin.android.litr.demo.fragment.MockTranscodeFragment;
 import com.linkedin.android.litr.demo.fragment.MuxVideoAndAudioFragment;
+import com.linkedin.android.litr.demo.fragment.NativeMuxerCameraFragment;
+import com.linkedin.android.litr.demo.fragment.NativeMuxerTranscodeFragment;
 import com.linkedin.android.litr.demo.fragment.RecordAudioFragment;
 import com.linkedin.android.litr.demo.fragment.SquareCenterCropFragment;
 import com.linkedin.android.litr.demo.fragment.TranscodeAudioFragment;
@@ -41,7 +43,9 @@ public enum DemoCase {
     EXTRACT_FRAMES(R.string.demo_case_extract_frames, "ExtractFramesFragment", new ExtractFramesFragment()),
     TRANSCODE_TO_VP9(R.string.demo_case_transcode_to_vp9, "TranscodeToVp9Fragment", new TranscodeToVp9Fragment()),
     RECORD_AUDIO(R.string.demo_case_audio_record, "RecordAudio", new RecordAudioFragment()),
-    @SuppressLint("NewApi") RECORD_CAMERA(R.string.demo_case_camera_record, "RecordCamera2", new RecordCamera2Fragment());
+    @SuppressLint("NewApi") RECORD_CAMERA(R.string.demo_case_camera_record, "RecordCamera2", new RecordCamera2Fragment()),
+    NATIVE_MUXER_TRANSCODE(R.string.demo_case_native_muxer_transcode, "NativeMuxerTranscode", new NativeMuxerTranscodeFragment()),
+    @SuppressLint("NewApi") NATIVE_MUXER_CAMERA(R.string.demo_case_native_muxer_camera, "NativeMuxerCamera", new NativeMuxerCameraFragment());
 
     @StringRes int displayName;
     String fragmentTag;

--- a/litr-demo/src/main/java/com/linkedin/android/litr/demo/RecordCamera2Fragment.kt
+++ b/litr-demo/src/main/java/com/linkedin/android/litr/demo/RecordCamera2Fragment.kt
@@ -45,8 +45,8 @@ private const val DEFAULT_TARGET_BITRATE = 5_000_000 // 5Mbps
 private const val DEFAULT_RECORD_WIDTH = 1280
 
 @RequiresApi(Build.VERSION_CODES.M)
-class RecordCamera2Fragment : BaseTransformationFragment() {
-    private lateinit var binding: FragmentCamera2RecordBinding
+open class RecordCamera2Fragment : BaseTransformationFragment() {
+    protected lateinit var binding: FragmentCamera2RecordBinding
 
     private lateinit var mediaTransformer: MediaTransformer
     private var targetMedia: TargetMedia = TargetMedia()
@@ -77,7 +77,8 @@ class RecordCamera2Fragment : BaseTransformationFragment() {
                     binding.audioMediaSource!!,
                     binding.videoMediaSource!!,
                     binding.targetMedia!!,
-                    binding.transformationState!!
+                    binding.transformationState!!,
+                    binding.enableNativeMuxer == true
             )
         }
 

--- a/litr-demo/src/main/java/com/linkedin/android/litr/demo/data/SharedMediaStoragePublisher.kt
+++ b/litr-demo/src/main/java/com/linkedin/android/litr/demo/data/SharedMediaStoragePublisher.kt
@@ -10,6 +10,7 @@ import android.os.Handler
 import android.os.Looper
 import android.provider.MediaStore
 import android.util.Log
+import android.webkit.MimeTypeMap
 import androidx.annotation.ChecksSdkIntAtLeast
 import androidx.annotation.WorkerThread
 import java.io.File
@@ -49,9 +50,11 @@ class SharedMediaStoragePublisher @JvmOverloads constructor(
         if (!file.exists()) return null
 
         val newFileName = file.name
+        val extension = MimeTypeMap.getFileExtensionFromUrl(newFileName)
+        val mimeType = MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension) ?: MIME_TYPE_MPEG_4
 
         val values = ContentValues().apply {
-            put(MediaStore.Video.Media.MIME_TYPE, MIME_TYPE_MPEG_4)
+            put(MediaStore.Video.Media.MIME_TYPE, mimeType)
             put(MediaStore.Video.Media.TITLE, newFileName)
             put(MediaStore.Video.Media.DISPLAY_NAME, newFileName)
             put(MediaStore.Video.Media.DATE_TAKEN, System.currentTimeMillis())

--- a/litr-demo/src/main/java/com/linkedin/android/litr/demo/data/TranscodeVideoGlPresenter.kt
+++ b/litr-demo/src/main/java/com/linkedin/android/litr/demo/data/TranscodeVideoGlPresenter.kt
@@ -23,6 +23,7 @@ import com.linkedin.android.litr.io.MediaMuxerMediaTarget
 import com.linkedin.android.litr.io.MediaRange
 import com.linkedin.android.litr.io.MediaSource
 import com.linkedin.android.litr.io.MediaTarget
+import com.linkedin.android.litr.muxers.NativeMediaMuxerMediaTarget
 import com.linkedin.android.litr.render.AudioRenderer
 import com.linkedin.android.litr.render.GlVideoRenderer
 import java.util.UUID
@@ -40,7 +41,8 @@ class TranscodeVideoGlPresenter(
         targetMedia: TargetMedia,
         trimConfig: TrimConfig,
         audioVolumeConfig: AudioVolumeConfig,
-        transformationState: TransformationState
+        transformationState: TransformationState,
+        enableNativeMuxer: Boolean
     ) {
         if (targetMedia.includedTrackCount < 1) {
             return
@@ -68,12 +70,11 @@ class TranscodeVideoGlPresenter(
                 }
             }
 
-            val mediaTarget: MediaTarget = MediaMuxerMediaTarget(
-                context,
-                Uri.fromFile(targetMedia.targetFile),
-                targetMedia.includedTrackCount,
-                videoRotation,
-                if (hasVp8OrVp9Track(targetMedia.tracks)) MediaMuxer.OutputFormat.MUXER_OUTPUT_WEBM else MediaMuxer.OutputFormat.MUXER_OUTPUT_MPEG_4
+            val mediaTarget = buildMediaTarget(
+                    context,
+                    targetMedia,
+                    videoRotation,
+                    enableNativeMuxer
             )
 
             val trackTransforms: MutableList<TrackTransform> = ArrayList(targetMedia.tracks.size)
@@ -131,6 +132,35 @@ class TranscodeVideoGlPresenter(
             )
         } catch (ex: MediaTransformationException) {
             Log.e(TAG, "Exception when trying to perform track operation", ex)
+        }
+    }
+
+    private fun buildMediaTarget(
+            context: Context,
+            targetMedia: TargetMedia,
+            videoRotation: Int,
+            enableNativeMuxer: Boolean
+    ): MediaTarget {
+        val outputFormat = if (hasVp8OrVp9Track(targetMedia.tracks))
+            MediaMuxer.OutputFormat.MUXER_OUTPUT_WEBM
+        else
+            MediaMuxer.OutputFormat.MUXER_OUTPUT_MPEG_4
+
+        return if (enableNativeMuxer) {
+            NativeMediaMuxerMediaTarget(
+                    targetMedia.targetFile.absolutePath,
+                    targetMedia.includedTrackCount,
+                    videoRotation,
+                    outputFormat
+            )
+        } else {
+            MediaMuxerMediaTarget(
+                    context,
+                    Uri.fromFile(targetMedia.targetFile),
+                    targetMedia.includedTrackCount,
+                    videoRotation,
+                    outputFormat
+            )
         }
     }
 }

--- a/litr-demo/src/main/java/com/linkedin/android/litr/demo/fragment/NativeMuxerCameraFragment.kt
+++ b/litr-demo/src/main/java/com/linkedin/android/litr/demo/fragment/NativeMuxerCameraFragment.kt
@@ -1,0 +1,22 @@
+package com.linkedin.android.litr.demo.fragment
+
+import android.os.Build
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.annotation.RequiresApi
+import com.linkedin.android.litr.demo.RecordCamera2Fragment
+
+@RequiresApi(Build.VERSION_CODES.M)
+class NativeMuxerCameraFragment: RecordCamera2Fragment() {
+    override fun onCreateView(
+            inflater: LayoutInflater,
+            container: ViewGroup?,
+            savedInstanceState: Bundle?
+    ): View {
+        return super.onCreateView(inflater, container, savedInstanceState).also {
+            binding.enableNativeMuxer = true
+        }
+    }
+}

--- a/litr-demo/src/main/java/com/linkedin/android/litr/demo/fragment/NativeMuxerTranscodeFragment.kt
+++ b/litr-demo/src/main/java/com/linkedin/android/litr/demo/fragment/NativeMuxerTranscodeFragment.kt
@@ -1,0 +1,19 @@
+package com.linkedin.android.litr.demo.fragment
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import com.linkedin.android.litr.demo.MediaPickerListener
+
+class NativeMuxerTranscodeFragment: TranscodeVideoGlFragment(), MediaPickerListener {
+    override fun onCreateView(
+            inflater: LayoutInflater,
+            container: ViewGroup?,
+            savedInstanceState: Bundle?
+    ): View? {
+        return super.onCreateView(inflater, container, savedInstanceState).also {
+            binding.enableNativeMuxer = true
+        }
+    }
+}

--- a/litr-demo/src/main/java/com/linkedin/android/litr/demo/fragment/TranscodeVideoGlFragment.java
+++ b/litr-demo/src/main/java/com/linkedin/android/litr/demo/fragment/TranscodeVideoGlFragment.java
@@ -32,7 +32,7 @@ import java.io.File;
 
 public class TranscodeVideoGlFragment extends BaseTransformationFragment implements MediaPickerListener {
 
-    private FragmentTranscodeVideoGlBinding binding;
+    protected FragmentTranscodeVideoGlBinding binding;
 
     private MediaTransformer mediaTransformer;
 

--- a/litr-demo/src/main/res/layout/fragment_camera2_record.xml
+++ b/litr-demo/src/main/res/layout/fragment_camera2_record.xml
@@ -32,6 +32,10 @@
             name="transformationPresenter"
             type="com.linkedin.android.litr.demo.data.RecordCameraPresenter" />
 
+        <variable
+            name="enableNativeMuxer"
+            type="java.lang.Boolean" />
+
     </data>
 
     <RelativeLayout

--- a/litr-demo/src/main/res/layout/fragment_transcode_video_gl.xml
+++ b/litr-demo/src/main/res/layout/fragment_transcode_video_gl.xml
@@ -38,6 +38,10 @@
             name="transformationPresenter"
             type="com.linkedin.android.litr.demo.data.TranscodeVideoGlPresenter" />
 
+        <variable
+            name="enableNativeMuxer"
+            type="java.lang.Boolean" />
+
     </data>
 
     <androidx.core.widget.NestedScrollView
@@ -83,7 +87,7 @@
                 android:text="@string/transcode"
                 android:enabled="@{sourceMedia != null &amp;&amp; targetMedia != null &amp;&amp; targetMedia.getIncludedTrackCount() > 0 &amp;&amp; (transformationState.state != transformationState.STATE_RUNNING)}"
                 android:padding="@dimen/cell_padding"
-                android:onClick="@{() -> transformationPresenter.startTransformation(sourceMedia, targetMedia, trimConfig, audioVolumeConfig, transformationState)}"/>
+                android:onClick="@{() -> transformationPresenter.startTransformation(sourceMedia, targetMedia, trimConfig, audioVolumeConfig, transformationState, enableNativeMuxer)}"/>
 
             <include layout="@layout/section_transformation_progress"
                 android:id="@+id/section_transformation_progress"

--- a/litr-demo/src/main/res/values/strings.xml
+++ b/litr-demo/src/main/res/values/strings.xml
@@ -20,6 +20,8 @@
     <string name="demo_case_transcode_to_vp9">Transcode To VP9</string>
     <string name="demo_case_audio_record">Record Audio</string>
     <string name="demo_case_camera_record">Record Camera (via Camera2)</string>
+    <string name="demo_case_native_muxer_transcode">Native Muxer (Transcode)</string>
+    <string name="demo_case_native_muxer_camera">Native Muxer (Camera)</string>
 
     <string name="error_vp9_not_supported">VP8/VP9 is not supported</string>
     <string name="error_marshmallow_or_newer_required">Android Marshmallow or newer required</string>

--- a/litr-muxers/.gitignore
+++ b/litr-muxers/.gitignore
@@ -1,0 +1,4 @@
+/build
+
+# FFmpeg symlink
+src/main/cpp/ffmpeg

--- a/litr-muxers/README.md
+++ b/litr-muxers/README.md
@@ -1,0 +1,58 @@
+# Litr Muxers module
+
+The Litr Muxers module provides `NativeMediaMuxerMediaTarget`, which uses FFmpeg for muxing 
+individual streams into a target file container.
+
+## Build instructions (Linux, macOS)
+
+It is necessary to manually build the FFmpeg library, so that gradle  can bundle the FFmpeg binaries
+in the APK:
+
+* Set the following shell variable:
+
+```
+cd "<path to project checkout>"
+FFMPEG_MODULE_PATH="$(pwd)/litr-muxers/src/main"
+```
+
+* Download the [Android NDK][] and set its location in a shell variable.
+  This build configuration has been tested on NDK r22b.
+
+```
+NDK_PATH="<path to Android NDK>"
+```
+
+* Set the host platform (use "darwin-x86_64" for Mac OS X):
+
+```
+HOST_PLATFORM="linux-x86_64"
+```
+
+* Fetch FFmpeg and checkout an appropriate branch. We cannot guarantee
+  compatibility with all versions of FFmpeg. We currently recommend version 4.2:
+
+```
+cd "<preferred location for ffmpeg>" && \
+git clone git://source.ffmpeg.org/ffmpeg && \
+cd ffmpeg && \
+git checkout release/4.2 && \
+FFMPEG_PATH="$(pwd)"
+```
+
+*   Add a link to the FFmpeg source code in the FFmpeg module `cpp` directory.
+
+```
+cd "${FFMPEG_MODULE_PATH}/cpp" && \
+ln -s "$FFMPEG_PATH" ffmpeg
+```
+
+* Execute `build_ffmpeg.sh` to build FFmpeg for `armeabi-v7a`, `arm64-v8a`,
+  `x86` and `x86_64`. The script can be edited if you need to build for
+  different architectures:
+
+```
+cd "${FFMPEG_MODULE_PATH}/cpp" && \
+chmod +x build_ffmpeg.sh && \
+./build_ffmpeg.sh \
+  "${FFMPEG_MODULE_PATH}" "${NDK_PATH}" "${HOST_PLATFORM}"
+```

--- a/litr-muxers/build.gradle
+++ b/litr-muxers/build.gradle
@@ -1,0 +1,36 @@
+plugins {
+    id 'com.android.library'
+    id 'org.jetbrains.kotlin.android'
+}
+
+android {
+    namespace 'com.linkedin.android.litr.muxers'
+
+    compileSdkVersion rootProject.ext.compileSdkVersion
+    buildToolsVersion rootProject.ext.buildToolsVersion
+
+    defaultConfig {
+        minSdkVersion rootProject.ext.minSdkVersion
+        targetSdkVersion rootProject.ext.targetSdkVersion
+    }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
+    kotlinOptions {
+        freeCompilerArgs += "-Xopt-in=kotlin.RequiresOptIn"
+    }
+
+    externalNativeBuild {
+        cmake {
+            path file('src/main/cpp/CMakeLists.txt')
+            version '3.10.2'
+        }
+    }
+}
+
+dependencies {
+    implementation project(':litr')
+}

--- a/litr-muxers/src/main/AndroidManifest.xml
+++ b/litr-muxers/src/main/AndroidManifest.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+</manifest>

--- a/litr-muxers/src/main/cpp/CMakeLists.txt
+++ b/litr-muxers/src/main/cpp/CMakeLists.txt
@@ -1,0 +1,44 @@
+cmake_minimum_required(VERSION 3.10.2)
+
+# Enable C++11 features.
+set(CMAKE_CXX_STANDARD 11)
+
+project(LiTrMuxers C CXX)
+
+# Additional flags needed for "arm64-v8a" from NDK 23.1.7779620 and above.
+if(${ANDROID_ABI} MATCHES "arm64-v8a")
+    set(CMAKE_CXX_FLAGS "-Wl,-Bsymbolic")
+endif()
+
+set(ffmpeg_location "${CMAKE_CURRENT_SOURCE_DIR}/ffmpeg")
+set(ffmpeg_binaries "${ffmpeg_location}/android-libs/${ANDROID_ABI}")
+
+foreach(ffmpeg_lib avutil avcodec avformat)
+    set(ffmpeg_lib_filename lib${ffmpeg_lib}.so)
+    set(ffmpeg_lib_file_path ${ffmpeg_binaries}/${ffmpeg_lib_filename})
+    add_library(
+            ${ffmpeg_lib}
+            SHARED
+            IMPORTED)
+    set_target_properties(
+            ${ffmpeg_lib} PROPERTIES
+            IMPORTED_LOCATION
+            ${ffmpeg_lib_file_path})
+endforeach()
+
+include_directories(${ffmpeg_location})
+find_library(log-lib log)
+
+add_library(litr-muxers SHARED
+        FFmpeg.h
+        Logging.h
+        NativeLogger.cpp
+        NativeMediaMuxer.cpp
+        MediaMuxer.cpp)
+
+target_link_libraries(litr-muxers
+        PRIVATE android
+        PRIVATE avcodec
+        PRIVATE avutil
+        PRIVATE avformat
+        PRIVATE ${log-lib})

--- a/litr-muxers/src/main/cpp/FFmpeg.h
+++ b/litr-muxers/src/main/cpp/FFmpeg.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2022 LinkedIn Corporation
+ * All Rights Reserved.
+ *
+ * Licensed under the BSD 2-Clause License (the "License").  See License in the project root for
+ * license information.
+ *
+ * Author: Ian Bird
+ */
+
+#ifndef LITR_FFMPEG_H
+#define LITR_FFMPEG_H
+
+extern "C" {
+#include "libavutil/log.h"
+#include "libavformat/avformat.h"
+}
+
+#endif //LITR_FFMPEG_H

--- a/litr-muxers/src/main/cpp/Logging.h
+++ b/litr-muxers/src/main/cpp/Logging.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2022 LinkedIn Corporation
+ * All Rights Reserved.
+ *
+ * Licensed under the BSD 2-Clause License (the "License").  See License in the project root for
+ * license information.
+ *
+ * Author: Ian Bird
+ */
+
+#ifndef LITR_LOGGING_H
+#define LITR_LOGGING_H
+
+#include <android/log.h>
+
+#define LOG_TAG "LiTrMuxers_JNI"
+#define LOGD(...) ((void)__android_log_print(ANDROID_LOG_DEBUG, LOG_TAG, __VA_ARGS__))
+#define LOGI(...) ((void)__android_log_print(ANDROID_LOG_INFO, LOG_TAG, __VA_ARGS__))
+#define LOGW(...) ((void)__android_log_print(ANDROID_LOG_WARN, LOG_TAG, __VA_ARGS__))
+#define LOGE(...) ((void)__android_log_print(ANDROID_LOG_ERROR, LOG_TAG, __VA_ARGS__))
+
+#endif //LITR_LOGGING_H

--- a/litr-muxers/src/main/cpp/MediaMuxer.cpp
+++ b/litr-muxers/src/main/cpp/MediaMuxer.cpp
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2022 LinkedIn Corporation
+ * All Rights Reserved.
+ *
+ * Licensed under the BSD 2-Clause License (the "License").  See License in the project root for
+ * license information.
+ *
+ * Author: Ian Bird
+ */
+
+#include <string>
+
+#include "MediaMuxer.h"
+#include "FFmpeg.h"
+#include "Logging.h"
+
+// References:
+//  - https://github.com/FFmpeg/FFmpeg/blob/n3.0/doc/examples/muxing.c#L569
+//  - https://github.com/leandromoreira/ffmpeg-libav-tutorial
+
+MediaMuxer::MediaMuxer() = default;
+
+MediaMuxer::~MediaMuxer() {
+    if (!mContext) {
+        return;
+    }
+
+    if (mContext->pb != nullptr) {
+        // Close output file.
+        avio_closep(&mContext->pb);
+    }
+
+    // Free the context.
+    avformat_free_context(mContext);
+}
+
+int MediaMuxer::init(const char *path, const char *formatName) {
+    int err = avformat_alloc_output_context2(&mContext, nullptr, formatName, path);
+    if (err < 0) {
+        logErrorCode("Failed to allocate AVFormatContext", err);
+        return STATUS_ERROR;
+    }
+
+    return STATUS_OK;
+}
+
+int MediaMuxer::start(const char *keys[], const char *values[], int optionSize) {
+    int err;
+
+    // Open File.
+    err = avio_open(&mContext->pb, mContext->url, AVIO_FLAG_WRITE);
+    if (err < 0) {
+        logErrorCode("Failed to open file", err);
+        return STATUS_ERROR;
+    }
+
+    // Build the muxer's options with the keys and corresponding values that were provided.
+    AVDictionary *opts = nullptr;
+    for (int i = 0; i < optionSize; i++) {
+        av_dict_set(&opts, keys[i], values[i], 0);
+    }
+
+    // Write the stream header, if any.
+    err = avformat_write_header(mContext, &opts);
+    if (err < 0) {
+        logErrorCode("Failed to write stream header", err);
+        return STATUS_ERROR;
+    }
+
+    return STATUS_OK;
+}
+
+int MediaMuxer::stop() {
+    // Write the trailer, if any.
+    int err = av_write_trailer(mContext);
+    if (err < 0) {
+        logErrorCode("Failed to write trailer", err);
+        return STATUS_ERROR;
+    }
+
+    // Close output file.
+    avio_closep(&mContext->pb);
+
+    // Free the context.
+    avformat_free_context(mContext);
+    mContext = nullptr;
+    return STATUS_OK;
+}
+
+int MediaMuxer::addVideoStream(const char *codec_name, int64_t bitrate, int width, int height,
+                               uint8_t *extradata, int extradata_size) {
+    AVStream* stream = addStream(codec_name, bitrate, extradata, extradata_size);
+    if (!stream) {
+        LOGE("Failed to create new stream");
+        return STATUS_ERROR;
+    }
+
+    // Add the video specific stream details.
+    stream->codecpar->width = width;
+    stream->codecpar->height = height;
+
+    return stream->index;
+}
+
+int MediaMuxer::addAudioStream(const char *codec_name, int64_t bitrate, int channels,
+                               int sample_rate, int frame_size, uint8_t *extradata,
+                               int extradata_size) {
+    AVStream* stream = addStream(codec_name, bitrate, extradata, extradata_size);
+    if (!stream) {
+        LOGE("Failed to create new stream");
+        return STATUS_ERROR;
+    }
+
+    // Add the audio specific stream details.
+    stream->codecpar->channels = channels;
+    stream->codecpar->sample_rate = sample_rate;
+    stream->codecpar->frame_size = frame_size;
+
+    return stream->index;
+}
+
+AVStream* MediaMuxer::addStream(const char *codec_name, int64_t bitrate, uint8_t *extradata, int extradata_size) {
+    AVStream* stream = avformat_new_stream(mContext, nullptr);
+    if (!stream) {
+        LOGE("Failed to allocate new stream");
+        return nullptr;
+    }
+
+    // Look up the AVCodecDescriptor based upon it's name. If we don't locate/understand it, we are
+    // unable to determine the codec type (video, audio, etc) as well as it's AVCodecID.
+    const AVCodecDescriptor* descriptor = avcodec_descriptor_get_by_name(codec_name);
+    if (!descriptor) {
+        LOGE("Failed to identify AVCodecDescriptor by name");
+        return nullptr;
+    }
+
+    // Build known, common, stream details...
+    stream->codecpar->codec_type = descriptor->type;
+    stream->codecpar->codec_id = descriptor->id;
+    stream->codecpar->bit_rate = bitrate;
+
+    // If extra data was provided, we should copy it for the stream.
+    if (extradata && extradata_size) {
+        stream->codecpar->extradata_size = extradata_size;
+        stream->codecpar->extradata = static_cast<uint8_t *>(av_mallocz(
+                extradata_size + AV_INPUT_BUFFER_PADDING_SIZE));
+        memcpy(stream->codecpar->extradata, extradata, extradata_size);
+    }
+
+    // We will set all streams to have a time base that is in microseconds. This is because we
+    // expect all PTS values provided to be in those units, since that's what Android provides.
+    stream->time_base = (AVRational){ 1, 1000000 };
+
+    return stream;
+}
+
+int MediaMuxer::writeSampleData(int stream_index, uint8_t *buffer, int size, int64_t ptsUs, int flags) {
+    // Build the packet that we will attempt to write.
+    AVPacket pkt = { 0 }; // Data and size must be 0;
+    av_init_packet(&pkt);
+
+    // Populate the packet data with what we've been given. Since we're using the buffer directly
+    // we will not wrap it in a AVBuffer/Ref instance.
+    pkt.stream_index = stream_index;
+    pkt.data = buffer;
+    pkt.size = size;
+    pkt.dts = ptsUs;
+    pkt.pts = ptsUs;
+    pkt.flags = flags;
+
+    // While we originally set the ideal time base of the stream to be in microseconds, the muxer
+    // is allowed to change this. We will therefore need to scale our given PTS (in microseconds) to
+    // something suitable for the specific stream.
+    auto stream = mContext->streams[stream_index];
+    av_packet_rescale_ts(&pkt, (AVRational){ 1, 1000000 }, stream->time_base);
+
+    LOGI("writeSampleData(index: %d size: %d pts: %lld flags: %d)", stream_index, size, ptsUs, flags);
+
+    // Write the compressed frame to the media file.
+    int err = av_interleaved_write_frame(mContext, &pkt);
+    if (err < 0) {
+        logErrorCode("Failed to write frame", err);
+        return STATUS_ERROR;
+    }
+
+    return STATUS_OK;
+}
+
+void MediaMuxer::logErrorCode(const char *error, int errorCode) {
+    char errorStr[AV_ERROR_MAX_STRING_SIZE] = {0};
+    av_make_error_string(errorStr, AV_ERROR_MAX_STRING_SIZE, errorCode);
+
+    if (errorStr) {
+        LOGE("%s: %s", error, errorStr);
+    } else {
+        LOGE("%s: %d", error, errorCode);
+    }
+}

--- a/litr-muxers/src/main/cpp/MediaMuxer.h
+++ b/litr-muxers/src/main/cpp/MediaMuxer.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2022 LinkedIn Corporation
+ * All Rights Reserved.
+ *
+ * Licensed under the BSD 2-Clause License (the "License").  See License in the project root for
+ * license information.
+ *
+ * Author: Ian Bird
+ */
+
+#ifndef LITR_MEDIAMUXER_H
+#define LITR_MEDIAMUXER_H
+
+#define STATUS_OK 0
+#define STATUS_ERROR -1
+
+#include "FFmpeg.h"
+
+class MediaMuxer
+{
+public:
+    MediaMuxer();
+    ~MediaMuxer();
+
+    int init(const char *path, const char *formatName);
+    int start(const char **keys, const char **values, int optionSize);
+    int stop();
+    int addVideoStream(const char * codec_name, int64_t bitrate, int width, int height,
+                       uint8_t *extradata, int extradata_size);
+    int addAudioStream(const char * codec_name, int64_t bitrate, int channels, int sample_rate,
+                       int frame_size, uint8_t *extradata, int extradata_size);
+    int writeSampleData(int stream_index, uint8_t *buffer, int size, int64_t ptsUs, int flags);
+
+private:
+    AVFormatContext *mContext = nullptr;
+
+    AVStream* addStream(const char * codec_name, int64_t bitrate, uint8_t *extradata, int extradata_size);
+    void logErrorCode(const char * error, int errorCode);
+};
+
+#endif //LITR_MEDIAMUXER_H

--- a/litr-muxers/src/main/cpp/NativeLogger.cpp
+++ b/litr-muxers/src/main/cpp/NativeLogger.cpp
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2023 LinkedIn Corporation
+ * All Rights Reserved.
+ *
+ * Licensed under the BSD 2-Clause License (the "License").  See License in the project root for
+ * license information.
+ *
+ * Author: Ian Bird
+ */
+
+#include <jni.h>
+
+#include "FFmpeg.h"
+#include "Logging.h"
+
+static void av_log_callback(void *ptr, int level, const char *fmt, va_list vl) {
+    // Check to see if we care about the log.
+    if (level > av_log_get_level())
+        return;
+
+    va_list vl2;
+    char line[1024];
+    static int print_prefix = 1;
+
+    // Extract and format the log line.
+    va_copy(vl2, vl);
+    av_log_format_line(ptr, level, fmt, vl2, line, sizeof(line), &print_prefix);
+    va_end(vl2);
+
+    // Log it via Android with the relevant logcat equivalent level.
+    if (level <= AV_LOG_ERROR) {
+        LOGE("FFMPEG: %s", line);
+    } else if (level <= AV_LOG_WARNING) {
+        LOGW("FFMPEG: %s", line);
+    } else if (level <= AV_LOG_INFO) {
+        LOGI("FFMPEG: %s", line);
+    } else {
+        LOGD("FFMPEG: %s", line);
+    }
+}
+
+extern "C" JNIEXPORT void
+Java_com_linkedin_android_litr_muxers_NativeLogger_nativeSetup(
+        JNIEnv *env,
+        jobject /* this */,
+        jint level
+) {
+    // Configure the log level and attach a callback.
+    av_log_set_level(level);
+    av_log_set_callback(av_log_callback);
+}
+

--- a/litr-muxers/src/main/cpp/NativeMediaMuxer.cpp
+++ b/litr-muxers/src/main/cpp/NativeMediaMuxer.cpp
@@ -1,0 +1,345 @@
+/*
+ * Copyright 2022 LinkedIn Corporation
+ * All Rights Reserved.
+ *
+ * Licensed under the BSD 2-Clause License (the "License").  See License in the project root for
+ * license information.
+ *
+ * Author: Ian Bird
+ */
+
+#include <jni.h>
+#include <string>
+
+#include "Logging.h"
+#include "MediaMuxer.h"
+
+// References:
+//  - https://github.com/aosp-mirror/platform_frameworks_base/blob/master/media/java/android/media/MediaMuxer.java
+//  - https://sources.debian.org/src/android-framework-23/6.0.1+r72-3/frameworks/base/media/jni/android_media_MediaMuxer.cpp
+//  - https://github.com/sztwang/TX2_libstagefright/blob/master/MediaMuxer.cpp
+
+struct fields_t {
+    jmethodID arrayID;
+};
+
+static fields_t gFields;
+
+/**
+ * Helper to throw a JNI based exception.
+ *
+ * @param env The JNI environment.
+ * @param className The name of the Java class which represents the exception.
+ * @param message The message associated with the exception.
+ */
+void jniThrowException(JNIEnv *env, const char* className, const char* message) {
+    jclass exClass = env->FindClass(className);
+    if (exClass != nullptr) {
+        env->ThrowNew(exClass, message);
+    }
+}
+
+void initByteBuffer(JNIEnv *env) {
+    // We only need to look up the ByteBuffer.array() method ID once. It will be stored in a global
+    // field, so that it can be re-used after first found, on subsequent sample writes.
+    if (gFields.arrayID == nullptr) {
+        jclass byteBufClass = env->FindClass("java/nio/ByteBuffer");
+        if (byteBufClass == nullptr) {
+            LOGE("Unable to find ByteBuffer class");
+            jniThrowException(env, "java/lang/IllegalStateException",
+                              "Unable to find ByteBuffer class");
+        }
+
+        gFields.arrayID = env->GetMethodID(byteBufClass, "array", "()[B");
+        if (gFields.arrayID == nullptr) {
+            LOGE("Unable to find ByteBuffer array method");
+            jniThrowException(env, "java/lang/IllegalStateException",
+                              "Unable to find ByteBuffer array method");
+        }
+    }
+}
+
+extern "C" JNIEXPORT jlong JNICALL
+Java_com_linkedin_android_litr_muxers_NativeMediaMuxer_nativeSetup(
+        JNIEnv *env,
+        jobject /* this */,
+        jstring jOutputPath,
+        jstring jFormatName) {
+    const char* path = env->GetStringUTFChars(jOutputPath, nullptr);
+    const char* formatName = env->GetStringUTFChars(jFormatName, nullptr);
+
+    // Initialise the MediaMuxer, using the path and format provided.
+    auto muxer = new MediaMuxer();
+    auto err = muxer->init(path, formatName);
+
+    env->ReleaseStringUTFChars(jOutputPath, path);
+    env->ReleaseStringUTFChars(jFormatName, formatName);
+
+    if (err == STATUS_ERROR) {
+        LOGE("Unable to initialise MediaMuxer");
+        jniThrowException(env, "java/lang/IllegalStateException",
+                          "Failed to initialise the muxer");
+    }
+
+    return reinterpret_cast<jlong>(muxer);
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_com_linkedin_android_litr_muxers_NativeMediaMuxer_nativeStart(
+        JNIEnv *env,
+        jobject /* this */,
+        jlong nativeObject,
+        jobjectArray keys,
+        jobjectArray values) {
+    auto* muxer = reinterpret_cast<MediaMuxer*>(nativeObject);
+    if (muxer == nullptr) {
+        LOGE("Muxer was not set up correctly");
+        jniThrowException(env, "java/lang/IllegalStateException",
+                          "Muxer was not set up correctly");
+    }
+
+    // Check to make sure the given options have the same number of keys as they do values.
+    int keysCount = env->GetArrayLength(keys);
+    int valuesCount = env->GetArrayLength(values);
+    if (keysCount != valuesCount) {
+        LOGE("Invalid options specified");
+        jniThrowException(env, "java/lang/IllegalStateException",
+                          "Invalid options specified");
+    }
+
+    // The muxer options are provided as two separate arrays that represent the key-value pairs
+    // of a dictionary. We have to extract these via JNI and build up our two primative arrays.
+    const char* keySet[keysCount];
+    const char* valueSet[valuesCount];
+    for (int i = 0; i < keysCount; i++) {
+        auto jKey = (jstring) env->GetObjectArrayElement(keys, i);
+        const char* key = env->GetStringUTFChars(jKey, nullptr);
+        keySet[i] = key;
+
+        auto jValue = (jstring) env->GetObjectArrayElement(values, i);
+        const char* value = env->GetStringUTFChars(jValue, nullptr);
+        valueSet[i] = value;
+    }
+
+    // Start the muxer with the given options.
+    auto err = muxer->start(keySet, valueSet, keysCount);
+
+    // Ensure that all UTF chars are released.
+    for (int i = 0; i < keysCount; i++) {
+        auto jKey = (jstring) env->GetObjectArrayElement(keys, i);
+        env->ReleaseStringUTFChars(jKey, keySet[i]);
+
+        auto jValue = (jstring) env->GetObjectArrayElement(values, i);
+        env->ReleaseStringUTFChars(jValue, valueSet[i]);
+    }
+
+    if (err == STATUS_ERROR) {
+        LOGE("Unable to start MediaMuxer");
+        jniThrowException(env, "java/lang/IllegalStateException",
+                          "Failed to start the muxer");
+    }
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_com_linkedin_android_litr_muxers_NativeMediaMuxer_nativeStop(
+        JNIEnv *env,
+        jobject /* this */,
+        jlong nativeObject) {
+    auto* muxer = reinterpret_cast<MediaMuxer*>(nativeObject);
+    if (muxer == nullptr) {
+        LOGE("Muxer was not set up correctly");
+        jniThrowException(env, "java/lang/IllegalStateException",
+                          "Muxer was not set up correctly");
+    }
+
+    auto err = muxer->stop();
+    if (err == STATUS_ERROR) {
+        LOGE("Unable to stop MediaMuxer");
+        jniThrowException(env, "java/lang/IllegalStateException",
+                          "Failed to stop the muxer");
+    }
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_com_linkedin_android_litr_muxers_NativeMediaMuxer_nativeRelease(
+        JNIEnv *env,
+        jobject /* this */,
+        jlong nativeObject) {
+    auto* muxer = reinterpret_cast<MediaMuxer*>(nativeObject);
+    delete muxer;
+}
+
+extern "C" JNIEXPORT jint JNICALL
+Java_com_linkedin_android_litr_muxers_NativeMediaMuxer_nativeAddAudioTrack(
+        JNIEnv *env,
+        jobject /* this */,
+        jlong nativeObject,
+        jstring codecId,
+        jint bitrate,
+        jint channelCount,
+        jint sampleRate,
+        jint frameSize,
+        jobject byteBuf,
+        jint size) {
+    auto* muxer = reinterpret_cast<MediaMuxer*>(nativeObject);
+    if (muxer == nullptr) {
+        LOGE("Muxer was not set up correctly");
+        jniThrowException(env, "java/lang/IllegalStateException",
+                          "Muxer was not set up correctly");
+    }
+
+    initByteBuffer(env);
+    if (gFields.arrayID == nullptr) {
+        LOGE("Unable to find ByteBuffer array method");
+        jniThrowException(env, "java/lang/IllegalStateException",
+                          "Unable to find ByteBuffer array method");
+    }
+
+    const char* codecName = env->GetStringUTFChars(codecId, nullptr);
+
+    auto byteArray = (jbyteArray)env->CallObjectMethod(byteBuf, gFields.arrayID);
+    if (byteArray == nullptr) {
+        LOGE("byteArray is null");
+        jniThrowException(env, "java/lang/IllegalArgumentException",
+                          "byteArray is null");
+        return -1;
+    }
+
+    auto dst = env->GetByteArrayElements(byteArray, nullptr);
+    auto dstSize = env->GetArrayLength(byteArray);
+
+    auto streamIndex = muxer->addAudioStream(
+            codecName,
+            bitrate,
+            channelCount,
+            sampleRate,
+            frameSize,
+            (uint8_t *) dst,
+            size);
+
+    env->ReleaseStringUTFChars(codecId, codecName);
+    env->ReleaseByteArrayElements(byteArray, (jbyte *)dst, 0);
+
+    if (streamIndex < 0) {
+        LOGE("Unable to add video track");
+        jniThrowException(env, "java/lang/IllegalStateException",
+                          "Unable to add video track");
+    }
+
+    return streamIndex;
+}
+
+extern "C" JNIEXPORT jint JNICALL
+Java_com_linkedin_android_litr_muxers_NativeMediaMuxer_nativeAddVideoTrack(
+        JNIEnv *env,
+        jobject /* this */,
+        jlong nativeObject,
+        jstring codecId,
+        jint bitrate,
+        jint width,
+        jint height,
+        jobject byteBuf,
+        jint size) {
+    auto* muxer = reinterpret_cast<MediaMuxer*>(nativeObject);
+    if (muxer == nullptr) {
+        LOGE("Muxer was not set up correctly");
+        jniThrowException(env, "java/lang/IllegalStateException",
+                          "Muxer was not set up correctly");
+    }
+
+    initByteBuffer(env);
+    if (gFields.arrayID == nullptr) {
+        LOGE("Unable to find ByteBuffer array method");
+        jniThrowException(env, "java/lang/IllegalStateException",
+                          "Unable to find ByteBuffer array method");
+    }
+
+    const char* codecName = env->GetStringUTFChars(codecId, nullptr);
+
+    auto byteArray = (jbyteArray)env->CallObjectMethod(byteBuf, gFields.arrayID);
+    if (byteArray == nullptr) {
+        LOGE("byteArray is null");
+        jniThrowException(env, "java/lang/IllegalArgumentException",
+                          "byteArray is null");
+        return -1;
+    }
+
+    auto dst = env->GetByteArrayElements(byteArray, nullptr);
+    auto dstSize = env->GetArrayLength(byteArray);
+
+    auto streamIndex = muxer->addVideoStream(
+            codecName,
+            bitrate,
+            width,
+            height,
+            (uint8_t *) dst,
+            size);
+
+    env->ReleaseStringUTFChars(codecId, codecName);
+    env->ReleaseByteArrayElements(byteArray, (jbyte *)dst, 0);
+
+    if (streamIndex < 0) {
+        LOGE("Unable to add video track");
+        jniThrowException(env, "java/lang/IllegalStateException",
+                          "Unable to add video track");
+    }
+
+    return streamIndex;
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_com_linkedin_android_litr_muxers_NativeMediaMuxer_nativeWriteSampleData(
+        JNIEnv *env,
+        jobject /* this */,
+        jlong nativeObject,
+        jint trackIndex,
+        jobject byteBuf,
+        jint offset,
+        jint size,
+        jlong presentationTimeUs,
+        jint flags) {
+    auto* muxer = reinterpret_cast<MediaMuxer*>(nativeObject);
+    if (muxer == nullptr) {
+        LOGE("Muxer was not set up correctly");
+        jniThrowException(env, "java/lang/IllegalStateException",
+                          "Muxer was not set up correctly");
+    }
+
+    initByteBuffer(env);
+    if (gFields.arrayID == nullptr) {
+        LOGE("Unable to find ByteBuffer array method");
+        jniThrowException(env, "java/lang/IllegalStateException",
+                          "Unable to find ByteBuffer array method");
+    }
+
+    auto byteArray = (jbyteArray)env->CallObjectMethod(byteBuf, gFields.arrayID);
+    if (byteArray == nullptr) {
+        LOGE("byteArray is null");
+        jniThrowException(env, "java/lang/IllegalArgumentException",
+                          "byteArray is null");
+        return;
+    }
+
+    auto dst = env->GetByteArrayElements(byteArray, nullptr);
+    auto dstSize = env->GetArrayLength(byteArray);
+
+    if (dstSize < (offset + size)) {
+        LOGE("writeSampleData saw wrong dstSize %lld, size  %d, offset %d", (long long)dstSize, size, offset);
+        env->ReleaseByteArrayElements(byteArray, (jbyte *)dst, 0);
+        jniThrowException(env, "java/lang/IllegalArgumentException",
+                          "sample has a wrong size");
+        return;
+    }
+
+    // Now that we have access to the underlying buffer, let's use that to build a suitable sample
+    // to write via the Muxer.
+    auto err = muxer->writeSampleData(trackIndex, (uint8_t *) dst + offset, size, presentationTimeUs, flags);
+
+    env->ReleaseByteArrayElements(byteArray, (jbyte *)dst, 0);
+
+    if (err == STATUS_ERROR) {
+        LOGE("writeSampleData returned an error");
+        jniThrowException(env, "java/lang/IllegalStateException",
+                          "writeSampleData returned an error");
+    }
+}

--- a/litr-muxers/src/main/cpp/build_ffmpeg.sh
+++ b/litr-muxers/src/main/cpp/build_ffmpeg.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+
+FFMPEG_MODULE_PATH=$1
+NDK_PATH=$2
+HOST_PLATFORM=$3
+ENABLED_DECODERS=("${@:4}")
+JOBS=$(nproc 2> /dev/null || sysctl -n hw.ncpu 2> /dev/null || echo 4)
+echo "Using $JOBS jobs for make"
+COMMON_OPTIONS="
+    --target-os=android
+    --enable-shared
+    --disable-static
+    --disable-doc
+    --disable-all
+    --enable-avcodec
+    --enable-avformat
+    --enable-protocol=file
+    --enable-protocol=hls
+    --enable-muxer=mp4
+    --enable-muxer=matroska
+    --enable-muxer=hls
+    --enable-muxer=stream_segment
+    --enable-parser=aac
+    --enable-parser=aac_latm
+    --enable-parser=h264
+    --enable-parser=hevc
+    --extra-ldexeflags=-pie
+    "
+TOOLCHAIN_PREFIX="${NDK_PATH}/toolchains/llvm/prebuilt/${HOST_PLATFORM}/bin"
+cd "${FFMPEG_MODULE_PATH}/cpp/ffmpeg"
+./configure \
+    --libdir=android-libs/armeabi-v7a \
+    --arch=arm \
+    --cpu=armv7-a \
+    --cross-prefix="${TOOLCHAIN_PREFIX}/armv7a-linux-androideabi16-" \
+    --nm="${TOOLCHAIN_PREFIX}/llvm-nm" \
+    --ar="${TOOLCHAIN_PREFIX}/llvm-ar" \
+    --ranlib="${TOOLCHAIN_PREFIX}/llvm-ranlib" \
+    --strip="${TOOLCHAIN_PREFIX}/llvm-strip" \
+    --extra-cflags="-march=armv7-a -mfloat-abi=softfp" \
+    --extra-ldflags="-Wl,--fix-cortex-a8" \
+    ${COMMON_OPTIONS}
+make -j$JOBS
+make install-libs
+make clean
+./configure \
+    --libdir=android-libs/arm64-v8a \
+    --arch=aarch64 \
+    --cpu=armv8-a \
+    --cross-prefix="${TOOLCHAIN_PREFIX}/aarch64-linux-android21-" \
+    --nm="${TOOLCHAIN_PREFIX}/llvm-nm" \
+    --ar="${TOOLCHAIN_PREFIX}/llvm-ar" \
+    --ranlib="${TOOLCHAIN_PREFIX}/llvm-ranlib" \
+    --strip="${TOOLCHAIN_PREFIX}/llvm-strip" \
+    ${COMMON_OPTIONS}
+make -j$JOBS
+make install-libs
+make clean
+./configure \
+    --libdir=android-libs/x86 \
+    --arch=x86 \
+    --cpu=i686 \
+    --cross-prefix="${TOOLCHAIN_PREFIX}/i686-linux-android16-" \
+    --nm="${TOOLCHAIN_PREFIX}/llvm-nm" \
+    --ar="${TOOLCHAIN_PREFIX}/llvm-ar" \
+    --ranlib="${TOOLCHAIN_PREFIX}/llvm-ranlib" \
+    --strip="${TOOLCHAIN_PREFIX}/llvm-strip" \
+    --disable-asm \
+    ${COMMON_OPTIONS}
+make -j$JOBS
+make install-libs
+make clean
+./configure \
+    --libdir=android-libs/x86_64 \
+    --arch=x86_64 \
+    --cpu=x86_64 \
+    --cross-prefix="${TOOLCHAIN_PREFIX}/x86_64-linux-android21-" \
+    --nm="${TOOLCHAIN_PREFIX}/llvm-nm" \
+    --ar="${TOOLCHAIN_PREFIX}/llvm-ar" \
+    --ranlib="${TOOLCHAIN_PREFIX}/llvm-ranlib" \
+    --strip="${TOOLCHAIN_PREFIX}/llvm-strip" \
+    --disable-asm \
+    ${COMMON_OPTIONS}
+make -j$JOBS
+make install-libs
+make clean

--- a/litr-muxers/src/main/java/com/linkedin/android/litr/muxers/MediaFormatEx.kt
+++ b/litr-muxers/src/main/java/com/linkedin/android/litr/muxers/MediaFormatEx.kt
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2022 LinkedIn Corporation
+ * All Rights Reserved.
+ *
+ * Licensed under the BSD 2-Clause License (the "License").  See License in the project root for
+ * license information.
+ *
+ * Author: Ian Bird
+ */
+package com.linkedin.android.litr.muxers
+
+import android.media.MediaFormat
+import com.linkedin.android.litr.MimeType
+import java.nio.ByteBuffer
+
+const val KEY_MIME_TYPE = MediaFormat.KEY_MIME
+const val KEY_BIT_RATE = MediaFormat.KEY_BIT_RATE
+const val KEY_WIDTH = MediaFormat.KEY_WIDTH
+const val KEY_HEIGHT = MediaFormat.KEY_HEIGHT
+const val KEY_FRAME_RATE = MediaFormat.KEY_FRAME_RATE
+const val KEY_CHANNEL_COUNT = MediaFormat.KEY_CHANNEL_COUNT
+const val KEY_SAMPLE_RATE = MediaFormat.KEY_SAMPLE_RATE
+
+fun MediaFormat.isVideo(): Boolean {
+    val mimeType = getStringSafe(KEY_MIME_TYPE, "")
+    return MimeType.IsVideo(mimeType)
+}
+
+fun MediaFormat.isAudio(): Boolean {
+    val mimeType = getStringSafe(KEY_MIME_TYPE, "")
+    return MimeType.IsAudio(mimeType)
+}
+
+fun MediaFormat.getCodecId(): String {
+    // We ideally just use the mime type name, but there are some required substitutions.
+    return when(val mimeType = getStringSafe(KEY_MIME_TYPE, "")) {
+        MimeType.AUDIO_AAC -> "aac"
+
+        MimeType.VIDEO_AVC -> "h264"
+        MimeType.VIDEO_HEVC -> "hevc"
+        else -> {
+            val components = mimeType.split("/")
+            return components.last()
+        }
+    }
+}
+
+fun MediaFormat.getBitrate() = getIntSafe(KEY_BIT_RATE, 0)
+
+fun MediaFormat.getChannelCount() = getIntSafe(KEY_CHANNEL_COUNT, 0)
+
+fun MediaFormat.getSampleRate() = getIntSafe(KEY_SAMPLE_RATE, 0)
+
+fun MediaFormat.getWidth() = getIntSafe(KEY_WIDTH, 0)
+
+fun MediaFormat.getHeight() = getIntSafe(KEY_HEIGHT, 0)
+
+fun MediaFormat.getExtraData(): ByteBuffer? {
+    val buffers = mutableListOf<ByteBuffer>()
+    var targetBufferSize = 0
+
+    // A MediaFormat can contain 0-N buffers that represent the codec specific data (aka csd). We
+    // need to combine these individual buffers into a single ByteBuffer. Let's start by finding all
+    // the associated buffers and how large our final buffer will be.
+    var index = 0
+    while (true) {
+        val buffer = getByteBuffer("csd-$index") ?: break
+
+        buffers.add(buffer)
+        targetBufferSize += buffer.capacity()
+        index++
+    }
+
+    // Check to see if we found at least one non-empty buffer.
+    if (targetBufferSize == 0) {
+        return null
+    }
+
+    // Build the final ByteBuffer and add each original buffer sequentially.
+    val extraBuffer = ByteBuffer.allocate(targetBufferSize)
+    for (buffer in buffers) {
+        extraBuffer.put(buffer)
+    }
+
+    extraBuffer.position(0)
+    return extraBuffer
+}
+
+fun MediaFormat.getSampleSize(): Int {
+    return when(getStringSafe(KEY_MIME_TYPE, "")) {
+        MimeType.AUDIO_AAC -> 1024
+        else -> 0
+    }
+}
+
+private fun MediaFormat.getStringSafe(key: String, default: String): String {
+    return getString(key) ?: default
+}
+
+private fun MediaFormat.getIntSafe(key: String, default: Int): Int {
+    return runCatching { getInteger(key) }.getOrDefault(default)
+}

--- a/litr-muxers/src/main/java/com/linkedin/android/litr/muxers/NativeLogger.kt
+++ b/litr-muxers/src/main/java/com/linkedin/android/litr/muxers/NativeLogger.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2023 LinkedIn Corporation
+ * All Rights Reserved.
+ *
+ * Licensed under the BSD 2-Clause License (the "License").  See License in the project root for
+ * license information.
+ *
+ * Author: Ian Bird
+ */
+package com.linkedin.android.litr.muxers
+
+/**
+ * Allows configuration of the logging performed by the native components.
+ */
+object NativeLogger {
+    // Level's defined in avutil/log.h
+    const val LEVEL_TRACE = 56
+    const val LEVEL_DEBUG = 48
+    const val LEVEL_VERBOSE = 40
+    const val LEVEL_INFO = 32
+    const val LEVEL_WARNING = 24
+    const val LEVEL_ERROR = 16
+    const val LEVEL_FATAL = 8
+    const val LEVEL_PANIC = 0
+    const val LEVEL_QUIET = -8
+
+    /**
+     * Configures the native logger with the given level. These log messages will be written to
+     * the application's logcat messages.
+     */
+    fun setup(level: Int) = nativeSetup(level)
+
+    private external fun nativeSetup(level: Int)
+}

--- a/litr-muxers/src/main/java/com/linkedin/android/litr/muxers/NativeMediaMuxer.kt
+++ b/litr-muxers/src/main/java/com/linkedin/android/litr/muxers/NativeMediaMuxer.kt
@@ -1,0 +1,236 @@
+/*
+ * Copyright 2022 LinkedIn Corporation
+ * All Rights Reserved.
+ *
+ * Licensed under the BSD 2-Clause License (the "License").  See License in the project root for
+ * license information.
+ *
+ * Author: Ian Bird
+ */
+package com.linkedin.android.litr.muxers
+
+import android.media.MediaCodec.BufferInfo
+import android.media.MediaFormat
+import android.util.Log
+import java.nio.ByteBuffer
+
+private const val TAG = "NativeMediaMuxer"
+
+private const val MUXER_STATE_UNINITIALIZED = -1
+private const val MUXER_STATE_INITIALIZED = 0
+private const val MUXER_STATE_STARTED = 1
+private const val MUXER_STATE_STOPPED = 2
+
+private fun convertMuxerStateCodeToString(state: Int): String {
+    return when(state) {
+        MUXER_STATE_UNINITIALIZED -> { "UNINITIALIZED" }
+        MUXER_STATE_INITIALIZED -> { "INITIALIZED" }
+        MUXER_STATE_STARTED -> { "STARTED" }
+        MUXER_STATE_STOPPED -> { "STOPPED " }
+        else -> { "UNKNOWN" }
+    }
+}
+
+class NativeMediaMuxer(val path: String, val format: String) {
+    private var nativeObject: Long = 0L
+    private var state: Int = MUXER_STATE_UNINITIALIZED
+
+    private var lastTrackIndex = -1
+
+    // Muxers support a number of options when started. This will control their behaviour, for
+    // example MP4 vs fMP4. We store the configured options to pass through to libavformat when
+    // we're about to start muxing.
+    private var options = mutableMapOf<String, String>()
+
+    init {
+        // Initialise the native muxer.
+        nativeObject = nativeSetup(path, format)
+        state = MUXER_STATE_INITIALIZED
+    }
+
+    /**
+     * Adds a track with the specified format.
+     */
+    fun addTrack(format: MediaFormat): Int {
+        if (state != MUXER_STATE_INITIALIZED) {
+            throw IllegalStateException("Muxer is not initialized.")
+        }
+        if (nativeObject == 0L) {
+            throw IllegalStateException("Muxer has been released")
+        }
+
+        // Add the track to the muxer.
+        val extra = format.getExtraData()
+        val trackIndex = if (format.isAudio()) {
+            nativeAddAudioTrack(
+                    nativeObject,
+                    format.getCodecId(),
+                    format.getBitrate(),
+                    format.getChannelCount(),
+                    format.getSampleRate(),
+                    format.getSampleSize(),
+                    extra,
+                    extra?.capacity() ?: 0
+            )
+        } else if (format.isVideo()) {
+            nativeAddVideoTrack(
+                    nativeObject,
+                    format.getCodecId(),
+                    format.getBitrate(),
+                    format.getWidth(),
+                    format.getHeight(),
+                    extra,
+                    extra?.capacity() ?: 0
+            )
+        } else {
+            error("Unable to add unsupported track")
+        }
+
+        // The returned track index is expected to be incremented as addTrack succeeds. However, if
+        // the format is invalid, it will get a negative track index.
+        if (lastTrackIndex >= trackIndex) {
+            throw IllegalStateException("Invalid format")
+        }
+
+        Log.i(TAG, "Stream Added (ID: ${format.getCodecId()} Index: $trackIndex)")
+        lastTrackIndex = trackIndex
+        return trackIndex
+    }
+
+    /**
+     * Adds a muxer option. This method *must* be called before the muxer has been started.
+     */
+    fun addOption(key: String, value: String) {
+        if (state != MUXER_STATE_INITIALIZED) {
+            throw IllegalStateException("Muxer is not initialized.")
+        }
+        if (nativeObject == 0L) {
+            throw IllegalStateException("Muxer has been released")
+        }
+
+        // Store the option for later.
+        Log.i(TAG, "Option Added (Key: $key Value: $value)")
+        options[key] = value
+    }
+
+    /**
+     * Starts the muxer.
+     */
+    fun start() {
+        if (nativeObject == 0L) {
+            throw IllegalStateException("Muxer has been released")
+        }
+
+        if (state == MUXER_STATE_INITIALIZED) {
+            nativeStart(nativeObject, options.keys.toTypedArray(), options.values.toTypedArray())
+            state = MUXER_STATE_STARTED
+        } else {
+            throw IllegalStateException(
+                    "Can't start due to wrong state (${convertMuxerStateCodeToString(state)})")
+        }
+    }
+
+    /**
+     * Stops the muxer.
+     */
+    fun stop() {
+        if (state == MUXER_STATE_STARTED) {
+            try {
+                nativeStop(nativeObject)
+                Log.i(TAG, "Muxer stopped successfully")
+            } catch (e: Exception) {
+                throw e
+            } finally {
+                state = MUXER_STATE_STOPPED
+            }
+        } else {
+            throw IllegalStateException(
+                    "Can't stop due to wrong state (${convertMuxerStateCodeToString(state)})")
+        }
+    }
+
+    /**
+     * Writes an encoded sample into the muxer.
+     */
+    fun writeSampleData(trackIndex: Int, byteBuf: ByteBuffer, bufferInfo: BufferInfo) {
+        if (trackIndex < 0 || trackIndex > lastTrackIndex) {
+            throw IllegalArgumentException("trackIndex is invalid")
+        }
+        if (bufferInfo.size < 0 || bufferInfo.offset < 0 ||
+                (bufferInfo.offset + bufferInfo.size) > byteBuf.capacity()) {
+            throw IllegalArgumentException("bufferInfo must specify a valid buffer offset and size")
+        }
+        if (!byteBuf.hasArray()) {
+            throw IllegalArgumentException("byteBuf must have an accessible buffer.")
+        }
+        if (nativeObject == 0L) {
+            throw IllegalStateException("Muxer has been released")
+        }
+        if (state != MUXER_STATE_STARTED) {
+            throw IllegalStateException("Can't write, muxer is not started")
+        }
+
+        // Pass the buffer and info to the native layer.
+        nativeWriteSampleData(
+                nativeObject,
+                trackIndex,
+                byteBuf,
+                bufferInfo.offset,
+                bufferInfo.size,
+                bufferInfo.presentationTimeUs,
+                bufferInfo.flags
+        )
+    }
+
+    /**
+     * Make sure you call this when you're done to free up any resources, instead of relying on the
+     * garbage collector to do this for you at some point in the future.
+     */
+    fun release() {
+        if (state == MUXER_STATE_STARTED) {
+            stop()
+        }
+
+        if (nativeObject != 0L) {
+            nativeRelease(nativeObject)
+            nativeObject = 0L
+        }
+
+        state = MUXER_STATE_UNINITIALIZED
+    }
+
+    protected fun finalize() {
+        if (nativeObject != 0L) {
+            nativeRelease(nativeObject)
+            nativeObject = 0L
+        }
+    }
+
+    private external fun nativeSetup(outputPath: String, formatName: String): Long
+    private external fun nativeRelease(nativeObject: Long)
+    private external fun nativeStart(nativeObject: Long, keys: Array<String>, values: Array<String>)
+    private external fun nativeStop(nativeObject: Long)
+    private external fun nativeAddAudioTrack(nativeObject: Long, codecId: String, bitrate: Int,
+                                             channelCount: Int, sampleRate: Int, frameSize: Int,
+                                             byteBuf: ByteBuffer?, size: Int): Int
+    private external fun nativeAddVideoTrack(nativeObject: Long, codecId: String, bitrate: Int,
+                                             width: Int, height: Int, byteBuf: ByteBuffer?,
+                                             size: Int): Int
+    private external fun nativeWriteSampleData(nativeObject: Long, trackIndex: Int,
+                                               byteBuf: ByteBuffer, offset: Int, size: Int,
+                                               presentationTimeUs: Long, flags: Int)
+
+    companion object {
+        init {
+            // Static initializer to ensure that our native libraries are loaded and we have
+            // configured their logging to be captured by Android.
+            NativeMuxersLib.loadLibraries()
+            NativeLogger.setup(
+                    if (BuildConfig.DEBUG)
+                        NativeLogger.LEVEL_TRACE
+                    else
+                        NativeLogger.LEVEL_WARNING
+            )
+        }
+    }
+}

--- a/litr-muxers/src/main/java/com/linkedin/android/litr/muxers/NativeMediaMuxerMediaTarget.kt
+++ b/litr-muxers/src/main/java/com/linkedin/android/litr/muxers/NativeMediaMuxerMediaTarget.kt
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2022 LinkedIn Corporation
+ * All Rights Reserved.
+ *
+ * Licensed under the BSD 2-Clause License (the "License").  See License in the project root for
+ * license information.
+ *
+ * Author: Ian Bird
+ */
+package com.linkedin.android.litr.muxers
+
+import android.media.MediaCodec
+import android.media.MediaFormat
+import android.util.Log
+import com.linkedin.android.litr.exception.MediaTargetException
+import com.linkedin.android.litr.io.MediaTarget
+import com.linkedin.android.litr.io.MediaTargetSample
+import java.nio.ByteBuffer
+import java.util.*
+
+private const val TAG = "NativeMediaTarget"
+
+class NativeMediaMuxerMediaTarget(
+        private val outputFilePath: String,
+        private val trackCount: Int,
+        private val orientationHint: Int,
+        outputFormat: String
+): MediaTarget {
+
+    constructor(outputFilePath: String, trackCount: Int, orientationHint: Int, outputFormat: Int) :
+            this(
+                    outputFilePath,
+                    trackCount,
+                    orientationHint,
+                    NativeOutputFormats.fromOutputFormat(outputFormat)
+            )
+
+    private val queue: LinkedList<MediaTargetSample> = LinkedList()
+    private var isStarted: Boolean = false
+    private val mediaMuxer : NativeMediaMuxer
+
+    private var numberOfTracksToAdd = 0
+    private val mediaFormatsToAdd = arrayOfNulls<MediaFormat>(trackCount)
+
+    init {
+        try {
+            mediaMuxer = NativeMediaMuxer(outputFilePath, outputFormat)
+        } catch (ex: IllegalStateException) {
+            throw MediaTargetException(
+                    MediaTargetException.Error.INVALID_PARAMS,
+                    outputFilePath,
+                    outputFormat,
+                    ex);
+        }
+    }
+
+    /**
+     * Adds a muxer option. This method *must* be called before the muxer has been started.
+     */
+    fun addOption(key: String, value: String) = mediaMuxer.addOption(key, value)
+
+    override fun addTrack(mediaFormat: MediaFormat, targetTrack: Int): Int {
+        mediaFormatsToAdd[targetTrack] = mediaFormat
+        numberOfTracksToAdd++
+
+        if (numberOfTracksToAdd == trackCount) {
+            Log.d(TAG, "All tracks added, starting MediaMuxer, writing out ${queue.size} queued samples")
+
+            mediaFormatsToAdd.filterNotNull().forEach {
+                mediaMuxer.addTrack(it)
+            }
+
+            mediaMuxer.start()
+            isStarted = true
+
+            // Write out any queued samples.
+            while (queue.isNotEmpty()) {
+                val sample = queue.removeFirst()
+                mediaMuxer.writeSampleData(sample.targetTrack, sample.buffer, sample.info)
+            }
+        }
+
+        return targetTrack
+    }
+
+    override fun writeSampleData(targetTrack: Int, buffer: ByteBuffer, info: MediaCodec.BufferInfo) {
+        // We always create a sample before we write it, to ensure that the ByteBuffer is in a
+        // suitable format to be passed to the native component.
+        val sample = MediaTargetSample(targetTrack, buffer, info)
+        if (isStarted) {
+            mediaMuxer.writeSampleData(sample.targetTrack, sample.buffer, sample.info)
+        } else {
+            // The NativeMediaMuxer is not yet started, so queue up incoming buffers to write them out later
+            queue.addLast(sample)
+        }
+    }
+
+    override fun release() {
+        mediaMuxer.release()
+    }
+
+    override fun getOutputFilePath() = outputFilePath
+}

--- a/litr-muxers/src/main/java/com/linkedin/android/litr/muxers/NativeMuxersLib.kt
+++ b/litr-muxers/src/main/java/com/linkedin/android/litr/muxers/NativeMuxersLib.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2022 LinkedIn Corporation
+ * All Rights Reserved.
+ *
+ * Licensed under the BSD 2-Clause License (the "License").  See License in the project root for
+ * license information.
+ *
+ * Author: Ian Bird
+ */
+package com.linkedin.android.litr.muxers
+
+import android.util.Log
+
+private const val TAG = "NativeMuxersLib"
+private val FFMPEG_LIBRARIES = listOf(
+        "avutil",
+        "avcodec",
+        "avformat",
+        "litr-muxers"
+)
+
+object NativeMuxersLib {
+    /**
+     * Loads all required libraries for the Native Muxer.
+     */
+    fun loadLibraries() {
+        FFMPEG_LIBRARIES.forEach {
+            loadLibrary(it)
+        }
+    }
+
+    private fun loadLibrary(libraryName: String) {
+        try {
+            System.loadLibrary(libraryName)
+            Log.i(TAG, "Loaded: lib$libraryName")
+        } catch (e: UnsatisfiedLinkError) {
+            Log.e(TAG, "Unable to load: lib$libraryName")
+        }
+    }
+}

--- a/litr-muxers/src/main/java/com/linkedin/android/litr/muxers/NativeOutputFormats.kt
+++ b/litr-muxers/src/main/java/com/linkedin/android/litr/muxers/NativeOutputFormats.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2022 LinkedIn Corporation
+ * All Rights Reserved.
+ *
+ * Licensed under the BSD 2-Clause License (the "License").  See License in the project root for
+ * license information.
+ *
+ * Author: Ian Bird
+ */
+package com.linkedin.android.litr.muxers
+
+import android.media.MediaMuxer
+
+/**
+ * This object contains the known (and supported) output formats for the NativeMediaMuxer.
+ */
+object NativeOutputFormats {
+    const val FORMAT_MPEG4 = "mp4"
+    const val FORMAT_MKV = "matroska"
+
+    const val FORMAT_SEGMENT = "stream_segment"
+
+    /**
+     * Converts constants defined by MediaMuxer.OutputFormat into their equivalent NativeMediaMuxer
+     * constant.
+     */
+    fun fromOutputFormat(outputFormat: Int): String {
+        return when (outputFormat) {
+            MediaMuxer.OutputFormat.MUXER_OUTPUT_MPEG_4 -> FORMAT_MPEG4
+            MediaMuxer.OutputFormat.MUXER_OUTPUT_WEBM -> FORMAT_MKV
+            else -> error("Unsupported output format")
+        }
+    }
+}

--- a/litr/src/main/java/com/linkedin/android/litr/MimeType.java
+++ b/litr/src/main/java/com/linkedin/android/litr/MimeType.java
@@ -7,16 +7,41 @@
  */
 package com.linkedin.android.litr;
 
+import androidx.annotation.Nullable;
+
 public class MimeType {
+    private static final String BASE_TYPE_AUDIO = "audio";
+    private static final String BASE_TYPE_VIDEO = "video";
 
-    public static final String AUDIO_AAC = "audio/mp4a-latm";
-    public static final String AUDIO_RAW = "audio/raw";
-    public static final String AUDIO_OPUS = "audio/opus";
-    public static final String AUDIO_VORBIS = "audio/vorbis";
+    public static final String AUDIO_AAC = BASE_TYPE_AUDIO + "/mp4a-latm";
+    public static final String AUDIO_RAW = BASE_TYPE_AUDIO + "/raw";
+    public static final String AUDIO_OPUS = BASE_TYPE_AUDIO + "/opus";
+    public static final String AUDIO_VORBIS = BASE_TYPE_AUDIO + "/vorbis";
 
-    public static final String VIDEO_AVC = "video/avc";
-    public static final String VIDEO_HEVC = "video/hevc";
-    public static final String VIDEO_VP8 = "video/x-vnd.on2.vp8";
-    public static final String VIDEO_VP9 = "video/x-vnd.on2.vp9";
-    public static final String VIDEO_RAW = "video/raw";
+    public static final String VIDEO_AVC = BASE_TYPE_VIDEO + "/avc";
+    public static final String VIDEO_HEVC = BASE_TYPE_VIDEO + "/hevc";
+    public static final String VIDEO_VP8 = BASE_TYPE_VIDEO + "/x-vnd.on2.vp8";
+    public static final String VIDEO_VP9 = BASE_TYPE_VIDEO + "/x-vnd.on2.vp9";
+    public static final String VIDEO_RAW = BASE_TYPE_VIDEO + "/raw";
+
+    public static boolean IsVideo(@Nullable String mimeType) {
+        return BASE_TYPE_VIDEO.equals(GetTopLevelType(mimeType));
+    }
+
+    public static boolean IsAudio(@Nullable String mimeType) {
+        return BASE_TYPE_AUDIO.equals(GetTopLevelType(mimeType));
+    }
+
+    private static String GetTopLevelType(@Nullable String mimeType) {
+        if (mimeType == null) {
+            return null;
+        }
+
+        int indexOfSlash = mimeType.indexOf('/');
+        if (indexOfSlash == -1) {
+            return null;
+        }
+
+        return mimeType.substring(0, indexOfSlash);
+    }
 }

--- a/litr/src/main/java/com/linkedin/android/litr/exception/MediaTargetException.java
+++ b/litr/src/main/java/com/linkedin/android/litr/exception/MediaTargetException.java
@@ -20,13 +20,17 @@ public class MediaTargetException extends MediaTransformationException {
 
     private final Error error;
     private final String outputFilePath;
-    private final int outputFormat;
+    private final String outputFormat;
 
     public MediaTargetException(@NonNull Error error, @NonNull Uri outputFileUri, @IntRange(from=0, to=2) int outputFormat, @NonNull Throwable cause) {
         this(error, outputFileUri.toString(), outputFormat, cause);
     }
 
     public MediaTargetException(@NonNull Error error, @NonNull String outputFilePath, @IntRange(from=0, to=2) int outputFormat, @NonNull Throwable cause) {
+        this(error, outputFilePath, String.valueOf(outputFormat), cause);
+    }
+
+    public MediaTargetException(@NonNull Error error, @NonNull String outputFilePath, String outputFormat, @NonNull Throwable cause) {
         super(cause);
         this.error = error;
         this.outputFilePath = outputFilePath;

--- a/litr/src/main/java/com/linkedin/android/litr/io/MediaMuxerMediaTarget.java
+++ b/litr/src/main/java/com/linkedin/android/litr/io/MediaMuxerMediaTarget.java
@@ -38,7 +38,7 @@ import static com.linkedin.android.litr.exception.MediaTargetException.Error.UNS
 public class MediaMuxerMediaTarget implements MediaTarget {
     private static final String TAG = MediaMuxerMediaTarget.class.getSimpleName();
 
-    @VisibleForTesting LinkedList<MediaSample> queue;
+    @VisibleForTesting LinkedList<MediaTargetSample> queue;
     @VisibleForTesting boolean isStarted;
     @VisibleForTesting MediaMuxer mediaMuxer;
 
@@ -121,8 +121,8 @@ public class MediaMuxerMediaTarget implements MediaTarget {
 
             // write out queued items
             while (!queue.isEmpty()) {
-                MediaSample mediaSample = queue.removeFirst();
-                mediaMuxer.writeSampleData(mediaSample.targetTrack, mediaSample.buffer, mediaSample.info);
+                MediaTargetSample mediaSample = queue.removeFirst();
+                mediaMuxer.writeSampleData(mediaSample.getTargetTrack(), mediaSample.getBuffer(), mediaSample.getInfo());
             }
         }
 
@@ -139,7 +139,7 @@ public class MediaMuxerMediaTarget implements MediaTarget {
             }
         } else {
             // media muxer is not started yet, so queue up incoming buffers to write them out later
-            MediaSample mediaSample = new MediaSample(targetTrack, buffer, info);
+            MediaTargetSample mediaSample = new MediaTargetSample(targetTrack, buffer, info);
             queue.addLast(mediaSample);
         }
     }
@@ -163,24 +163,6 @@ public class MediaMuxerMediaTarget implements MediaTarget {
                 parcelFileDescriptor = null;
             }
         } catch (IOException ignored) {
-        }
-    }
-
-    private class MediaSample {
-        private int targetTrack;
-        private ByteBuffer buffer;
-        private MediaCodec.BufferInfo info;
-
-        private MediaSample(int targetTrack, ByteBuffer buffer, MediaCodec.BufferInfo info) {
-            this.targetTrack = targetTrack;
-
-            this.info = new MediaCodec.BufferInfo();
-            this.info.set(0, info.size, info.presentationTimeUs, info.flags);
-
-            // we want to make a deep copy so we can release the incoming buffer back to encoder immediately
-            this.buffer = ByteBuffer.allocate(buffer.capacity());
-            this.buffer.put(buffer);
-            this.buffer.flip();
         }
     }
 }

--- a/litr/src/main/java/com/linkedin/android/litr/io/MediaTargetSample.kt
+++ b/litr/src/main/java/com/linkedin/android/litr/io/MediaTargetSample.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2022 LinkedIn Corporation
+ * All Rights Reserved.
+ *
+ * Licensed under the BSD 2-Clause License (the "License").  See License in the project root for
+ * license information.
+ *
+ * Author: Ian Bird
+ */
+package com.linkedin.android.litr.io
+
+import android.media.MediaCodec
+import java.nio.ByteBuffer
+
+/**
+ * If a {@link MediaTarget} needs to temporarily queue up samples, this class can provide a deep
+ * copy of the sample to allow the original to be returned (e.g. to the encoder).
+ */
+class MediaTargetSample(
+        val targetTrack: Int,
+        buffer: ByteBuffer,
+        info: MediaCodec.BufferInfo
+) {
+    val buffer: ByteBuffer = ByteBuffer.allocate(buffer.capacity())
+    val info : MediaCodec.BufferInfo = MediaCodec.BufferInfo()
+
+    init {
+        this.info.set(0, info.size, info.presentationTimeUs, info.flags)
+
+        // We want to make a deep copy so that we can release the incoming buffer back to the
+        // encoder immediately.
+        this.buffer.put(buffer)
+        this.buffer.flip()
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,1 @@
-include ':litr-demo', ':litr', ':litr-filters'
+include ':litr-demo', ':litr', ':litr-filters', ':litr-muxers'


### PR DESCRIPTION
**Work In Progress: This is not yet ready to be merged but is to provide visibility of the progress of a NativeMediaTarget**

This PR introduces the following:
 - A separate `litr-muxers` module
 - The build scripts and process required to build ffmpeg's libavformat with a number of common muxers (including parsers and bitstream filters)
 - Code that wraps libavformat's muxers and exposes them via an interface similar to Android's MediaMuxer.
 - A `NativeMediaMuxerMediaTarget` that allows LiTr to use these new classes to mux output samples into the target file.


**Status**

While most of the module skeleton is complete, along with build scripts/introductions, the main area remaining in the JNI interface. We need to flesh out `MediaMuxer.cpp` more along with dealing with the marshalling of required data via `NativeMediaMuxer.cpp`