### PR TITLE
Always set TargetFormat value in TrackTransformationInfo object

### DIFF
--- a/litr/src/main/java/com/linkedin/android/litr/TransformationJob.java
+++ b/litr/src/main/java/com/linkedin/android/litr/TransformationJob.java
@@ -132,8 +132,10 @@ class TransformationJob implements Runnable {
     @VisibleForTesting
     void initStatsCollector() {
         // TODO modify TrackTransformationInfo to report muxing/demuxing and different media sources/targets
-        for (TrackTransform trackTransform : trackTransforms) {
+        for (int track = 0; track < trackTransforms.size(); track++) {
+            TrackTransform trackTransform = trackTransforms.get(track);
             statsCollector.addSourceTrack(trackTransform.getMediaSource().getTrackFormat(trackTransform.getSourceTrack()));
+            statsCollector.setTargetFormat(track, trackTransform.getTargetFormat());
         }
     }
 

--- a/litr/src/test/java/com/linkedin/android/litr/TransformationJobShould.java
+++ b/litr/src/test/java/com/linkedin/android/litr/TransformationJobShould.java
@@ -210,8 +210,10 @@ public class TransformationJobShould {
         transformationJob.transform();
 
         verify(marshallingTransformationListener).onCompleted(eq(JOB_ID), ArgumentMatchers.<TrackTransformationInfo>anyList());
+        verify(statsCollector).setTargetFormat(0, targetVideoFormat);
         verify(statsCollector).addSourceTrack(sourceVideoFormat);
         verify(statsCollector).addSourceTrack(sourceAudioFormat);
+        verify(statsCollector).setTargetFormat(1, targetAudioFormat);
     }
 
     @Test(expected = InsufficientDiskSpaceException.class)


### PR DESCRIPTION
Currently the value of TargetFormat field in the TrackTransformationInfo object is only set in the release method of the TransformationJob class. Also, the value is only set if a corresponding TrackTranscoder object is created successfully. 

Updated logic to always set the value of TargetFormat field in the TrackTransformationInfo object when initiating stats. If the format is not set here initially, then in some scenarios where we fail to create a corresponding TrackTranscoder, the target format value will be reported back as null as part of the MediaTransformationListener callbacks.