### PR TITLE
Add missing duration target track metadata to decoder output format

### DIFF
--- a/litr/src/main/java/com/linkedin/android/litr/transcoder/VideoTrackTranscoder.java
+++ b/litr/src/main/java/com/linkedin/android/litr/transcoder/VideoTrackTranscoder.java
@@ -239,7 +239,7 @@ public class VideoTrackTranscoder extends TrackTranscoder {
                     // Log.d(TAG, "Will try getting decoder output later");
                     break;
                 case MediaCodec.INFO_OUTPUT_FORMAT_CHANGED:
-                    sourceVideoFormat = decoder.getOutputFormat();
+                    sourceVideoFormat = addMissingMetadata(sourceVideoFormat, decoder.getOutputFormat());
                     renderer.onMediaFormatChanged(sourceVideoFormat, targetVideoFormat);
                     Log.d(TAG, "Decoder output format changed: " + sourceVideoFormat);
                     break;


### PR DESCRIPTION
Duration and language metadata was lost in video decoder output as well, which in turn was later used to populate muxer track metadata. Fixing this by populating those values when decoder output changes.