### PR TITLE
Muxers: integrate native muxer with LiTr

### DIFF
--- a/litr-demo/src/main/java/com/linkedin/android/litr/demo/DemoCase.java
+++ b/litr-demo/src/main/java/com/linkedin/android/litr/demo/DemoCase.java
@@ -18,6 +18,8 @@ import com.linkedin.android.litr.demo.fragment.ExtractFramesFragment;
 import com.linkedin.android.litr.demo.fragment.FreeTransformVideoGlFragment;
 import com.linkedin.android.litr.demo.fragment.MockTranscodeFragment;
 import com.linkedin.android.litr.demo.fragment.MuxVideoAndAudioFragment;
+import com.linkedin.android.litr.demo.fragment.NativeMuxerCameraFragment;
+import com.linkedin.android.litr.demo.fragment.NativeMuxerTranscodeFragment;
 import com.linkedin.android.litr.demo.fragment.RecordAudioFragment;
 import com.linkedin.android.litr.demo.fragment.RecordCamera2Fragment;
 import com.linkedin.android.litr.demo.fragment.SquareCenterCropFragment;
@@ -42,7 +44,9 @@ public enum DemoCase {
     EXTRACT_FRAMES(R.string.demo_case_extract_frames, "ExtractFramesFragment", new ExtractFramesFragment()),
     TRANSCODE_TO_VP9(R.string.demo_case_transcode_to_vp9, "TranscodeToVp9Fragment", new TranscodeToVp9Fragment()),
     RECORD_AUDIO(R.string.demo_case_audio_record, "RecordAudio", new RecordAudioFragment()),
-    @SuppressLint("NewApi") RECORD_CAMERA(R.string.demo_case_camera_record, "RecordCamera2", new RecordCamera2Fragment());
+    @SuppressLint("NewApi") RECORD_CAMERA(R.string.demo_case_camera_record, "RecordCamera2", new RecordCamera2Fragment()),
+    NATIVE_MUXER_TRANSCODE(R.string.demo_case_native_muxer_transcode, "NativeMuxerTranscode", new NativeMuxerTranscodeFragment()),
+    @SuppressLint("NewApi") NATIVE_MUXER_CAMERA(R.string.demo_case_native_muxer_camera, "NativeMuxerCamera", new NativeMuxerCameraFragment());
 
     @StringRes int displayName;
     String fragmentTag;

--- a/litr-demo/src/main/java/com/linkedin/android/litr/demo/data/RecordCameraPresenter.kt
+++ b/litr-demo/src/main/java/com/linkedin/android/litr/demo/data/RecordCameraPresenter.kt
@@ -22,6 +22,7 @@ import com.linkedin.android.litr.codec.MediaCodecEncoder
 import com.linkedin.android.litr.exception.MediaTransformationException
 import com.linkedin.android.litr.filter.GlFilter
 import com.linkedin.android.litr.io.*
+import com.linkedin.android.litr.muxers.NativeMediaMuxerMediaTarget
 import com.linkedin.android.litr.render.GlVideoRenderer
 import java.util.UUID
 
@@ -37,7 +38,8 @@ class RecordCameraPresenter(
             audioMediaSource: AudioRecordMediaSource,
             videoMediaSource: Camera2MediaSource,
             targetMedia: TargetMedia,
-            transformationState: TransformationState
+            transformationState: TransformationState,
+            enableNativeMuxer: Boolean
     ) {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
             throw UnsupportedOperationException("Android Marshmallow or newer required")
@@ -56,12 +58,7 @@ class RecordCameraPresenter(
         )
 
         try {
-            val mediaTarget: MediaTarget = MediaMuxerMediaTarget(
-                targetMedia.targetFile.path,
-                2,
-                0,
-                MediaMuxer.OutputFormat.MUXER_OUTPUT_MPEG_4
-            )
+            val mediaTarget = buildMediaTarget(targetMedia, enableNativeMuxer)
 
             val videoTrackFormat = VideoTrackFormat(0, MimeType.VIDEO_AVC)
                 .apply {
@@ -128,5 +125,26 @@ class RecordCameraPresenter(
         }
         audioMediaSource.stopRecording()
         videoMediaSource.stopRecording()
+    }
+
+    private fun buildMediaTarget(
+        targetMedia: TargetMedia,
+        enableNativeMuxer: Boolean
+    ): MediaTarget {
+        return if (enableNativeMuxer) {
+            NativeMediaMuxerMediaTarget(
+                targetMedia.targetFile.path,
+                2,
+                0,
+                MediaMuxer.OutputFormat.MUXER_OUTPUT_MPEG_4
+            )
+        } else {
+            MediaMuxerMediaTarget(
+                targetMedia.targetFile.path,
+                2,
+                0,
+                MediaMuxer.OutputFormat.MUXER_OUTPUT_MPEG_4
+            )
+        }
     }
 }

--- a/litr-demo/src/main/java/com/linkedin/android/litr/demo/fragment/NativeMuxerCameraFragment.kt
+++ b/litr-demo/src/main/java/com/linkedin/android/litr/demo/fragment/NativeMuxerCameraFragment.kt
@@ -1,0 +1,21 @@
+package com.linkedin.android.litr.demo.fragment
+
+import android.os.Build
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.annotation.RequiresApi
+
+@RequiresApi(Build.VERSION_CODES.M)
+class NativeMuxerCameraFragment: RecordCamera2Fragment() {
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        return super.onCreateView(inflater, container, savedInstanceState).also {
+            binding.enableNativeMuxer = true
+        }
+    }
+}

--- a/litr-demo/src/main/java/com/linkedin/android/litr/demo/fragment/NativeMuxerTranscodeFragment.kt
+++ b/litr-demo/src/main/java/com/linkedin/android/litr/demo/fragment/NativeMuxerTranscodeFragment.kt
@@ -1,0 +1,19 @@
+package com.linkedin.android.litr.demo.fragment
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import com.linkedin.android.litr.demo.MediaPickerListener
+
+class NativeMuxerTranscodeFragment: TranscodeVideoGlFragment(), MediaPickerListener {
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        return super.onCreateView(inflater, container, savedInstanceState).also {
+            binding.enableNativeMuxer = true
+        }
+    }
+}

--- a/litr-demo/src/main/java/com/linkedin/android/litr/demo/fragment/RecordCamera2Fragment.kt
+++ b/litr-demo/src/main/java/com/linkedin/android/litr/demo/fragment/RecordCamera2Fragment.kt
@@ -47,8 +47,8 @@ private const val DEFAULT_TARGET_BITRATE = 5_000_000 // 5Mbps
 private const val DEFAULT_RECORD_WIDTH = 1280
 
 @RequiresApi(Build.VERSION_CODES.M)
-class RecordCamera2Fragment : BaseTransformationFragment() {
-    private lateinit var binding: FragmentCamera2RecordBinding
+open class RecordCamera2Fragment : BaseTransformationFragment() {
+    protected lateinit var binding: FragmentCamera2RecordBinding
 
     private lateinit var mediaTransformer: MediaTransformer
     private var targetMedia: TargetMedia = TargetMedia()
@@ -79,7 +79,8 @@ class RecordCamera2Fragment : BaseTransformationFragment() {
                     binding.audioMediaSource!!,
                     binding.videoMediaSource!!,
                     binding.targetMedia!!,
-                    binding.transformationState!!
+                    binding.transformationState!!,
+                    binding.enableNativeMuxer == true
             )
         }
 

--- a/litr-demo/src/main/java/com/linkedin/android/litr/demo/fragment/TranscodeVideoGlFragment.java
+++ b/litr-demo/src/main/java/com/linkedin/android/litr/demo/fragment/TranscodeVideoGlFragment.java
@@ -32,7 +32,7 @@ import java.io.File;
 
 public class TranscodeVideoGlFragment extends BaseTransformationFragment implements MediaPickerListener {
 
-    private FragmentTranscodeVideoGlBinding binding;
+    protected FragmentTranscodeVideoGlBinding binding;
 
     private MediaTransformer mediaTransformer;
 

--- a/litr-demo/src/main/res/layout/fragment_camera2_record.xml
+++ b/litr-demo/src/main/res/layout/fragment_camera2_record.xml
@@ -32,6 +32,10 @@
             name="transformationPresenter"
             type="com.linkedin.android.litr.demo.data.RecordCameraPresenter" />
 
+        <variable
+            name="enableNativeMuxer"
+            type="java.lang.Boolean" />
+
     </data>
 
     <RelativeLayout

--- a/litr-demo/src/main/res/layout/fragment_transcode_video_gl.xml
+++ b/litr-demo/src/main/res/layout/fragment_transcode_video_gl.xml
@@ -38,6 +38,10 @@
             name="transformationPresenter"
             type="com.linkedin.android.litr.demo.data.TranscodeVideoGlPresenter" />
 
+        <variable
+            name="enableNativeMuxer"
+            type="java.lang.Boolean" />
+
     </data>
 
     <androidx.core.widget.NestedScrollView
@@ -83,7 +87,7 @@
                 android:text="@string/transcode"
                 android:enabled="@{sourceMedia != null &amp;&amp; targetMedia != null &amp;&amp; targetMedia.getIncludedTrackCount() > 0 &amp;&amp; (transformationState.state != transformationState.STATE_RUNNING)}"
                 android:padding="@dimen/cell_padding"
-                android:onClick="@{() -> transformationPresenter.startTransformation(sourceMedia, targetMedia, trimConfig, audioVolumeConfig, transformationState)}"/>
+                android:onClick="@{() -> transformationPresenter.startTransformation(sourceMedia, targetMedia, trimConfig, audioVolumeConfig, transformationState, enableNativeMuxer)}"/>
 
             <include layout="@layout/section_transformation_progress"
                 android:id="@+id/section_transformation_progress"

--- a/litr-demo/src/main/res/values/strings.xml
+++ b/litr-demo/src/main/res/values/strings.xml
@@ -20,6 +20,8 @@
     <string name="demo_case_transcode_to_vp9">Transcode To VP9</string>
     <string name="demo_case_audio_record">Record Audio</string>
     <string name="demo_case_camera_record">Record Camera (via Camera2)</string>
+    <string name="demo_case_native_muxer_transcode">Native Muxer (Transcode)</string>
+    <string name="demo_case_native_muxer_camera">Native Muxer (Camera)</string>
 
     <string name="error_vp9_not_supported">VP8/VP9 is not supported</string>
     <string name="error_marshmallow_or_newer_required">Android Marshmallow or newer required</string>

--- a/litr-muxers/src/main/cpp/MediaMuxer.cpp
+++ b/litr-muxers/src/main/cpp/MediaMuxer.cpp
@@ -174,7 +174,7 @@ int MediaMuxer::writeSampleData(int stream_index, uint8_t *buffer, int size, int
     auto stream = mContext->streams[stream_index];
     av_packet_rescale_ts(&pkt, (AVRational){ 1, 1000000 }, stream->time_base);
 
-    LOGI("writeSampleData(index: %d size: %d pts: %lld flags: %d)", stream_index, size, ptsUs, flags);
+    //LOGI("writeSampleData(index: %d size: %d pts: %lld flags: %d)", stream_index, size, ptsUs, flags);
 
     // Write the compressed frame to the media file.
     int err = av_interleaved_write_frame(mContext, &pkt);

--- a/litr-muxers/src/main/java/com/linkedin/android/litr/muxers/MediaFormatEx.kt
+++ b/litr-muxers/src/main/java/com/linkedin/android/litr/muxers/MediaFormatEx.kt
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2023 LinkedIn Corporation
+ * All Rights Reserved.
+ *
+ * Licensed under the BSD 2-Clause License (the "License").  See License in the project root for
+ * license information.
+ *
+ * Author: Ian Bird
+ */
+package com.linkedin.android.litr.muxers
+
+import android.media.MediaFormat
+import com.linkedin.android.litr.MimeType
+import java.nio.ByteBuffer
+
+const val KEY_MIME_TYPE = MediaFormat.KEY_MIME
+const val KEY_BIT_RATE = MediaFormat.KEY_BIT_RATE
+const val KEY_WIDTH = MediaFormat.KEY_WIDTH
+const val KEY_HEIGHT = MediaFormat.KEY_HEIGHT
+const val KEY_CHANNEL_COUNT = MediaFormat.KEY_CHANNEL_COUNT
+const val KEY_SAMPLE_RATE = MediaFormat.KEY_SAMPLE_RATE
+
+fun MediaFormat.isVideo(): Boolean {
+    val mimeType = getStringSafe(KEY_MIME_TYPE, "")
+    return MimeType.isVideo(mimeType)
+}
+
+fun MediaFormat.isAudio(): Boolean {
+    val mimeType = getStringSafe(KEY_MIME_TYPE, "")
+    return MimeType.isAudio(mimeType)
+}
+
+fun MediaFormat.getCodecId(): String {
+    // We ideally just use the mime type name, but there are some required substitutions.
+    return when(val mimeType = getStringSafe(KEY_MIME_TYPE, "")) {
+        MimeType.AUDIO_AAC -> "aac"
+
+        MimeType.VIDEO_AVC -> "h264"
+        MimeType.VIDEO_HEVC -> "hevc"
+        else -> {
+            val components = mimeType.split("/")
+            return components.last()
+        }
+    }
+}
+
+fun MediaFormat.getBitrate() = getIntSafe(KEY_BIT_RATE, 0)
+
+fun MediaFormat.getChannelCount() = getIntSafe(KEY_CHANNEL_COUNT, 0)
+
+fun MediaFormat.getSampleRate() = getIntSafe(KEY_SAMPLE_RATE, 0)
+
+fun MediaFormat.getWidth() = getIntSafe(KEY_WIDTH, 0)
+
+fun MediaFormat.getHeight() = getIntSafe(KEY_HEIGHT, 0)
+
+fun MediaFormat.getExtraData(): ByteBuffer? {
+    val buffers = mutableListOf<ByteBuffer>()
+    var targetBufferSize = 0
+
+    // A MediaFormat can contain 0-N buffers that represent the codec specific data (aka csd). We
+    // need to combine these individual buffers into a single ByteBuffer. Let's start by finding all
+    // the associated buffers and how large our final buffer will be.
+    var index = 0
+    while (true) {
+        val buffer = getByteBuffer("csd-$index") ?: break
+
+        buffers.add(buffer)
+        targetBufferSize += buffer.capacity()
+        index++
+    }
+
+    // Check to see if we found at least one non-empty buffer.
+    if (targetBufferSize == 0) {
+        return null
+    }
+
+    // Build the final ByteBuffer and add each original buffer sequentially.
+    val extraBuffer = ByteBuffer.allocate(targetBufferSize)
+    for (buffer in buffers) {
+        extraBuffer.put(buffer)
+    }
+
+    extraBuffer.position(0)
+    return extraBuffer
+}
+
+fun MediaFormat.getSampleSize(): Int {
+    return when(getStringSafe(KEY_MIME_TYPE, "")) {
+        MimeType.AUDIO_AAC -> 1024
+        else -> 0
+    }
+}
+
+private fun MediaFormat.getStringSafe(key: String, default: String): String {
+    return getString(key) ?: default
+}
+
+private fun MediaFormat.getIntSafe(key: String, default: Int): Int {
+    return runCatching { getInteger(key) }.getOrDefault(default)
+}

--- a/litr-muxers/src/main/java/com/linkedin/android/litr/muxers/NativeLogger.kt
+++ b/litr-muxers/src/main/java/com/linkedin/android/litr/muxers/NativeLogger.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2023 LinkedIn Corporation
+ * All Rights Reserved.
+ *
+ * Licensed under the BSD 2-Clause License (the "License").  See License in the project root for
+ * license information.
+ *
+ * Author: Ian Bird
+ */
+package com.linkedin.android.litr.muxers
+
+/**
+ * Allows configuration of the logging performed by the native components.
+ */
+object NativeLogger {
+    // Level's defined in avutil/log.h
+    const val LEVEL_TRACE = 56
+    const val LEVEL_DEBUG = 48
+    const val LEVEL_VERBOSE = 40
+    const val LEVEL_INFO = 32
+    const val LEVEL_WARNING = 24
+    const val LEVEL_ERROR = 16
+    const val LEVEL_FATAL = 8
+    const val LEVEL_PANIC = 0
+    const val LEVEL_QUIET = -8
+
+    /**
+     * Configures the native logger with the given level. These log messages will be written to
+     * the application's logcat messages.
+     */
+    fun setup(level: Int) = nativeSetup(level)
+
+    private external fun nativeSetup(level: Int)
+}

--- a/litr-muxers/src/main/java/com/linkedin/android/litr/muxers/NativeMediaMuxer.kt
+++ b/litr-muxers/src/main/java/com/linkedin/android/litr/muxers/NativeMediaMuxer.kt
@@ -1,0 +1,240 @@
+/*
+ * Copyright 2023 LinkedIn Corporation
+ * All Rights Reserved.
+ *
+ * Licensed under the BSD 2-Clause License (the "License").  See License in the project root for
+ * license information.
+ *
+ * Author: Ian Bird
+ */
+package com.linkedin.android.litr.muxers
+
+import android.media.MediaCodec.BufferInfo
+import android.media.MediaFormat
+import android.util.Log
+import java.nio.ByteBuffer
+
+private const val TAG = "NativeMediaMuxer"
+
+private const val MUXER_STATE_UNINITIALIZED = -1
+private const val MUXER_STATE_INITIALIZED = 0
+private const val MUXER_STATE_STARTED = 1
+private const val MUXER_STATE_STOPPED = 2
+
+private fun convertMuxerStateCodeToString(state: Int): String {
+    return when(state) {
+        MUXER_STATE_UNINITIALIZED -> { "UNINITIALIZED" }
+        MUXER_STATE_INITIALIZED -> { "INITIALIZED" }
+        MUXER_STATE_STARTED -> { "STARTED" }
+        MUXER_STATE_STOPPED -> { "STOPPED " }
+        else -> { "UNKNOWN" }
+    }
+}
+
+/**
+ * A Muxer that is based off Android's built in MediaMuxer, but internally uses ffmpeg's libavformat
+ * for generating the output file. This allows support for a lot more advanced formats.
+ */
+class NativeMediaMuxer(val path: String, val format: String) {
+    private var nativeObject: Long = 0L
+    private var state: Int = MUXER_STATE_UNINITIALIZED
+
+    private var lastTrackIndex = -1
+
+    // Muxers support a number of options when started. This will control their behaviour, for
+    // example MP4 vs fMP4. We store the configured options to pass through to libavformat when
+    // we're about to start muxing.
+    private var options = mutableMapOf<String, String>()
+
+    init {
+        // Initialise the native muxer.
+        nativeObject = nativeSetup(path, format)
+        state = MUXER_STATE_INITIALIZED
+    }
+
+    /**
+     * Adds a track with the specified format.
+     */
+    fun addTrack(format: MediaFormat): Int {
+        if (state != MUXER_STATE_INITIALIZED) {
+            throw IllegalStateException("Muxer is not initialized.")
+        }
+        if (nativeObject == 0L) {
+            throw IllegalStateException("Muxer has been released")
+        }
+
+        // Add the track to the muxer.
+        val extra = format.getExtraData()
+        val trackIndex = if (format.isAudio()) {
+            nativeAddAudioTrack(
+                    nativeObject,
+                    format.getCodecId(),
+                    format.getBitrate(),
+                    format.getChannelCount(),
+                    format.getSampleRate(),
+                    format.getSampleSize(),
+                    extra,
+                    extra?.capacity() ?: 0
+            )
+        } else if (format.isVideo()) {
+            nativeAddVideoTrack(
+                    nativeObject,
+                    format.getCodecId(),
+                    format.getBitrate(),
+                    format.getWidth(),
+                    format.getHeight(),
+                    extra,
+                    extra?.capacity() ?: 0
+            )
+        } else {
+            error("Unable to add unsupported track")
+        }
+
+        // The returned track index is expected to be incremented as addTrack succeeds. However, if
+        // the format is invalid, it will get a negative track index.
+        if (lastTrackIndex >= trackIndex) {
+            throw IllegalStateException("Invalid format")
+        }
+
+        Log.i(TAG, "Stream Added (ID: ${format.getCodecId()} Index: $trackIndex)")
+        lastTrackIndex = trackIndex
+        return trackIndex
+    }
+
+    /**
+     * Adds a muxer option. This method *must* be called before the muxer has been started.
+     */
+    fun addOption(key: String, value: String) {
+        if (state != MUXER_STATE_INITIALIZED) {
+            throw IllegalStateException("Muxer is not initialized.")
+        }
+        if (nativeObject == 0L) {
+            throw IllegalStateException("Muxer has been released")
+        }
+
+        // Store the option for later.
+        Log.i(TAG, "Option Added (Key: $key Value: $value)")
+        options[key] = value
+    }
+
+    /**
+     * Starts the muxer.
+     */
+    fun start() {
+        if (nativeObject == 0L) {
+            throw IllegalStateException("Muxer has been released")
+        }
+
+        if (state == MUXER_STATE_INITIALIZED) {
+            nativeStart(nativeObject, options.keys.toTypedArray(), options.values.toTypedArray())
+            state = MUXER_STATE_STARTED
+        } else {
+            throw IllegalStateException(
+                    "Can't start due to wrong state (${convertMuxerStateCodeToString(state)})")
+        }
+    }
+
+    /**
+     * Stops the muxer.
+     */
+    fun stop() {
+        if (state == MUXER_STATE_STARTED) {
+            try {
+                nativeStop(nativeObject)
+                Log.i(TAG, "Muxer stopped successfully")
+            } catch (e: Exception) {
+                throw e
+            } finally {
+                state = MUXER_STATE_STOPPED
+            }
+        } else {
+            throw IllegalStateException(
+                    "Can't stop due to wrong state (${convertMuxerStateCodeToString(state)})")
+        }
+    }
+
+    /**
+     * Writes an encoded sample into the muxer.
+     */
+    fun writeSampleData(trackIndex: Int, byteBuf: ByteBuffer, bufferInfo: BufferInfo) {
+        if (trackIndex < 0 || trackIndex > lastTrackIndex) {
+            throw IllegalArgumentException("trackIndex is invalid")
+        }
+        if (bufferInfo.size < 0 || bufferInfo.offset < 0 ||
+                (bufferInfo.offset + bufferInfo.size) > byteBuf.capacity()) {
+            throw IllegalArgumentException("bufferInfo must specify a valid buffer offset and size")
+        }
+        if (!byteBuf.hasArray()) {
+            throw IllegalArgumentException("byteBuf must have an accessible buffer.")
+        }
+        if (nativeObject == 0L) {
+            throw IllegalStateException("Muxer has been released")
+        }
+        if (state != MUXER_STATE_STARTED) {
+            throw IllegalStateException("Can't write, muxer is not started")
+        }
+
+        // Pass the buffer and info to the native layer.
+        nativeWriteSampleData(
+                nativeObject,
+                trackIndex,
+                byteBuf,
+                bufferInfo.offset,
+                bufferInfo.size,
+                bufferInfo.presentationTimeUs,
+                bufferInfo.flags
+        )
+    }
+
+    /**
+     * Make sure you call this when you're done to free up any resources, instead of relying on the
+     * garbage collector to do this for you at some point in the future.
+     */
+    fun release() {
+        if (state == MUXER_STATE_STARTED) {
+            stop()
+        }
+
+        if (nativeObject != 0L) {
+            nativeRelease(nativeObject)
+            nativeObject = 0L
+        }
+
+        state = MUXER_STATE_UNINITIALIZED
+    }
+
+    protected fun finalize() {
+        if (nativeObject != 0L) {
+            nativeRelease(nativeObject)
+            nativeObject = 0L
+        }
+    }
+
+    private external fun nativeSetup(outputPath: String, formatName: String): Long
+    private external fun nativeRelease(nativeObject: Long)
+    private external fun nativeStart(nativeObject: Long, keys: Array<String>, values: Array<String>)
+    private external fun nativeStop(nativeObject: Long)
+    private external fun nativeAddAudioTrack(nativeObject: Long, codecId: String, bitrate: Int,
+                                             channelCount: Int, sampleRate: Int, frameSize: Int,
+                                             byteBuf: ByteBuffer?, size: Int): Int
+    private external fun nativeAddVideoTrack(nativeObject: Long, codecId: String, bitrate: Int,
+                                             width: Int, height: Int, byteBuf: ByteBuffer?,
+                                             size: Int): Int
+    private external fun nativeWriteSampleData(nativeObject: Long, trackIndex: Int,
+                                               byteBuf: ByteBuffer, offset: Int, size: Int,
+                                               presentationTimeUs: Long, flags: Int)
+
+    companion object {
+        init {
+            // Static initializer to ensure that our native libraries are loaded and we have
+            // configured their logging to be captured by Android.
+            NativeMuxersLib.loadLibraries()
+            NativeLogger.setup(
+                    if (BuildConfig.DEBUG)
+                        NativeLogger.LEVEL_TRACE
+                    else
+                        NativeLogger.LEVEL_WARNING
+            )
+        }
+    }
+}

--- a/litr-muxers/src/main/java/com/linkedin/android/litr/muxers/NativeMediaMuxerMediaTarget.kt
+++ b/litr-muxers/src/main/java/com/linkedin/android/litr/muxers/NativeMediaMuxerMediaTarget.kt
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2023 LinkedIn Corporation
+ * All Rights Reserved.
+ *
+ * Licensed under the BSD 2-Clause License (the "License").  See License in the project root for
+ * license information.
+ *
+ * Author: Ian Bird
+ */
+package com.linkedin.android.litr.muxers
+
+import android.media.MediaCodec
+import android.media.MediaFormat
+import android.util.Log
+import com.linkedin.android.litr.exception.MediaTargetException
+import com.linkedin.android.litr.io.MediaTarget
+import com.linkedin.android.litr.io.MediaTargetSample
+import java.nio.ByteBuffer
+import java.util.*
+
+private const val TAG = "NativeMediaTarget"
+
+/**
+ * An implementation of MediaTarget, which wraps FFMpeg's libavformat.
+ *
+ * Before writing any media samples to MediaMuxer, all tracks must be added and MediaMuxer must be started. Some track
+ * transcoders may start writing their output before other track transcoders added their track. This class queues writing
+ * media samples until all tracks are created, allowing track transcoders to work independently.
+ */
+class NativeMediaMuxerMediaTarget(
+        private val outputFilePath: String,
+        private val trackCount: Int,
+        private val orientationHint: Int,
+        outputFormat: String
+): MediaTarget {
+
+    constructor(outputFilePath: String, trackCount: Int, orientationHint: Int, outputFormat: Int) :
+            this(
+                    outputFilePath,
+                    trackCount,
+                    orientationHint,
+                    NativeOutputFormats.fromOutputFormat(outputFormat)
+            )
+
+    private val queue: LinkedList<MediaTargetSample> = LinkedList()
+    private var isStarted: Boolean = false
+    private val mediaMuxer : NativeMediaMuxer
+
+    private var numberOfTracksToAdd = 0
+    private val mediaFormatsToAdd = arrayOfNulls<MediaFormat>(trackCount)
+
+    init {
+        try {
+            mediaMuxer = NativeMediaMuxer(outputFilePath, outputFormat)
+        } catch (ex: IllegalStateException) {
+            throw MediaTargetException(
+                    MediaTargetException.Error.INVALID_PARAMS,
+                    outputFilePath,
+                    outputFormat,
+                    ex);
+        }
+    }
+
+    /**
+     * Adds a muxer option. This method *must* be called before the muxer has been started.
+     */
+    fun addOption(key: String, value: String) = mediaMuxer.addOption(key, value)
+
+    override fun addTrack(mediaFormat: MediaFormat, targetTrack: Int): Int {
+        mediaFormatsToAdd[targetTrack] = mediaFormat
+        numberOfTracksToAdd++
+
+        if (numberOfTracksToAdd == trackCount) {
+            Log.d(TAG, "All tracks added, starting MediaMuxer, writing out ${queue.size} queued samples")
+
+            mediaFormatsToAdd.filterNotNull().forEach {
+                mediaMuxer.addTrack(it)
+            }
+
+            mediaMuxer.start()
+            isStarted = true
+
+            // Write out any queued samples.
+            while (queue.isNotEmpty()) {
+                val sample = queue.removeFirst()
+                mediaMuxer.writeSampleData(sample.targetTrack, sample.buffer, sample.info)
+            }
+        }
+
+        return targetTrack
+    }
+
+    override fun writeSampleData(targetTrack: Int, buffer: ByteBuffer, info: MediaCodec.BufferInfo) {
+        // We always create a sample before we write it, to ensure that the ByteBuffer is in a
+        // suitable format to be passed to the native component.
+        val sample = MediaTargetSample(targetTrack, buffer, info)
+        if (isStarted) {
+            mediaMuxer.writeSampleData(sample.targetTrack, sample.buffer, sample.info)
+        } else {
+            // The NativeMediaMuxer is not yet started, so queue up incoming buffers to write them out later
+            queue.addLast(sample)
+        }
+    }
+
+    override fun release() {
+        mediaMuxer.release()
+    }
+
+    override fun getOutputFilePath() = outputFilePath
+}

--- a/litr-muxers/src/main/java/com/linkedin/android/litr/muxers/NativeMuxersLib.kt
+++ b/litr-muxers/src/main/java/com/linkedin/android/litr/muxers/NativeMuxersLib.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2023 LinkedIn Corporation
+ * All Rights Reserved.
+ *
+ * Licensed under the BSD 2-Clause License (the "License").  See License in the project root for
+ * license information.
+ *
+ * Author: Ian Bird
+ */
+package com.linkedin.android.litr.muxers
+
+import android.util.Log
+
+private const val TAG = "NativeMuxersLib"
+private val FFMPEG_LIBRARIES = listOf(
+        "avutil",
+        "avcodec",
+        "avformat",
+        "litr-muxers"
+)
+
+/**
+ * Helper method for loading all required ffmpeg binaries and dependencies.
+ */
+object NativeMuxersLib {
+    /**
+     * Loads all required libraries for the Native Muxer.
+     */
+    fun loadLibraries() {
+        FFMPEG_LIBRARIES.forEach {
+            loadLibrary(it)
+        }
+    }
+
+    private fun loadLibrary(libraryName: String) {
+        try {
+            System.loadLibrary(libraryName)
+            Log.i(TAG, "Loaded: lib$libraryName")
+        } catch (e: UnsatisfiedLinkError) {
+            Log.e(TAG, "Unable to load: lib$libraryName")
+        }
+    }
+}

--- a/litr-muxers/src/main/java/com/linkedin/android/litr/muxers/NativeOutputFormats.kt
+++ b/litr-muxers/src/main/java/com/linkedin/android/litr/muxers/NativeOutputFormats.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2023 LinkedIn Corporation
+ * All Rights Reserved.
+ *
+ * Licensed under the BSD 2-Clause License (the "License").  See License in the project root for
+ * license information.
+ *
+ * Author: Ian Bird
+ */
+package com.linkedin.android.litr.muxers
+
+import android.media.MediaMuxer
+
+/**
+ * This object contains the known (and supported) output formats for the NativeMediaMuxer.
+ */
+object NativeOutputFormats {
+    const val FORMAT_MPEG4 = "mp4"
+    const val FORMAT_MKV = "matroska"
+
+    const val FORMAT_SEGMENT = "stream_segment"
+
+    /**
+     * Converts constants defined by MediaMuxer.OutputFormat into their equivalent NativeMediaMuxer
+     * constant.
+     */
+    fun fromOutputFormat(outputFormat: Int): String {
+        return when (outputFormat) {
+            MediaMuxer.OutputFormat.MUXER_OUTPUT_MPEG_4 -> FORMAT_MPEG4
+            MediaMuxer.OutputFormat.MUXER_OUTPUT_WEBM -> FORMAT_MKV
+            else -> error("Unsupported output format")
+        }
+    }
+}

--- a/litr/src/main/java/com/linkedin/android/litr/MimeType.java
+++ b/litr/src/main/java/com/linkedin/android/litr/MimeType.java
@@ -7,16 +7,41 @@
  */
 package com.linkedin.android.litr;
 
+import androidx.annotation.Nullable;
+
 public class MimeType {
+    private static final String BASE_TYPE_AUDIO = "audio";
+    private static final String BASE_TYPE_VIDEO = "video";
 
-    public static final String AUDIO_AAC = "audio/mp4a-latm";
-    public static final String AUDIO_RAW = "audio/raw";
-    public static final String AUDIO_OPUS = "audio/opus";
-    public static final String AUDIO_VORBIS = "audio/vorbis";
+    public static final String AUDIO_AAC = BASE_TYPE_AUDIO + "/mp4a-latm";
+    public static final String AUDIO_RAW = BASE_TYPE_AUDIO + "/raw";
+    public static final String AUDIO_OPUS = BASE_TYPE_AUDIO + "/opus";
+    public static final String AUDIO_VORBIS = BASE_TYPE_AUDIO + "/vorbis";
 
-    public static final String VIDEO_AVC = "video/avc";
-    public static final String VIDEO_HEVC = "video/hevc";
-    public static final String VIDEO_VP8 = "video/x-vnd.on2.vp8";
-    public static final String VIDEO_VP9 = "video/x-vnd.on2.vp9";
-    public static final String VIDEO_RAW = "video/raw";
+    public static final String VIDEO_AVC = BASE_TYPE_VIDEO + "/avc";
+    public static final String VIDEO_HEVC = BASE_TYPE_VIDEO + "/hevc";
+    public static final String VIDEO_VP8 = BASE_TYPE_VIDEO + "/x-vnd.on2.vp8";
+    public static final String VIDEO_VP9 = BASE_TYPE_VIDEO + "/x-vnd.on2.vp9";
+    public static final String VIDEO_RAW = BASE_TYPE_VIDEO + "/raw";
+
+    public static boolean isVideo(@Nullable String mimeType) {
+        return BASE_TYPE_VIDEO.equals(getTopLevelType(mimeType));
+    }
+
+    public static boolean isAudio(@Nullable String mimeType) {
+        return BASE_TYPE_AUDIO.equals(getTopLevelType(mimeType));
+    }
+
+    private static String getTopLevelType(@Nullable String mimeType) {
+        if (mimeType == null) {
+            return null;
+        }
+
+        int indexOfSlash = mimeType.indexOf('/');
+        if (indexOfSlash == -1) {
+            return null;
+        }
+
+        return mimeType.substring(0, indexOfSlash);
+    }
 }

--- a/litr/src/main/java/com/linkedin/android/litr/exception/MediaTargetException.java
+++ b/litr/src/main/java/com/linkedin/android/litr/exception/MediaTargetException.java
@@ -20,13 +20,17 @@ public class MediaTargetException extends MediaTransformationException {
 
     private final Error error;
     private final String outputFilePath;
-    private final int outputFormat;
+    private final String outputFormat;
 
     public MediaTargetException(@NonNull Error error, @NonNull Uri outputFileUri, @IntRange(from=0, to=2) int outputFormat, @NonNull Throwable cause) {
         this(error, outputFileUri.toString(), outputFormat, cause);
     }
 
     public MediaTargetException(@NonNull Error error, @NonNull String outputFilePath, @IntRange(from=0, to=2) int outputFormat, @NonNull Throwable cause) {
+        this(error, outputFilePath, String.valueOf(outputFormat), cause);
+    }
+
+    public MediaTargetException(@NonNull Error error, @NonNull String outputFilePath, String outputFormat, @NonNull Throwable cause) {
         super(cause);
         this.error = error;
         this.outputFilePath = outputFilePath;

--- a/litr/src/main/java/com/linkedin/android/litr/io/MediaMuxerMediaTarget.java
+++ b/litr/src/main/java/com/linkedin/android/litr/io/MediaMuxerMediaTarget.java
@@ -38,7 +38,7 @@ import static com.linkedin.android.litr.exception.MediaTargetException.Error.UNS
 public class MediaMuxerMediaTarget implements MediaTarget {
     private static final String TAG = MediaMuxerMediaTarget.class.getSimpleName();
 
-    @VisibleForTesting LinkedList<MediaSample> queue;
+    @VisibleForTesting LinkedList<MediaTargetSample> queue;
     @VisibleForTesting boolean isStarted;
     @VisibleForTesting MediaMuxer mediaMuxer;
 
@@ -121,8 +121,8 @@ public class MediaMuxerMediaTarget implements MediaTarget {
 
             // write out queued items
             while (!queue.isEmpty()) {
-                MediaSample mediaSample = queue.removeFirst();
-                mediaMuxer.writeSampleData(mediaSample.targetTrack, mediaSample.buffer, mediaSample.info);
+                MediaTargetSample mediaSample = queue.removeFirst();
+                mediaMuxer.writeSampleData(mediaSample.getTargetTrack(), mediaSample.getBuffer(), mediaSample.getInfo());
             }
         }
 
@@ -139,7 +139,7 @@ public class MediaMuxerMediaTarget implements MediaTarget {
             }
         } else {
             // media muxer is not started yet, so queue up incoming buffers to write them out later
-            MediaSample mediaSample = new MediaSample(targetTrack, buffer, info);
+            MediaTargetSample mediaSample = new MediaTargetSample(targetTrack, buffer, info);
             queue.addLast(mediaSample);
         }
     }
@@ -163,24 +163,6 @@ public class MediaMuxerMediaTarget implements MediaTarget {
                 parcelFileDescriptor = null;
             }
         } catch (IOException ignored) {
-        }
-    }
-
-    private class MediaSample {
-        private int targetTrack;
-        private ByteBuffer buffer;
-        private MediaCodec.BufferInfo info;
-
-        private MediaSample(int targetTrack, ByteBuffer buffer, MediaCodec.BufferInfo info) {
-            this.targetTrack = targetTrack;
-
-            this.info = new MediaCodec.BufferInfo();
-            this.info.set(0, info.size, info.presentationTimeUs, info.flags);
-
-            // we want to make a deep copy so we can release the incoming buffer back to encoder immediately
-            this.buffer = ByteBuffer.allocate(buffer.capacity());
-            this.buffer.put(buffer);
-            this.buffer.flip();
         }
     }
 }

--- a/litr/src/main/java/com/linkedin/android/litr/io/MediaTargetSample.kt
+++ b/litr/src/main/java/com/linkedin/android/litr/io/MediaTargetSample.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2023 LinkedIn Corporation
+ * All Rights Reserved.
+ *
+ * Licensed under the BSD 2-Clause License (the "License").  See License in the project root for
+ * license information.
+ *
+ * Author: Ian Bird
+ */
+package com.linkedin.android.litr.io
+
+import android.media.MediaCodec
+import java.nio.ByteBuffer
+
+/**
+ * If a {@link MediaTarget} needs to temporarily queue up samples, this class can provide a deep
+ * copy of the sample to allow the original to be returned (e.g. to the encoder).
+ */
+class MediaTargetSample(
+    val targetTrack: Int,
+    buffer: ByteBuffer,
+    info: MediaCodec.BufferInfo
+) {
+    val buffer: ByteBuffer = ByteBuffer.allocate(buffer.capacity())
+    val info : MediaCodec.BufferInfo = MediaCodec.BufferInfo()
+
+    init {
+        this.info.set(0, info.size, info.presentationTimeUs, info.flags)
+
+        // We want to make a deep copy so that we can release the incoming buffer back to the
+        // encoder immediately.
+        this.buffer.put(buffer)
+        this.buffer.flip()
+    }
+}


### PR DESCRIPTION
After adding ffmpeg and the native wrapper code, this PR integrates it with LiTr along with exposing it via the demo app. The demo app now provides options to try the native muxer with a normal file transcode, as well as a camera capture. For the camera example, I've also configured the native muxer to generate a single fMP4 which demonstrates something that isn't possible with Android's built in MediaMuxer.

You'll notice that `orientationHint` is not yet used in the new muxer. I plan to add this next, as will require some plumbing/support for file based metadata, rather than stream information.