### PR TITLE
Adds 16KB page size support for Android 15

### DIFF
--- a/litr-ffmpeg/src/main/cpp/CMakeLists.txt
+++ b/litr-ffmpeg/src/main/cpp/CMakeLists.txt
@@ -84,3 +84,5 @@ target_link_libraries(litr-muxers
         PRIVATE avformat
         PRIVATE ${log-lib})
 
+#[[To support compiling 16 KB-aligned shared libraries with Android NDK version r26 or lower]]
+target_link_options(litr-muxers PRIVATE "-Wl,-z,max-page-size=16384")

--- a/litr/src/main/cpp/CMakeLists.txt
+++ b/litr/src/main/cpp/CMakeLists.txt
@@ -12,3 +12,8 @@ find_library(log-lib log)
 target_link_libraries(litr-jni
         ${log-lib}
         oboe-resampler)
+
+#[[To support compiling 16 KB-aligned shared libraries with Android NDK version r26 or lower]]
+set_target_properties(litr-jni PROPERTIES
+        LINK_FLAGS "-Wl,-z,max-page-size=16384"
+)


### PR DESCRIPTION
Updates CMakeLists.txt to enable 16 KB ELF alignment support for Android 15