### PR TITLE
Fixes a crash in demo app due to a null pointer

### DIFF
--- a/litr-demo/src/main/res/layout/fragment_transcode_video_gl.xml
+++ b/litr-demo/src/main/res/layout/fragment_transcode_video_gl.xml
@@ -87,7 +87,7 @@
                 android:text="@string/transcode"
                 android:enabled="@{sourceMedia != null &amp;&amp; targetMedia != null &amp;&amp; targetMedia.getIncludedTrackCount() > 0 &amp;&amp; (transformationState.state != transformationState.STATE_RUNNING)}"
                 android:padding="@dimen/cell_padding"
-                android:onClick="@{() -> transformationPresenter.startTransformation(sourceMedia, targetMedia, trimConfig, audioVolumeConfig, transformationState, enableNativeMuxer)}"/>
+                android:onClick="@{() -> transformationPresenter.startTransformation(sourceMedia, targetMedia, trimConfig, audioVolumeConfig, transformationState, enableNativeMuxer == null ? false : enableNativeMuxer)}"/>
 
             <include layout="@layout/section_transformation_progress"
                 android:id="@+id/section_transformation_progress"


### PR DESCRIPTION
Update the logic in fragment_transcode_video_gl.xml to use a default value of false for the data binding variable 'enableNativeMuxer' whenever it is null.