### PR TITLE
Refactors TransformationJob to handle terminal states in a more determisitic fashion

### DIFF
--- a/litr/src/main/java/com/linkedin/android/litr/io/MediaMuxerMediaTarget.java
+++ b/litr/src/main/java/com/linkedin/android/litr/io/MediaMuxerMediaTarget.java
@@ -146,11 +146,8 @@ public class MediaMuxerMediaTarget implements MediaTarget {
 
     @Override
     public void release() {
-        try {
-            mediaMuxer.release();
-        } finally {
-            releaseFileDescriptor();
-        }
+        mediaMuxer.release();
+        releaseFileDescriptor();
     }
 
     @Override

--- a/litr/src/main/java/com/linkedin/android/litr/io/MediaMuxerMediaTarget.java
+++ b/litr/src/main/java/com/linkedin/android/litr/io/MediaMuxerMediaTarget.java
@@ -146,8 +146,11 @@ public class MediaMuxerMediaTarget implements MediaTarget {
 
     @Override
     public void release() {
-        mediaMuxer.release();
-        releaseFileDescriptor();
+        try {
+            mediaMuxer.release();
+        } finally {
+            releaseFileDescriptor();
+        }
     }
 
     @Override


### PR DESCRIPTION
1. Updated release API in TransformationJob such that it only takes care of stopping transcoders and releasing muxers without having to deal with callbacks. Exceptions that can be ignored here are now handled & logged to ensure that the execution continues. 
2. Separated out logic that updates stats (with latest target format) and deletes output files (in error scenarios) into individual methods.
3. Updated overall terminal state (cancelled/completed/failed) handling logic to follow a deterministic order of updating stats, stopping & releasing transcoders, deleting output files, and invoking appropriate callbacks.

Testing Done:
1. Updated unit tests
2. Manual testing to make sure existing functionality did not break and all app callbacks are invoked appropriately