### PR TITLE
Fix potential buffer overflow issue

### DIFF
--- a/litr/src/main/cpp/audio-processor.cpp
+++ b/litr/src/main/cpp/audio-processor.cpp
@@ -52,7 +52,8 @@ Java_com_linkedin_android_litr_render_OboeAudioProcessor_processAudioFrame(
         jobject,
         jobject jsourceBuffer,
         jint sampleCount,
-        jobject jtargetBuffer) {
+        jobject jtargetBuffer,
+        jint jtargetBufferSize) {
     if (oboeResampler != nullptr && inputChannelCount > 0 && outputChannelCount > 0) {
         auto sourceBuffer = (jbyte *) env->GetDirectBufferAddress(jsourceBuffer);
         auto targetBuffer = (jbyte *) env->GetDirectBufferAddress(jtargetBuffer);
@@ -75,8 +76,10 @@ Java_com_linkedin_android_litr_render_OboeAudioProcessor_processAudioFrame(
                         value = 32767;
                     }
                     int index = framesProcessed * outputChannelCount + channel;
-                    targetBuffer[index * 2 + 0] = ((short) value) & 0xFF;
-                    targetBuffer[index * 2 + 1] = ((short) value >> 8) & 0xFF;
+                    if((index * 2 + 1) < jtargetBufferSize) {
+                        targetBuffer[index * 2 + 0] = ((short) value) & 0xFF;
+                        targetBuffer[index * 2 + 1] = ((short) value >> 8) & 0xFF;
+                    }
                 }
                 framesProcessed++;
             }

--- a/litr/src/main/java/com/linkedin/android/litr/render/OboeAudioProcessor.kt
+++ b/litr/src/main/java/com/linkedin/android/litr/render/OboeAudioProcessor.kt
@@ -8,8 +8,8 @@
 package com.linkedin.android.litr.render
 
 import com.linkedin.android.litr.codec.Frame
-import java.lang.IllegalArgumentException
 import java.nio.ByteBuffer
+import kotlin.math.min
 
 private const val BYTES_PER_SAMPLE = 2
 
@@ -37,11 +37,14 @@ internal class OboeAudioProcessor(
     override fun processFrame(sourceFrame: Frame, targetFrame: Frame) {
         if (sourceFrame.buffer != null && targetFrame.buffer != null) {
             val sourceSampleCount = sourceFrame.bufferInfo.size / (BYTES_PER_SAMPLE * sourceChannelCount)
-            val targetSampleCount = processAudioFrame(sourceFrame.buffer, sourceSampleCount, targetFrame.buffer)
+            val targetSampleCount = processAudioFrame(sourceFrame.buffer, sourceSampleCount, targetFrame.buffer, targetFrame.buffer.capacity())
 
             val targetBufferSize = targetSampleCount * BYTES_PER_SAMPLE * targetChannelCount
             targetFrame.buffer.rewind()
-            targetFrame.buffer.limit(targetBufferSize)
+
+            val limit = min(targetBufferSize, targetFrame.buffer.capacity())
+
+            targetFrame.buffer.limit(limit)
             targetFrame.bufferInfo.set(
                 0,
                 targetBufferSize,
@@ -61,7 +64,7 @@ internal class OboeAudioProcessor(
 
     private external fun initProcessor(sourceChannelCount: Int, sourceSampleRate: Int, targetChannelCount: Int, targetSampleRate: Int)
 
-    private external fun processAudioFrame(sourceBuffer: ByteBuffer, sampleCount: Int, targetBuffer: ByteBuffer): Int
+    private external fun processAudioFrame(sourceBuffer: ByteBuffer, sampleCount: Int, targetBuffer: ByteBuffer, targetBufferSize: Int): Int
 
     private external fun releaseProcessor()
 


### PR DESCRIPTION
I found this issue while implementing a small [resampler](https://github.com/Nailik/AndroidResampler) based on this project.

**Description**
`AudioRenderer`and `AudioOverlayFilter`use:
```
val estimatedTargetSampleCount = ceil(sourceSampleCount * samplingRatio).toInt()
 val targetBufferCapacity = estimatedTargetSampleCount * channelCount * BYTES_PER_SAMPLE
```
to calculate the size of the target buffer.
In case this estimation is too small (happens on big differences in samplerate) this results in 2 issues.

**Issue**
`processAudioFrame` in `audio-processor.cpp` doesn't know about the size, resulting in memory access vialoation.

**Fix**
Drop audio when target buffer capacity is reached.

**Issue**
`targetFrame.buffer.limit(targetBufferSize)` throws an `IllegalArgumentException`.

**Fix**
Take min `min(targetBufferSize, targetFrame.buffer.capacity())`
