### PR TITLE
Add missing duration target track metadata when adding track to muxer

### DIFF
--- a/litr/src/main/java/com/linkedin/android/litr/transcoder/AudioTrackTranscoder.java
+++ b/litr/src/main/java/com/linkedin/android/litr/transcoder/AudioTrackTranscoder.java
@@ -238,8 +238,8 @@ public class AudioTrackTranscoder extends TrackTranscoder {
                     // TODO for now, we assume that we only get one media format as a first buffer
                     MediaFormat outputMediaFormat = encoder.getOutputFormat();
                     if (!targetTrackAdded) {
-                        targetFormat = outputMediaFormat;
-                        targetTrack = mediaMuxer.addTrack(outputMediaFormat, targetTrack);
+                        targetFormat = addMissingMetadata(sourceAudioFormat, outputMediaFormat);
+                        targetTrack = mediaMuxer.addTrack(targetFormat, targetTrack);
                         targetTrackAdded = true;
                         renderer.onMediaFormatChanged(sourceAudioFormat, targetFormat);
                     }

--- a/litr/src/main/java/com/linkedin/android/litr/transcoder/TrackTranscoder.java
+++ b/litr/src/main/java/com/linkedin/android/litr/transcoder/TrackTranscoder.java
@@ -9,6 +9,8 @@ package com.linkedin.android.litr.transcoder;
 
 import android.media.MediaCodec;
 import android.media.MediaFormat;
+import android.os.Build;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.RestrictTo;
@@ -129,6 +131,19 @@ public abstract class TrackTranscoder {
             }
         }
         return RESULT_END_OF_RANGE_REACHED;
+    }
+
+    protected MediaFormat addMissingMetadata(@NonNull MediaFormat sourceMediaFormat, @NonNull MediaFormat targetMediaFormat) {
+        if (!targetMediaFormat.containsKey(MediaFormat.KEY_DURATION)
+                && sourceMediaFormat.containsKey(MediaFormat.KEY_DURATION)) {
+            targetMediaFormat.setLong(MediaFormat.KEY_DURATION, sourceMediaFormat.getLong(MediaFormat.KEY_DURATION));
+        }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT
+                && !targetMediaFormat.containsKey(MediaFormat.KEY_LANGUAGE)
+                && sourceMediaFormat.containsKey(MediaFormat.KEY_LANGUAGE)) {
+            targetMediaFormat.setString(MediaFormat.KEY_LANGUAGE, sourceMediaFormat.getString(MediaFormat.KEY_LANGUAGE));
+        }
+        return targetMediaFormat;
     }
 
 }

--- a/litr/src/main/java/com/linkedin/android/litr/transcoder/VideoTrackTranscoder.java
+++ b/litr/src/main/java/com/linkedin/android/litr/transcoder/VideoTrackTranscoder.java
@@ -284,8 +284,8 @@ public class VideoTrackTranscoder extends TrackTranscoder {
                     // TODO for now, we assume that we only get one media format as a first buffer
                     MediaFormat outputMediaFormat = encoder.getOutputFormat();
                     if (!targetTrackAdded) {
-                        targetVideoFormat = targetFormat = outputMediaFormat;
-                        targetTrack = mediaMuxer.addTrack(outputMediaFormat, targetTrack);
+                        targetVideoFormat = targetFormat = addMissingMetadata(sourceVideoFormat, outputMediaFormat);
+                        targetTrack = mediaMuxer.addTrack(targetFormat, targetTrack);
                         targetTrackAdded = true;
                         renderer.onMediaFormatChanged(sourceVideoFormat, targetVideoFormat);
                     }


### PR DESCRIPTION
On newer versions of Android `MediaFormat` produced by `Encoder` might not contain some useful values (such as duration) even if they were passed in. When such `MediaFormat` is added to `MediaTarget` it will produce a video with missing useful metadata, as reported in #222 

We are fixing this by populating missing duration and language metadata from source `MediaFormat` in encoder output `MediaFormat` before adding a track in `MediaTarget`. 

Assertions are added in unit tests for new logic.