### PR TITLE
Release file descriptor even when releasing of android muxer fails

### DIFF
--- a/litr/src/main/java/com/linkedin/android/litr/io/MediaMuxerMediaTarget.java
+++ b/litr/src/main/java/com/linkedin/android/litr/io/MediaMuxerMediaTarget.java
@@ -146,8 +146,11 @@ public class MediaMuxerMediaTarget implements MediaTarget {
 
     @Override
     public void release() {
-        mediaMuxer.release();
-        releaseFileDescriptor();
+        try {
+            mediaMuxer.release();
+        } finally {
+            releaseFileDescriptor();
+        }
     }
 
     @Override


### PR DESCRIPTION
Release file descriptor even when releasing of android muxer fails with an exception. This is to eliminate any file access issues for client apps.