### PR TITLE
Fixes a null pointer crash (Github Issue #269)

### DIFF
--- a/litr/src/main/java/com/linkedin/android/litr/MediaTransformer.java
+++ b/litr/src/main/java/com/linkedin/android/litr/MediaTransformer.java
@@ -57,6 +57,7 @@ public class MediaTransformer {
 
     public static final int DEFAULT_KEY_FRAME_INTERVAL = 5;
     private static final int DEFAULT_AUDIO_BITRATE = 256_000;
+    private static final int DEFAULT_VIDEO_BITRATE = 10_000_000;
     private static final int DEFAULT_FRAME_RATE = 30;
 
     private static final String TAG = MediaTransformer.class.getSimpleName();
@@ -412,6 +413,10 @@ public class MediaTransformer {
                                                                   sourceMediaFormat.getInteger(MediaFormat.KEY_WIDTH),
                                                                   sourceMediaFormat.getInteger(MediaFormat.KEY_HEIGHT));
                 int targetBitrate = TranscoderUtils.estimateVideoTrackBitrate(mediaSource, sourceTrackIndex);
+                if (targetBitrate <= 0) {
+                    // Use a default value in case of failure to extract value from source media
+                    targetBitrate = DEFAULT_VIDEO_BITRATE;
+                }
                 targetMediaFormat.setInteger(MediaFormat.KEY_BIT_RATE, targetBitrate);
 
                 int targetKeyFrameInterval = DEFAULT_KEY_FRAME_INTERVAL;

--- a/litr/src/main/java/com/linkedin/android/litr/io/MediaExtractorMediaSource.java
+++ b/litr/src/main/java/com/linkedin/android/litr/io/MediaExtractorMediaSource.java
@@ -31,6 +31,7 @@ public class MediaExtractorMediaSource implements MediaSource {
 
     private int orientationHint;
     private long size;
+    private final long duration;
 
     public MediaExtractorMediaSource(@NonNull Context context, @NonNull Uri uri) throws MediaSourceException {
         this(context, uri, new MediaRange(0, Long.MAX_VALUE));
@@ -52,6 +53,8 @@ public class MediaExtractorMediaSource implements MediaSource {
         if (rotation != null) {
             orientationHint = Integer.parseInt(rotation);
         }
+        String durationStr = mediaMetadataRetriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_DURATION);
+        duration =  (durationStr != null) ? Long.parseLong(durationStr) : -1L;
         size = TranscoderUtils.getSize(context, uri);
         // Release unused anymore MediaMetadataRetriever instance
         releaseQuietly(mediaMetadataRetriever);
@@ -122,6 +125,11 @@ public class MediaExtractorMediaSource implements MediaSource {
     @Override
     public MediaRange getSelection() {
         return mediaRange;
+    }
+
+    @Override
+    public long getDuration() {
+        return duration;
     }
 
     private void releaseQuietly(MediaMetadataRetriever mediaMetadataRetriever) {

--- a/litr/src/main/java/com/linkedin/android/litr/io/MediaSource.java
+++ b/litr/src/main/java/com/linkedin/android/litr/io/MediaSource.java
@@ -99,4 +99,13 @@ public interface MediaSource {
     default MediaRange getSelection() {
         return new MediaRange(0, Long.MAX_VALUE);
     }
+
+    /**
+     * Returns the playback duration of the media if applicable and known
+     *
+     * @return playback duration in milliseconds, -1 if unknown
+     */
+    default long getDuration() {
+        return -1;
+    }
 }

--- a/litr/src/main/java/com/linkedin/android/litr/utils/TranscoderUtils.java
+++ b/litr/src/main/java/com/linkedin/android/litr/utils/TranscoderUtils.java
@@ -174,14 +174,14 @@ public final class TranscoderUtils {
      * shall be returned.
      *
      * @param mediaSource {@link MediaSource} which contains the video track
-     * @param videoTrack Track whose duration needs to be determined
+     * @param videoTrackFormat MediaFormat of the track whose duration needs to be determined
      *
      * @return Duration of the given video track in seconds.
      */
     @VisibleForTesting
-    static float estimateVideoTrackDuration(MediaSource mediaSource, MediaFormat videoTrack) {
-       return videoTrack.containsKey(MediaFormat.KEY_DURATION) ?
-                TimeUtils.microsToSeconds(videoTrack.getLong(MediaFormat.KEY_DURATION)) :
+    static float estimateVideoTrackDuration(MediaSource mediaSource, MediaFormat videoTrackFormat) {
+       return videoTrackFormat.containsKey(MediaFormat.KEY_DURATION) ?
+                TimeUtils.microsToSeconds(videoTrackFormat.getLong(MediaFormat.KEY_DURATION)) :
                 TimeUtils.millisToSeconds(mediaSource.getDuration());
     }
 


### PR DESCRIPTION
1. Fixes a null pointer in TranscoderUtils when retrieving the duration value from a track by checking if the field is present before accessing it.
2. Updated logic of estimateVideoTrackBitrate API in TranscoderUtils to utilize the source media file duration in cases where track specific duration value is null.
3. Updated logic of createTargetMediaFormat API in MediaTransformer class to use a default bit rate of 10_000_000 when we fail to estimate a valid bitrate from the source media track.
4. Added unit tests